### PR TITLE
bb-imager-sd: Remove verify argument

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,7 +554,6 @@ dependencies = [
  "mbrman",
  "nix 0.29.0",
  "security-framework 3.2.0",
- "sha2",
  "tempfile",
  "thiserror 2.0.12",
  "tokio",

--- a/bb-flasher-sd/Cargo.toml
+++ b/bb-flasher-sd/Cargo.toml
@@ -14,7 +14,6 @@ categories = ["development-tools", "embedded", "filesystem", "os"]
 futures = "0.3"
 thiserror = "2.0"
 tracing = "0.1"
-sha2 = "0.10"
 bb-drivelist = "0.1"
 fatfs = "0.3.6"
 fscommon = "0.1.1"

--- a/bb-flasher-sd/README.md
+++ b/bb-flasher-sd/README.md
@@ -32,7 +32,6 @@ fn main() {
         bb_flasher_sd::flash(
             img,
             dst,
-            true,
             Some(tx),
             None,
             None

--- a/bb-flasher-sd/src/helpers.rs
+++ b/bb-flasher-sd/src/helpers.rs
@@ -1,41 +1,8 @@
-use std::io::Read;
-
 use futures::channel::mpsc;
-use sha2::{Digest, Sha256};
 
-use crate::{Result, Status};
+use crate::Result;
 
-pub(crate) fn sha256_reader_progress(
-    mut reader: impl Read,
-    size: u64,
-    mut chan: Option<futures::channel::mpsc::Sender<Status>>,
-) -> Result<[u8; 32]> {
-    let mut hasher = Sha256::new();
-    let mut buffer = [0; 512];
-    let mut pos = 0;
-
-    loop {
-        let count = reader.read(&mut buffer)?;
-        if count == 0 {
-            break;
-        }
-
-        hasher.update(&buffer[..count]);
-
-        pos += count;
-        chan_send(chan.as_mut(), Status::Verifying(progress(pos, size)));
-    }
-
-    let hash = hasher
-        .finalize()
-        .as_slice()
-        .try_into()
-        .expect("SHA-256 is 32 bytes");
-
-    Ok(hash)
-}
-
-pub(crate) fn chan_send(chan: Option<&mut mpsc::Sender<Status>>, msg: Status) {
+pub(crate) fn chan_send(chan: Option<&mut mpsc::Sender<f32>>, msg: f32) {
     if let Some(c) = chan {
         let _ = c.try_send(msg);
     }

--- a/bb-flasher-sd/src/lib.rs
+++ b/bb-flasher-sd/src/lib.rs
@@ -30,7 +30,6 @@
 //!     bb_flasher_sd::flash(
 //!         img,
 //!         dst,
-//!         true,
 //!         Some(tx),
 //!         None,
 //!         None
@@ -64,12 +63,10 @@ pub(crate) type Result<T, E = Error> = std::result::Result<T, E>;
 #[derive(Error, Debug)]
 /// Errors for this crate
 pub enum Error {
-    #[error("Sha256 verification error")]
-    Sha256Verification,
     #[error("Failed to customize flashed image {0}")]
     Customization(String),
     #[error("IO Error: {0}")]
-    IoError(io::Error),
+    IoError(#[from] io::Error),
     /// Aborted before completing
     #[error("Aborted before completing")]
     Aborted,
@@ -91,12 +88,6 @@ pub enum Error {
     #[cfg(windows)]
     #[error("Windows Error: {0}")]
     WindowsError(#[from] windows::core::Error),
-}
-
-impl From<io::Error> for Error {
-    fn from(value: io::Error) -> Self {
-        Self::IoError(value)
-    }
 }
 
 /// Enumerate all SD Cards in system
@@ -127,12 +118,4 @@ impl Device {
 /// Format SD card to fat32
 pub fn format(dst: &std::path::Path) -> Result<()> {
     crate::pal::format(dst)
-}
-
-/// Flashing status
-#[derive(Clone, Debug)]
-pub enum Status {
-    Preparing,
-    Flashing(f32),
-    Verifying(f32),
 }

--- a/bb-flasher/README.md
+++ b/bb-flasher/README.md
@@ -15,7 +15,7 @@ async fn main() {
     let img = bb_flasher::LocalImage::new("/tmp/abc.img.xz".into());
     let target = PathBuf::from("/tmp/target").try_into().unwrap();
     let customization = 
-        bb_flasher::sd::FlashingSdLinuxConfig::new(true, None, None, None, None, None);
+        bb_flasher::sd::FlashingSdLinuxConfig::new(None, None, None, None, None);
 
     let flasher = bb_flasher::sd::Flasher::new(img, target, customization)
         .flash(None)

--- a/bb-flasher/src/lib.rs
+++ b/bb-flasher/src/lib.rs
@@ -15,7 +15,7 @@
 //!     let img = bb_flasher::LocalImage::new("/tmp/abc.img.xz".into());
 //!     let target = PathBuf::from("/tmp/target").try_into().unwrap();
 //!     let customization = 
-//!         bb_flasher::sd::FlashingSdLinuxConfig::new(true, None, None, None, None, None);
+//!         bb_flasher::sd::FlashingSdLinuxConfig::new(None, None, None, None, None);
 //!
 //!     let flasher = bb_flasher::sd::Flasher::new(img, target, customization)
 //!         .flash(None)

--- a/bb-imager-cli/src/cli.rs
+++ b/bb-imager-cli/src/cli.rs
@@ -73,10 +73,6 @@ pub enum TargetCommands {
         /// The destination device (e.g., `/dev/sdX` or specific device identifiers).
         dst: PathBuf,
 
-        /// Disable checksum verification post-flash
-        #[arg(long)]
-        no_verify: bool,
-
         #[arg(long)]
         /// Set a custom hostname for the device (e.g., "beaglebone").
         hostname: Option<String>,

--- a/bb-imager-cli/src/main.rs
+++ b/bb-imager-cli/src/main.rs
@@ -111,7 +111,6 @@ async fn flash_internal(
     match target {
         TargetCommands::Sd {
             dst,
-            no_verify,
             hostname,
             timezone,
             keymap,
@@ -124,9 +123,8 @@ async fn flash_internal(
             let user = user_name.map(|x| (x, user_password.unwrap()));
             let wifi = wifi_ssid.map(|x| (x, wifi_password.unwrap()));
 
-            let customization = bb_flasher::sd::FlashingSdLinuxConfig::new(
-                !no_verify, hostname, timezone, keymap, user, wifi,
-            );
+            let customization =
+                bb_flasher::sd::FlashingSdLinuxConfig::new(hostname, timezone, keymap, user, wifi);
 
             bb_flasher::sd::Flasher::new(
                 LocalImage::new(img),

--- a/bb-imager-gui/src/helpers.rs
+++ b/bb-imager-gui/src/helpers.rs
@@ -533,9 +533,8 @@ impl GuiConfiguration {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub(crate) struct SdCustomization {
-    pub(crate) verify: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) hostname: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -548,25 +547,7 @@ pub(crate) struct SdCustomization {
     pub(crate) wifi: Option<SdCustomizationWifi>,
 }
 
-impl Default for SdCustomization {
-    fn default() -> Self {
-        Self {
-            verify: true,
-            hostname: None,
-            timezone: None,
-            keymap: None,
-            user: None,
-            wifi: None,
-        }
-    }
-}
-
 impl SdCustomization {
-    pub(crate) fn update_verify(mut self, t: bool) -> Self {
-        self.verify = t;
-        self
-    }
-
     pub(crate) fn update_hostname(mut self, t: Option<String>) -> Self {
         self.hostname = t;
         self
@@ -596,7 +577,6 @@ impl SdCustomization {
 impl From<SdCustomization> for bb_flasher::sd::FlashingSdLinuxConfig {
     fn from(value: SdCustomization) -> Self {
         Self::new(
-            value.verify,
             value.hostname,
             value.timezone,
             value.keymap,

--- a/bb-imager-gui/src/pages/configuration.rs
+++ b/bb-imager-gui/src/pages/configuration.rs
@@ -86,18 +86,6 @@ fn linux_sd_form<'a>(
     config: &'a helpers::SdCustomization,
 ) -> widget::Column<'a, BBImagerMessage> {
     widget::column![
-        widget::container(
-            widget::toggler(!config.verify)
-                .label("Skip Verification")
-                .on_toggle(|y| {
-                    BBImagerMessage::UpdateFlashConfig(FlashingCustomization::LinuxSd(
-                        config.clone().update_verify(!y),
-                    ))
-                })
-        )
-        .padding(10)
-        .width(iced::Length::Fill)
-        .style(widget::container::bordered_box),
         hostname_form(config).width(iced::Length::Fill),
         timezone_form(timezones, config).width(iced::Length::Fill),
         keymap_form(keymaps, config).width(iced::Length::Fill),


### PR DESCRIPTION
- It is better to use SHA verification on passed image rather than doing a sha calculation after reading sd card again.
- Rpi-imager also does not do this kind of verification.
- Also a lot of other cleanup.