### PR TITLE
Only install debian deps on ubuntu runner

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,6 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install dependencies
+      if: matrix.os == 'ubuntu-latest'
       run: make setup-debian-deps
     - name: Select rust toolchain
       run: rustup toolchain install stable --profile minimal


### PR DESCRIPTION
CI is failing for macOS otherwise.

There's an additional failure hiding behind this one; looking at that now.