### PR TITLE
bb-imager-gui: Show Log file path

### DIFF
--- a/bb-imager-gui/src/helpers.rs
+++ b/bb-imager-gui/src/helpers.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, fmt::Display, path::PathBuf, sync::LazyLock};
 
-use crate::BBImagerMessage;
+use crate::{BBImagerMessage, PACKAGE_QUALIFIER};
 use bb_config::config::{self, OsListItem};
 use bb_flasher::{BBFlasher, BBFlasherTarget, DownloadFlashingStatus, sd::FlashingSdLinuxConfig};
 use futures::StreamExt;
@@ -747,4 +747,12 @@ pub(crate) fn project_dirs() -> Option<directories::ProjectDirs> {
         crate::constants::PACKAGE_QUALIFIER.1,
         crate::constants::PACKAGE_QUALIFIER.2,
     )
+}
+
+pub(crate) fn log_file_path() -> PathBuf {
+    let dirs = crate::helpers::project_dirs().unwrap();
+    dirs.cache_dir().with_file_name(format!(
+        "{}.{}.{}.log",
+        PACKAGE_QUALIFIER.0, PACKAGE_QUALIFIER.1, PACKAGE_QUALIFIER.2
+    ))
 }

--- a/bb-imager-gui/src/main.rs
+++ b/bb-imager-gui/src/main.rs
@@ -20,15 +20,6 @@ mod persistance;
 mod ui;
 
 fn main() -> iced::Result {
-    let dirs = crate::helpers::project_dirs().unwrap();
-    let log_file_p = dirs
-        .cache_dir()
-        .with_file_name("bb-imager.log")
-        .with_file_name(format!(
-            "{}.{}.{}.log",
-            PACKAGE_QUALIFIER.0, PACKAGE_QUALIFIER.1, PACKAGE_QUALIFIER.2
-        ));
-
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::builder()
@@ -39,12 +30,10 @@ fn main() -> iced::Result {
         .with(
             tracing_subscriber::fmt::layer()
                 .with_ansi(false)
-                .with_writer(std::fs::File::create(&log_file_p).unwrap()),
+                .with_writer(std::fs::File::create(helpers::log_file_path()).unwrap()),
         )
         .try_init()
         .expect("Failed to register tracing_subscriber");
-
-    tracing::info!("Logging to file at: {:?}", log_file_p);
 
     let icon = iced::window::icon::from_file_data(
         constants::WINDOW_ICON,

--- a/bb-imager-gui/src/ui/configuration.rs
+++ b/bb-imager-gui/src/ui/configuration.rs
@@ -97,12 +97,25 @@ fn global_settings(
     widget::responsive(move |size| {
         const HEADER_FOOTER_HEIGHT: f32 = 90.0;
 
+        let log_file_p = helpers::log_file_path().to_string_lossy().to_string();
         let mid_el = widget::column![
-            widget::toggler(app_settings.skip_confirmation == Some(true))
-                .label("Disable confirmation dialog")
-                .on_toggle(move |t| BBImagerMessage::UpdateSettings(
-                    app_settings.update_skip_confirmation(Some(t))
-                ))
+            widget::container(
+                widget::toggler(app_settings.skip_confirmation == Some(true))
+                    .label("Disable confirmation dialog")
+                    .on_toggle(move |t| BBImagerMessage::UpdateSettings(
+                        app_settings.update_skip_confirmation(Some(t))
+                    ))
+            )
+            .width(iced::Length::Fill)
+            .padding(10)
+            .style(widget::container::bordered_box),
+            widget::container(element_with_label(
+                "Log File",
+                widget::text_input(&log_file_p, &log_file_p)
+                    .on_input(|_| BBImagerMessage::Null)
+                    .into()
+            ))
+            .style(widget::container::bordered_box)
         ]
         .spacing(5);
 


### PR DESCRIPTION
- Show log file path in settings. Allows users to easily identify the log file location.
- Fixes #80 