### PR TITLE
Add armbian os_list.json file

### DIFF
--- a/bb-config/src/config.rs
+++ b/bb-config/src/config.rs
@@ -77,6 +77,8 @@ pub struct Device {
 pub enum InitFormat {
     /// Sysconfig based customization
     Sysconf,
+    /// Armbian base customization
+    Armbian
 }
 
 /// Os List can contain multiple types of items depending on the situation.

--- a/config.json
+++ b/config.json
@@ -3,7 +3,8 @@
 		"latest_version": "2.0.0",
 		"remote_configs": [
 			"https://raw.githubusercontent.com/beagleboard/distros/refs/heads/main/os_list.json",
-			"https://github.com/beagleboard/micropython-builder/releases/download/continuous-release/os_list.json"
+			"https://github.com/beagleboard/micropython-builder/releases/download/continuous-release/os_list.json",
+			"https://github.com/beagleboard/bb-armbian-watcher/releases/download/continuous-release/os_list.json"
 		],
 		"devices": [
 			{


### PR DESCRIPTION
- Adds the basic os_list.json file for armbian.
- No support for customization right now.