### PR TITLE
bb-imager-gui: Log to file

### DIFF
--- a/bb-downloader/src/lib.rs
+++ b/bb-downloader/src/lib.rs
@@ -245,7 +245,7 @@ impl Downloader {
         mut chan: Option<mpsc::Sender<f32>>,
     ) -> io::Result<PathBuf> {
         let url = url.into_url().map_err(io::Error::other)?;
-        tracing::info!(
+        tracing::debug!(
             "Download {:?} with sha256: {:?}",
             url,
             const_hex::encode(sha256)

--- a/bb-imager-gui/src/helpers.rs
+++ b/bb-imager-gui/src/helpers.rs
@@ -737,3 +737,11 @@ pub(crate) async fn show_notification(body: String) -> notify_rust::error::Resul
     .unwrap()
     .map(|_| ())
 }
+
+pub(crate) fn project_dirs() -> Option<directories::ProjectDirs> {
+    directories::ProjectDirs::from(
+        crate::constants::PACKAGE_QUALIFIER.0,
+        crate::constants::PACKAGE_QUALIFIER.1,
+        crate::constants::PACKAGE_QUALIFIER.2,
+    )
+}

--- a/bb-imager-gui/src/message.rs
+++ b/bb-imager-gui/src/message.rs
@@ -226,7 +226,7 @@ pub(crate) fn update(state: &mut BBImager, message: BBImagerMessage) -> Task<BBI
         BBImagerMessage::OpenUrl(x) => {
             return Task::future(async move {
                 let res = webbrowser::open(&x);
-                tracing::info!("Open Url Resp {res:?}");
+                tracing::debug!("Open Url Resp {res:?}");
                 BBImagerMessage::Null
             });
         }

--- a/bb-imager-gui/src/persistance.rs
+++ b/bb-imager-gui/src/persistance.rs
@@ -5,8 +5,6 @@ use std::{io::Read, path::PathBuf};
 use serde::{Deserialize, Serialize};
 use tokio::io::AsyncWriteExt;
 
-use crate::constants;
-
 /// Configuration for GUI that should be presisted
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct GuiConfiguration {
@@ -52,12 +50,7 @@ impl GuiConfiguration {
     }
 
     fn config_path() -> Option<PathBuf> {
-        let dirs = directories::ProjectDirs::from(
-            constants::PACKAGE_QUALIFIER.0,
-            constants::PACKAGE_QUALIFIER.1,
-            constants::PACKAGE_QUALIFIER.2,
-        )?;
-
+        let dirs = crate::helpers::project_dirs()?;
         Some(dirs.config_local_dir().join("config.json").to_owned())
     }
 


### PR DESCRIPTION
- Log to a file (along with stdout).
- This should make debugging other people's errors easier since they can just send the log files.