### PR TITLE
bb-imager-gui: Add xdg portal notification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -583,6 +583,7 @@ dependencies = [
 name = "bb-imager-gui"
 version = "0.0.8"
 dependencies = [
+ "ashpd",
  "bb-config",
  "bb-downloader",
  "bb-flasher",

--- a/bb-imager-gui/Cargo.toml
+++ b/bb-imager-gui/Cargo.toml
@@ -34,6 +34,7 @@ embed-resource = "2.5.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 bb-flasher = { path = "../bb-flasher", features = ["sd_linux_udev"] }
+ashpd = "0.11.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 bb-flasher = { path = "../bb-flasher", features = ["sd_macos_authopen"] }

--- a/bb-imager-gui/src/message.rs
+++ b/bb-imager-gui/src/message.rs
@@ -207,15 +207,9 @@ pub(crate) fn update(state: &mut BBImager, message: BBImagerMessage) -> Task<BBI
 
             let progress_task = Task::done(BBImagerMessage::ProgressBar(x));
             let notification_task = Task::future(async move {
-                let res = tokio::task::spawn_blocking(move || {
-                    notify_rust::Notification::new()
-                        .appname("BeagleBoard Imager")
-                        .body(&content)
-                        .finalize()
-                        .show()
-                })
-                .await
-                .expect("Tokio runtime failed to spawn blocking task");
+                let res = helpers::show_notification(content)
+                    .await
+                    .expect("Tokio runtime failed to spawn blocking task");
 
                 tracing::debug!("Notification response {res:?}");
                 BBImagerMessage::Null


### PR DESCRIPTION
- Flatpak prefers xdg portal for notification, so use that.
- Have notify-rust as fallback.