### PR TITLE
bb-imager-gui: Disable usb-dhcp default on windows

### DIFF
--- a/bb-imager-gui/src/persistance.rs
+++ b/bb-imager-gui/src/persistance.rs
@@ -131,7 +131,7 @@ impl Default for SdCustomization {
             user: None,
             wifi: None,
             ssh: None,
-            usb_enable_dhcp: if cfg!(windows) || cfg!(target_os = "macos") {
+            usb_enable_dhcp: if cfg!(target_os = "macos") {
                 Some(true)
             } else {
                 None


### PR DESCRIPTION
- USB DHCP was enabled by default on windows. However, this seems to have stopped working. So just do not enable it by default on Windows.