### PR TITLE
Format disk sizes in terms other than GB

### DIFF
--- a/bb-imager-gui/src/helpers.rs
+++ b/bb-imager-gui/src/helpers.rs
@@ -944,3 +944,22 @@ const fn flasher_supported(flasher: config::Flasher) -> bool {
         _ => false,
     }
 }
+
+pub(crate) fn format_size(size: u64) -> String {
+    const KB: f64 = 1024.0;
+    const MB: f64 = 1024.0 * KB;
+    const GB: f64 = 1024.0 * MB;
+    const TB: f64 = 1024.0 * GB;
+
+    if size < KB as u64 {
+        format!("{} B", size)
+    } else if size < MB as u64 {
+        format!("{:.2} KB", size as f64 / KB)
+    } else if size < GB as u64 {
+        format!("{:.2} MB", size as f64 / MB)
+    } else if size < TB as u64 {
+        format!("{:.2} GB", size as f64 / GB)
+    } else {
+        format!("{:.2} TB", size as f64 / TB)
+    }
+}

--- a/bb-imager-gui/src/pages/destination_selection.rs
+++ b/bb-imager-gui/src/pages/destination_selection.rs
@@ -19,8 +19,7 @@ where
             let mut row2 = widget::column![text(x.to_string())];
 
             if let Some(size) = x.size() {
-                let s = (size as f32) / (1024.0 * 1024.0 * 1024.0);
-                row2 = row2.push(text(format!("{:.2} GB", s)));
+                row2 = row2.push(text(helpers::format_size(size)));
             }
 
             button(


### PR DESCRIPTION
Admittedly, most likely everything will be easily measured in GB and TB, but in cases where smaller volumes show up it may be nice to avoid a small decimal number.

Was originally motivated by running this on a machine with a >1TB disk showing up -- not that'd you'd actually want to write there!

<img width="792" alt="Screenshot 2025-03-24 at 11 15 57 PM" src="https://github.com/user-attachments/assets/66e0f0a3-a1ca-4efd-9c75-942fcc615c79" />
