### PR TITLE
Only reference udisks2 when udev + linux

### DIFF
--- a/bb-flasher-sd/src/lib.rs
+++ b/bb-flasher-sd/src/lib.rs
@@ -79,7 +79,7 @@ pub enum Error {
     FailedToOpenDestination(String),
 
     #[error("Udisks2 Error: {0}")]
-    #[cfg(feature = "udev")]
+    #[cfg(all(feature = "udev", target_os = "linux"))]
     Udisks(#[from] udisks2::Error),
 
     #[cfg(windows)]


### PR DESCRIPTION
Tried going down more definitions in the `Cargo.toml`s but basically ran into this issue https://github.com/rust-lang/cargo/issues/1197

Would have included this in a previous PR but thought it needed to be more complex