### PR TITLE
bb-flasher-sd: Fix windows flashing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,6 +556,7 @@ dependencies = [
  "nix 0.29.0",
  "security-framework 3.2.0",
  "sha2",
+ "tempfile",
  "thiserror 2.0.12",
  "tokio",
  "tracing",

--- a/bb-flasher-sd/Cargo.toml
+++ b/bb-flasher-sd/Cargo.toml
@@ -26,6 +26,7 @@ tokio = { version = "1.43", default-features = false, features = ["rt"], optiona
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.60", features = ["Win32", "Win32_Storage", "Win32_Storage_FileSystem", "Win32_Security", "Win32_System", "Win32_System_IO", "Win32_System_Ioctl"] }
+tempfile = "3.17"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 security-framework = { version = "3.2", optional = true }


### PR DESCRIPTION
After trying out various things, I cannot seem to get windows to reliably
modify anything on SD card after the initial write.

So I am just giving up and modifying the OS image instead before
flashing. This seems to work reasonably well, and is less hacky than
every other thing I have tried.

Fixes #13, #14 