### PR TITLE
bb-flasher-gui: Add BeagleV-Fire instructions to UI

### DIFF
--- a/bb-imager-gui/src/constants.rs
+++ b/bb-imager-gui/src/constants.rs
@@ -1,3 +1,9 @@
+/// Instructions for BeagleV-Fire board
+pub(crate) const BEAGLEV_FIRE_INSTRUCTIONS: &str = "
+1. Connect the BeagleV-Fire board to your computer via USB.
+2. While powering on the board, click the USER button on the board as soon as you power it on.
+3. BeagleV-Fire must appear as a USB device in the destination list.
+";
 use iced::color;
 
 pub(crate) const PACKAGE_QUALIFIER: (&str, &str, &str) = ("org", "beagleboard", "imagingutility");

--- a/bb-imager-gui/src/ui/home.rs
+++ b/bb-imager-gui/src/ui/home.rs
@@ -109,16 +109,30 @@ pub(crate) fn view<'a>(
         .width(iced::Length::Fill)
         .align_y(iced::Alignment::Center);
 
-        let bottom = widget::center(
-            widget::column![
-                choice_btn_row.height(iced::Length::FillPortion(1)),
-                action_btn_row.height(iced::Length::FillPortion(1)),
-            ]
-            .height(iced::Length::Fill)
-            .align_x(iced::Alignment::Center),
-        )
-        .padding([0.0, size.width * 0.05])
-        .style(|_| widget::container::background(constants::BEAGLE_BRAND_COLOR));
+        // Check if BeagleV-Fire is selected
+        let show_beaglev_fire_instructions = selected_board
+            .map(|board| board.name.to_lowercase().contains("beaglev-fire"))
+            .unwrap_or(false);
+
+        let instructions_widget = if show_beaglev_fire_instructions {
+            Some(
+                widget::container(
+                    text(constants::BEAGLEV_FIRE_INSTRUCTIONS)
+                        .size(16)
+                        .color(iced::Color::BLACK)
+                )
+            )
+        } else {
+            None
+        };
+
+        let mut inner_col = widget::column![
+            choice_btn_row.height(iced::Length::FillPortion(1)),
+        ];
+        if let Some(instr) = instructions_widget {
+            inner_col = inner_col.push(instr);
+        }
+        inner_col = inner_col.push(action_btn_row.height(iced::Length::FillPortion(1)));
 
         widget::column![
             widget::container(
@@ -128,7 +142,13 @@ pub(crate) fn view<'a>(
             )
             .padding(iced::Padding::new(0.0).left(40))
             .width(iced::Length::Fill),
-            bottom
+            widget::center(
+                inner_col
+                    .height(iced::Length::Fill)
+                    .align_x(iced::Alignment::Center),
+            )
+            .padding([0.0, size.width * 0.05])
+            .style(|_| widget::container::background(constants::BEAGLE_BRAND_COLOR)),
         ]
         .into()
     })


### PR DESCRIPTION
I've added a small snippet of instructions for putting the beagleV-fire into boot mode before flashing it. This way, the users won't have to open documentation or stay lost until they figure out that the conventional flashing process doesn't work for beaglev-fire. Please let me know if you suggest any changes.

<img width="792" alt="Screenshot 2025-06-04 at 10 22 45 PM" src="https://github.com/user-attachments/assets/6e69affe-08be-4c15-a706-d1faa9906b8c" />
