### PR TITLE
Sort flash destinations by ascending size

### DIFF
--- a/bb-imager-gui/src/pages/destination_selection.rs
+++ b/bb-imager-gui/src/pages/destination_selection.rs
@@ -9,7 +9,10 @@ pub(crate) fn view<'a, D>(destinations: D, search_bar: &'a str) -> Element<'a, B
 where
     D: Iterator<Item = &'a helpers::Destination>,
 {
-    let items = destinations
+    let mut sorted_destinations = Vec::from_iter(destinations);
+    sorted_destinations.sort_by(|a, b| a.size().cmp(&b.size()));
+    let items = sorted_destinations
+        .into_iter()
         .filter(|x| {
             x.to_string()
                 .to_lowercase()


### PR DESCRIPTION
Previously, destination order was not deterministic. This now sorts destinations, with smaller volumes appearing near the top.

In a previous PR @Ayush1325 mentioned a better option to avoid an extra allocation. I'm down for a different approach or larger change (maybe plumbing through something other than a `HashSet`) if that's preferred. At the same time I would guess that a large enough disk list to make a meaningful difference here would probably be unlikely (now I'm curious if there's a practical limit on disk counts 🤷). But no strong opinion here 🙂 

Fixes #2 

Changelog: fixed