### PR TITLE
Add USB DHCP option to both GUI and CLI

### DIFF
--- a/bb-flasher-sd/src/customization.rs
+++ b/bb-flasher-sd/src/customization.rs
@@ -11,6 +11,7 @@ pub struct Customization {
     pub user: Option<(String, String)>,
     pub wifi: Option<(String, String)>,
     pub ssh: Option<String>,
+    pub usb_enable_dhcp: Option<bool>,
 }
 
 impl Customization {
@@ -66,6 +67,10 @@ impl Customization {
             sysconf_w(&mut conf, &format!("user_authorized_key={x}"))?;
         }
 
+        if let Some(x) = self.usb_enable_dhcp {
+            sysconf_w(&mut conf, &format!("usb_enable_dhcp={x}"))?;
+        }
+
         if let Some((ssid, psk)) = &self.wifi {
             sysconf_w(&mut conf, &format!("iwd_psk_file={ssid}.psk\n"))?;
 
@@ -92,6 +97,8 @@ impl Customization {
             || self.keymap.is_some()
             || self.user.is_some()
             || self.wifi.is_some()
+            || self.ssh.is_some()
+            || self.usb_enable_dhcp.is_some()
     }
 }
 

--- a/bb-flasher/src/flasher/sd.rs
+++ b/bb-flasher/src/flasher/sd.rs
@@ -76,6 +76,7 @@ impl FlashingSdLinuxConfig {
         user: Option<(String, String)>,
         wifi: Option<(String, String)>,
         ssh: Option<String>,
+        usb_enable_dhcp: Option<bool>,
     ) -> Self {
         Self {
             customization: bb_flasher_sd::Customization {
@@ -85,6 +86,7 @@ impl FlashingSdLinuxConfig {
                 user,
                 wifi,
                 ssh,
+                usb_enable_dhcp,
             },
         }
     }

--- a/bb-flasher/src/lib.rs
+++ b/bb-flasher/src/lib.rs
@@ -14,8 +14,8 @@
 //! async fn main() {
 //!     let img = bb_flasher::LocalImage::new("/tmp/abc.img.xz".into());
 //!     let target = PathBuf::from("/tmp/target").try_into().unwrap();
-//!     let customization = 
-//!         bb_flasher::sd::FlashingSdLinuxConfig::new(None, None, None, None, None, None);
+//!     let customization =
+//!         bb_flasher::sd::FlashingSdLinuxConfig::new(None, None, None, None, None, None, None);
 //!
 //!     let flasher = bb_flasher::sd::Flasher::new(img, target, customization)
 //!         .flash(None)

--- a/bb-imager-cli/src/cli.rs
+++ b/bb-imager-cli/src/cli.rs
@@ -105,7 +105,11 @@ pub enum TargetCommands {
 
         #[arg(long)]
         /// Set SSH public key for authentication
-        ssh_key: Option<String>
+        ssh_key: Option<String>,
+
+        #[arg(long)]
+        /// Enable USB DHCP
+        usb_enable_dhcp: bool,
     },
     /// Flash MSP430 on BeagleConnectFreedom.
     #[cfg(feature = "bcf_msp430")]

--- a/bb-imager-cli/src/main.rs
+++ b/bb-imager-cli/src/main.rs
@@ -120,12 +120,19 @@ async fn flash_internal(
             wifi_password,
             img,
             ssh_key,
+            usb_enable_dhcp,
         } => {
             let user = user_name.map(|x| (x, user_password.unwrap()));
             let wifi = wifi_ssid.map(|x| (x, wifi_password.unwrap()));
 
             let customization = bb_flasher::sd::FlashingSdLinuxConfig::new(
-                hostname, timezone, keymap, user, wifi, ssh_key,
+                hostname,
+                timezone,
+                keymap,
+                user,
+                wifi,
+                ssh_key,
+                Some(usb_enable_dhcp),
             );
 
             bb_flasher::sd::Flasher::new(

--- a/bb-imager-gui/src/helpers.rs
+++ b/bb-imager-gui/src/helpers.rs
@@ -462,7 +462,7 @@ pub(crate) async fn flash(
             bb_flasher::sd::Flasher::new(
                 img,
                 t,
-                FlashingSdLinuxConfig::new(None, None, None, None, None, None),
+                FlashingSdLinuxConfig::new(None, None, None, None, None, None, None),
             )
             .flash(Some(chan))
             .await

--- a/bb-imager-gui/src/persistance.rs
+++ b/bb-imager-gui/src/persistance.rs
@@ -81,7 +81,7 @@ impl GuiConfiguration {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct SdCustomization {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) hostname: Option<String>,
@@ -95,6 +95,26 @@ pub(crate) struct SdCustomization {
     pub(crate) wifi: Option<SdCustomizationWifi>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) ssh: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) usb_enable_dhcp: Option<bool>,
+}
+
+impl Default for SdCustomization {
+    fn default() -> Self {
+        Self {
+            hostname: None,
+            timezone: None,
+            keymap: None,
+            user: None,
+            wifi: None,
+            ssh: None,
+            usb_enable_dhcp: if cfg!(windows) || cfg!(target_os = "macos") {
+                Some(true)
+            } else {
+                None
+            },
+        }
+    }
 }
 
 impl SdCustomization {
@@ -127,6 +147,11 @@ impl SdCustomization {
         self.ssh = t;
         self
     }
+
+    pub(crate) fn update_usb_enable_dhcp(mut self, t: Option<bool>) -> Self {
+        self.usb_enable_dhcp = t;
+        self
+    }
 }
 
 impl From<SdCustomization> for bb_flasher::sd::FlashingSdLinuxConfig {
@@ -138,6 +163,7 @@ impl From<SdCustomization> for bb_flasher::sd::FlashingSdLinuxConfig {
             value.user.map(|x| (x.username, x.password)),
             value.wifi.map(|x| (x.ssid, x.password)),
             value.ssh,
+            value.usb_enable_dhcp,
         )
     }
 }

--- a/bb-imager-gui/src/ui/configuration.rs
+++ b/bb-imager-gui/src/ui/configuration.rs
@@ -94,7 +94,23 @@ fn linux_sd_form<'a>(
         uname_pass_form(config).width(iced::Length::Fill),
         wifi_form(config).width(iced::Length::Fill),
         ssh_form(config).width(iced::Length::Fill),
+        usb_enable_dhcp_form(config)
     ]
+}
+
+fn usb_enable_dhcp_form(config: &SdCustomization) -> widget::Container<'_, BBImagerMessage> {
+    let form = widget::toggler(config.usb_enable_dhcp == Some(true))
+        .label("Enable USB DHCP")
+        .on_toggle(|x| {
+            BBImagerMessage::UpdateFlashConfig(FlashingCustomization::LinuxSd(
+                config.clone().update_usb_enable_dhcp(Some(x)),
+            ))
+        })
+        .width(iced::Length::Fill);
+
+    widget::container(form)
+        .padding(10)
+        .style(widget::container::bordered_box)
 }
 
 fn ssh_form<'a>(config: &'a SdCustomization) -> widget::Container<'a, BBImagerMessage> {


### PR DESCRIPTION
- The sysconfig.txt variable used is `usb_enable_dhcp`
- Defaults to true for new users on windows and macos.