### PR TITLE
bb-imager-gui: Add global settings

### DIFF
--- a/bb-imager-gui/src/main.rs
+++ b/bb-imager-gui/src/main.rs
@@ -381,6 +381,10 @@ impl BBImager {
         self.customization.as_ref()
     }
 
+    pub(crate) fn app_settings(&self) -> persistance::AppSettings {
+        self.app_config.app_settings().cloned().unwrap_or_default()
+    }
+
     pub(crate) fn timezones(&self) -> &widget::combo_box::State<String> {
         &self.timezones
     }

--- a/bb-imager-gui/src/pages.rs
+++ b/bb-imager-gui/src/pages.rs
@@ -14,6 +14,7 @@ pub(crate) enum Screen {
 pub(crate) enum ConfigurationId {
     #[default]
     Customization,
+    Settings,
     About,
 }
 

--- a/bb-imager-gui/src/persistance.rs
+++ b/bb-imager-gui/src/persistance.rs
@@ -11,6 +11,8 @@ use crate::constants;
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct GuiConfiguration {
     #[serde(skip_serializing_if = "Option::is_none")]
+    app_settings: Option<AppSettings>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     sd_customization: Option<SdCustomization>,
     #[serde(skip_serializing_if = "Option::is_none")]
     bcf_customization: Option<BcfCustomization>,
@@ -67,6 +69,10 @@ impl GuiConfiguration {
         self.bcf_customization.as_ref()
     }
 
+    pub(crate) const fn app_settings(&self) -> Option<&AppSettings> {
+        self.app_settings.as_ref()
+    }
+
     #[cfg(feature = "pb2_mspm0")]
     pub(crate) const fn pb2_mspm0_customization(&self) -> Option<&Pb2Mspm0Customization> {
         self.pb2_mspm0_customization.as_ref()
@@ -78,6 +84,23 @@ impl GuiConfiguration {
 
     pub(crate) fn update_bcf_customization(&mut self, t: BcfCustomization) {
         self.bcf_customization = Some(t)
+    }
+
+    pub(crate) fn update_app_settings(&mut self, t: AppSettings) {
+        self.app_settings = Some(t)
+    }
+}
+
+#[derive(Default, Debug, Clone, Copy, Serialize, Deserialize)]
+pub(crate) struct AppSettings {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) skip_confirmation: Option<bool>,
+}
+
+impl AppSettings {
+    pub(crate) fn update_skip_confirmation(mut self, t: Option<bool>) -> Self {
+        self.skip_confirmation = t;
+        self
     }
 }
 

--- a/bb-imager-gui/src/ui/configuration.rs
+++ b/bb-imager-gui/src/ui/configuration.rs
@@ -13,6 +13,7 @@ use crate::{
 use super::helpers::home_btn_text;
 
 pub(crate) fn view<'a>(
+    app_settings: crate::persistance::AppSettings,
     customization: Option<&'a FlashingCustomization>,
     timezones: &'a widget::combo_box::State<String>,
     keymaps: &'a widget::combo_box::State<String>,
@@ -25,6 +26,11 @@ pub(crate) fn view<'a>(
                     ConfigurationId::Customization,
                     iced_aw::TabLabel::Text(String::from("Customization")),
                     customization_page(customization, timezones, keymaps),
+                ),
+                (
+                    ConfigurationId::Settings,
+                    iced_aw::TabLabel::Text(String::from("Settings")),
+                    global_settings(app_settings),
                 ),
                 (
                     ConfigurationId::About,
@@ -80,6 +86,39 @@ fn about_page() -> Element<'static, BBImagerMessage> {
         .height(iced::Length::Fill)
         .width(iced::Length::Fill)
         .align_x(iced::Alignment::Center)
+        .into()
+    })
+    .into()
+}
+
+fn global_settings(
+    app_settings: crate::persistance::AppSettings,
+) -> Element<'static, BBImagerMessage> {
+    widget::responsive(move |size| {
+        const HEADER_FOOTER_HEIGHT: f32 = 90.0;
+
+        let mid_el = widget::column![
+            widget::toggler(app_settings.skip_confirmation == Some(true))
+                .label("Disable confirmation dialog")
+                .on_toggle(move |t| BBImagerMessage::UpdateSettings(
+                    app_settings.update_skip_confirmation(Some(t))
+                ))
+        ]
+        .spacing(5);
+
+        widget::column![
+            widget::vertical_space().height(2),
+            widget::horizontal_rule(2),
+            widget::scrollable(mid_el).height(size.height - HEADER_FOOTER_HEIGHT),
+            widget::horizontal_rule(2),
+            home_btn_text("BACK", true, iced::Length::Fill)
+                .style(widget::button::secondary)
+                .width(iced::Length::FillPortion(1))
+                .on_press(BBImagerMessage::CancelCustomization),
+        ]
+        .spacing(10)
+        .height(iced::Length::Fill)
+        .width(iced::Length::Fill)
         .into()
     })
     .into()

--- a/bb-imager-gui/src/ui/mod.rs
+++ b/bb-imager-gui/src/ui/mod.rs
@@ -48,6 +48,7 @@ pub(crate) fn view(state: &BBImager) -> Element<BBImagerMessage> {
             destination_selection::view(state.destinations(), s.search_str())
         }
         Screen::ExtraConfiguration(id) => configuration::view(
+            state.app_settings(),
             state.customization(),
             state.timezones(),
             state.keymaps(),


### PR DESCRIPTION
- Currently only the option to disable confirmation dialog is available.
- Fixes #42 