### PR TITLE
bb-imager-gui: Do not try customization for local images

### DIFF
--- a/bb-imager-gui/src/helpers.rs
+++ b/bb-imager-gui/src/helpers.rs
@@ -295,11 +295,8 @@ impl BoardImage {
         Self::Image {
             img: bb_flasher::LocalImage::new(path).into(),
             flasher,
-            init_format: if flasher == config::Flasher::SdCard {
-                Some(config::InitFormat::Sysconf)
-            } else {
-                None
-            },
+            // Do not try to apply customization for local images
+            init_format: None,
         }
     }
 


### PR DESCRIPTION
- Do not show customization options for local images.
- Much better than showing unavailable options to new users.