### PR TITLE
enhancement: Add indeterminate progress bar for non-progress states (#23)

### DIFF
--- a/bb-imager-gui/src/helpers.rs
+++ b/bb-imager-gui/src/helpers.rs
@@ -6,8 +6,10 @@ use bb_flasher::{BBFlasher, BBFlasherTarget, DownloadFlashingStatus};
 use futures::StreamExt;
 use iced::{
     futures,
-    widget::{self, text},
+    widget::{self, text, progress_bar, Column},
+    Color, Length,
 };
+use iced_loading::Linear;
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub(crate) struct ProgressBarState {
@@ -77,19 +79,32 @@ impl ProgressBarState {
         Self::new(label, 1.0, ProgressBarStatus::Fail, None)
     }
 
-    pub(crate) fn bar(&self) -> widget::Column<'_, BBImagerMessage> {
+    pub(crate) fn bar(&self) -> Column<'_, BBImagerMessage> {
         use std::ops::RangeInclusive;
-        use widget::progress_bar;
 
         const RANGE: RangeInclusive<f32> = (0.0)..=1.0;
 
-        widget::column![
-            text(self.label.clone()).color(iced::Color::WHITE),
-            progress_bar(RANGE, self.progress)
-                .height(8)
-                .style(self.state.style()),
-        ]
-        .align_x(iced::Alignment::Center)
+        if self.state == ProgressBarStatus::Loading {
+            widget::column![
+                text(self.label.clone()).color(Color::WHITE),
+                Linear::new()
+                    .width(Length::Fill)
+                    .height(8.0)
+                    .cycle_duration(std::time::Duration::from_millis(1000))
+                    .color(Color::from_rgb(0.0, 0.5, 1.0)),
+            ]
+            .align_x(iced::Alignment::Center)
+            .spacing(12)
+        } else {
+            widget::column![
+                text(self.label.clone()).color(Color::WHITE),
+                progress_bar(RANGE, self.progress)
+                    .height(8)
+                    .style(self.state.style()),
+            ]
+            .align_x(iced::Alignment::Center)
+            .spacing(12)
+        }
     }
 
     pub(crate) fn cancel(&self) -> Option<Self> {

--- a/bb-imager-gui/src/ui/flash.rs
+++ b/bb-imager-gui/src/ui/flash.rs
@@ -1,4 +1,5 @@
-use iced::{Element, widget};
+use iced::{Color, Element, Length, widget};
+use iced_loading::Linear;
 
 use crate::{BBImagerMessage, Screen, constants, pages::FlashingState};
 
@@ -9,7 +10,22 @@ pub(crate) fn view(state: &FlashingState, running: bool) -> Element<BBImagerMess
         const FOOTER_HEIGHT: f32 = 150.0;
         let banner_height = size.height / 4.0;
 
-        let prog_bar = state.progress().bar().spacing(12);
+        let label = state.progress().content();
+        let prog_bar =
+            if label == "Preparing..." || label == "Verifying..." || label == "Customizing..." {
+                widget::column![
+                    widget::text(label).color(iced::Color::WHITE),
+                    Linear::new()
+                        .width(Length::Fill)
+                        .height(8.0)
+                        .cycle_duration(std::time::Duration::from_millis(1000))
+                        .color(Color::from_rgb(0.0, 0.5, 1.0)),
+                ]
+                .align_x(iced::Alignment::Center)
+                .spacing(12)
+            } else {
+                state.progress().bar().spacing(12)
+            };
 
         let btn = if running {
             home_btn_text("CANCEL", true, iced::Length::Shrink)

--- a/bb-imager-gui/src/ui/flash.rs
+++ b/bb-imager-gui/src/ui/flash.rs
@@ -1,5 +1,4 @@
-use iced::{Color, Element, Length, widget};
-use iced_loading::Linear;
+use iced::{Element, widget};
 
 use crate::{BBImagerMessage, Screen, constants, pages::FlashingState};
 
@@ -10,22 +9,7 @@ pub(crate) fn view(state: &FlashingState, running: bool) -> Element<BBImagerMess
         const FOOTER_HEIGHT: f32 = 150.0;
         let banner_height = size.height / 4.0;
 
-        let label = state.progress().content();
-        let prog_bar =
-            if label == "Preparing..." || label == "Verifying..." || label == "Customizing..." {
-                widget::column![
-                    widget::text(label).color(iced::Color::WHITE),
-                    Linear::new()
-                        .width(Length::Fill)
-                        .height(8.0)
-                        .cycle_duration(std::time::Duration::from_millis(1000))
-                        .color(Color::from_rgb(0.0, 0.5, 1.0)),
-                ]
-                .align_x(iced::Alignment::Center)
-                .spacing(12)
-            } else {
-                state.progress().bar().spacing(12)
-            };
+        let prog_bar = state.progress().bar().spacing(12);
 
         let btn = if running {
             home_btn_text("CANCEL", true, iced::Length::Shrink)

--- a/iced-loading/src/lib.rs
+++ b/iced-loading/src/lib.rs
@@ -1,2 +1,6 @@
 pub mod circular;
 pub mod easing;
+pub mod linear;
+
+pub use circular::Circular;
+pub use linear::Linear;

--- a/iced-loading/src/linear.rs
+++ b/iced-loading/src/linear.rs
@@ -1,0 +1,204 @@
+use iced::{
+    Border, Color, Element, Length, Rectangle, Shadow, Size,
+    advanced::{
+        Clipboard, Layout, Shell, Widget, layout, renderer,
+        widget::{self, Operation, Tree},
+    },
+    mouse,
+};
+use std::marker::PhantomData;
+use std::time::{Duration, Instant};
+
+pub struct Linear<Message> {
+    width: Length,
+    height: f32,
+    cycle_duration: Duration,
+    bar_width_ratio: f32,
+    color: Color,
+    _phantom: PhantomData<Message>,
+}
+
+impl<Message> Linear<Message> {
+    pub fn new() -> Self {
+        Self {
+            width: Length::Fill,
+            height: 8.0, // Match ProgressBar
+            cycle_duration: Duration::from_millis(1000),
+            bar_width_ratio: 0.3,
+            color: Color::from_rgb(0.0, 0.5, 1.0),
+            _phantom: PhantomData,
+        }
+    }
+
+    pub fn width(mut self, width: Length) -> Self {
+        self.width = width;
+        self
+    }
+
+    pub fn height(mut self, height: f32) -> Self {
+        self.height = height;
+        self
+    }
+
+    pub fn cycle_duration(mut self, duration: Duration) -> Self {
+        self.cycle_duration = duration;
+        self
+    }
+
+    pub fn bar_width_ratio(mut self, ratio: f32) -> Self {
+        self.bar_width_ratio = ratio.clamp(0.1, 0.8);
+        self
+    }
+
+    pub fn color(mut self, color: Color) -> Self {
+        self.color = color;
+        self
+    }
+}
+
+impl<Message> Default for Linear<Message> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer> for Linear<Message>
+where
+    Renderer: renderer::Renderer,
+    Theme: 'static,
+{
+    fn tag(&self) -> widget::tree::Tag {
+        widget::tree::Tag::of::<State>()
+    }
+
+    fn state(&self) -> widget::tree::State {
+        widget::tree::State::new(State::new())
+    }
+
+    fn size(&self) -> Size<Length> {
+        Size {
+            width: self.width,
+            height: Length::Fixed(self.height),
+        }
+    }
+
+    fn layout(
+        &self,
+        _tree: &mut Tree,
+        _renderer: &Renderer,
+        limits: &layout::Limits,
+    ) -> layout::Node {
+        let limits = limits.width(self.width).height(Length::Fixed(self.height));
+        let size = limits.resolve(self.width, Length::Fixed(self.height), Size::ZERO);
+        layout::Node::new(size)
+    }
+
+    fn operate(
+        &self,
+        tree: &mut Tree,
+        _layout: Layout<'_>,
+        _renderer: &Renderer,
+        operation: &mut dyn Operation,
+    ) {
+        let state = tree.state.downcast_mut::<State>();
+        operation.custom(state, None);
+    }
+
+    fn draw(
+        &self,
+        tree: &Tree,
+        renderer: &mut Renderer,
+        _theme: &Theme,
+        _style: &renderer::Style,
+        layout: Layout<'_>,
+        _cursor: mouse::Cursor,
+        _viewport: &Rectangle,
+    ) {
+        let state = tree.state.downcast_ref::<State>();
+        let bounds = layout.bounds();
+        let progress = state.progress(self.cycle_duration);
+
+        let bar_width = bounds.width * self.bar_width_ratio;
+        let max_offset = bounds.width - bar_width;
+        let offset = max_offset * progress; // Linear easing for simplicity
+
+        let bar = renderer::Quad {
+            bounds: Rectangle {
+                x: bounds.x + offset,
+                y: bounds.y,
+                width: bar_width,
+                height: bounds.height,
+            },
+            border: Border {
+                radius: 2.0.into(),
+                width: 0.0,
+                color: Color::TRANSPARENT,
+            },
+            shadow: Shadow::default(),
+        };
+
+        renderer.fill_quad(bar, self.color);
+    }
+
+    fn on_event(
+        &mut self,
+        tree: &mut Tree,
+        event: iced::Event,
+        _layout: Layout<'_>,
+        _cursor: mouse::Cursor,
+        _renderer: &Renderer,
+        _clipboard: &mut dyn Clipboard,
+        shell: &mut Shell<'_, Message>,
+        _viewport: &Rectangle,
+    ) -> iced::event::Status {
+        let state = tree.state.downcast_mut::<State>();
+
+        if let iced::Event::Window(iced::window::Event::RedrawRequested(now)) = event {
+            state.last_redraw = Some(now);
+            if state.start.is_none() {
+                state.start = Some(now);
+            }
+            shell.request_redraw(iced::window::RedrawRequest::NextFrame);
+            iced::event::Status::Captured
+        } else {
+            iced::event::Status::Ignored
+        }
+    }
+}
+
+#[derive(Debug)]
+struct State {
+    start: Option<Instant>,
+    last_redraw: Option<Instant>,
+}
+
+impl State {
+    fn new() -> Self {
+        Self {
+            start: None,
+            last_redraw: None,
+        }
+    }
+
+    fn progress(&self, cycle_duration: Duration) -> f32 {
+        match (self.start, self.last_redraw) {
+            (Some(start), Some(last_redraw)) => {
+                let elapsed = last_redraw.duration_since(start).as_secs_f32();
+                let duration = cycle_duration.as_secs_f32();
+                (elapsed % duration) / duration
+            }
+            _ => 0.0,
+        }
+    }
+}
+
+impl<Message, Theme, Renderer> From<Linear<Message>> for Element<'_, Message, Theme, Renderer>
+where
+    Message: Clone + 'static,
+    Theme: 'static,
+    Renderer: renderer::Renderer + 'static,
+{
+    fn from(widget: Linear<Message>) -> Self {
+        Element::new(widget)
+    }
+}


### PR DESCRIPTION
Replace static 50% bar with animated Linear widget for Preparing, Verifying, and Customizing, fixing issue #23.

- Added `Linear` widget in `iced-loading`.
- Updated `flash.rs` to use `Linear` for non-progress states.
- Closes #23.

Changelog: added

https://github.com/user-attachments/assets/608c51af-80b7-40b1-ba2d-a31f8dd54bc7

