### PR TITLE
bb-flasher-sd: linux: Disable OS cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -553,6 +553,7 @@ dependencies = [
  "fscommon",
  "futures",
  "gpt",
+ "libc",
  "mbrman",
  "nix 0.29.0",
  "security-framework 3.2.0",
@@ -3033,9 +3034,9 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libfuzzer-sys"

--- a/bb-flasher-sd/Cargo.toml
+++ b/bb-flasher-sd/Cargo.toml
@@ -23,6 +23,7 @@ gpt = "4.1.0"
 [target.'cfg(target_os = "linux")'.dependencies]
 udisks2 = { version = "0.3", optional = true }
 tokio = { version = "1.43", default-features = false, features = ["rt"], optional = true }
+libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.60", features = ["Win32", "Win32_Storage", "Win32_Storage_FileSystem", "Win32_Security", "Win32_System", "Win32_System_IO", "Win32_System_Ioctl"] }

--- a/bb-flasher-sd/src/flashing.rs
+++ b/bb-flasher-sd/src/flashing.rs
@@ -1,4 +1,4 @@
-use std::io::{BufWriter, Read, Seek, Write};
+use std::io::{Read, Seek, Write};
 use std::path::Path;
 use std::sync::Weak;
 
@@ -8,47 +8,54 @@ use crate::Result;
 use crate::customization::Customization;
 use crate::helpers::{Eject, chan_send, check_arc, progress};
 
-fn read_aligned(mut img: impl Read, buf: &mut [u8]) -> Result<usize> {
-    let mut pos = 0;
+const BUFFER_SIZE: usize = 1 * 1024 * 1024;
+const ALIGNMENT: usize = 512;
 
-    while pos != buf.len() {
-        let count = img.read(&mut buf[pos..])?;
-        // Need to align to 512 byte boundary for writing to sd card
-        if count == 0 {
-            buf[pos..].fill(0);
-            return Ok(pos);
-        }
+#[repr(align(512))]
+struct DirectIoBuffer([u8; BUFFER_SIZE]);
 
-        pos += count;
+impl DirectIoBuffer {
+    const fn new() -> Self {
+        Self([0u8; BUFFER_SIZE])
     }
-
-    Ok(pos)
 }
 
 fn write_sd(
     mut img: impl Read,
     img_size: u64,
-    mut sd: impl Write,
+    mut sd: impl Write + Seek,
     mut chan: Option<&mut mpsc::Sender<f32>>,
     cancel: Option<&Weak<()>>,
 ) -> Result<()> {
-    let mut buf = [0u8; 512];
+    let mut buf = Box::new(DirectIoBuffer::new());
     let mut pos = 0;
 
     // Clippy warning is simply wrong here
     #[allow(clippy::option_map_or_none)]
     chan_send(chan.as_mut().map_or(None, |p| Some(p)), 0.0);
     loop {
-        let count = read_aligned(&mut img, &mut buf)?;
+        let buf_pos = pos % ALIGNMENT;
+
+        let count = img.read(&mut buf.0[buf_pos..])?;
         if count == 0 {
+            // Pad remaining data with 0 and write
+            if buf_pos != 0 {
+                buf.0[buf_pos..ALIGNMENT].fill(0);
+                sd.write_all(&mut buf.0[..ALIGNMENT])?;
+            }
+
             break;
         }
 
-        // Since buf is 512, just write the whole thing since read_aligned will always fill it
-        // fully.
-        sd.write_all(&buf)?;
+        // Can only write in ALIGNMENT byte chunks
+        let bytes_to_write = buf_pos + count - count % ALIGNMENT;
+        sd.write_all(&buf.0[..bytes_to_write])?;
 
-        pos += count;
+        // Copy the remaining bytes to buffer start and update position in buffer
+        buf.0
+            .copy_within(bytes_to_write..(bytes_to_write + count % ALIGNMENT), 0);
+
+        pos += bytes_to_write;
         // Clippy warning is simply wrong here
         #[allow(clippy::option_map_or_none)]
         chan_send(
@@ -118,13 +125,7 @@ fn flash_internal(
 ) -> Result<()> {
     chan_send(chan.as_mut(), 0.0);
 
-    write_sd(
-        img,
-        img_size,
-        BufWriter::new(&mut sd),
-        chan.as_mut(),
-        cancel.as_ref(),
-    )?;
+    write_sd(img, img_size, &mut sd, chan.as_mut(), cancel.as_ref())?;
 
     check_arc(cancel.as_ref())?;
 


### PR DESCRIPTION
- Disable OS cache when writing to SD Card on Linux from GUI. This make the progress bar represent the actual progress.
- Requires buffer to be 512 byte aligned.
- Also make buffer size 1MB for a bit better performance.
- Still no match for Balena Etcher.