### PR TITLE
bb-imager-gui: No confirmation dialog for images without customization

### DIFF
--- a/bb-imager-gui/src/helpers.rs
+++ b/bb-imager-gui/src/helpers.rs
@@ -667,6 +667,16 @@ impl FlashingCustomization {
             _ => true,
         }
     }
+
+    /// Check if any configuration is even present
+    pub(crate) const fn need_confirmation(&self) -> bool {
+        match self {
+            Self::LinuxSd(_) | Self::Bcf(_) => true,
+            #[cfg(feature = "pb2_mspm0")]
+            Self::Pb2Mspm0(_) => true,
+            _ => false,
+        }
+    }
 }
 
 /// Fetches the main remote os_list file from `bb_config::DISTROS_URL` and merges it with the base

--- a/bb-imager-gui/src/message.rs
+++ b/bb-imager-gui/src/message.rs
@@ -32,6 +32,9 @@ pub(crate) enum BBImagerMessage {
     StopFlashing(ProgressBarState),
     UpdateFlashConfig(FlashingCustomization),
 
+    /// Write button was pressed
+    WriteBtn,
+
     OpenUrl(Cow<'static, str>),
 
     /// Messages to ignore
@@ -178,6 +181,13 @@ pub(crate) fn update(state: &mut BBImager, message: BBImagerMessage) -> Task<BBI
                 }
                 _ => unreachable!(),
             }
+        }
+        BBImagerMessage::WriteBtn => {
+            return match state.customization() {
+                Some(x) if x.need_confirmation() => state.push_page(Screen::FlashingConfirmation),
+                Some(x) => state.start_flashing(Some(x.clone())),
+                None => state.start_flashing(None),
+            };
         }
         BBImagerMessage::StartFlashing => {
             return state.start_flashing(state.customization.clone());

--- a/bb-imager-gui/src/ui/home.rs
+++ b/bb-imager-gui/src/ui/home.rs
@@ -67,7 +67,7 @@ pub(crate) fn view<'a>(
             .on_press_maybe(if next_btn_active {
                 None
             } else {
-                Some(BBImagerMessage::PushScreen(Screen::FlashingConfirmation))
+                Some(BBImagerMessage::WriteBtn)
             });
 
         let choice_btn_row = widget::row![


### PR DESCRIPTION
Do not show confirmation dialog when no customization options are present.