### PR TITLE
bb-flasher-sd: Make sd open async

### DIFF
--- a/bb-flasher-sd/Cargo.toml
+++ b/bb-flasher-sd/Cargo.toml
@@ -31,6 +31,7 @@ libc = "0.2"
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.61", features = ["Win32", "Win32_Storage", "Win32_Storage_FileSystem", "Win32_Security", "Win32_System", "Win32_System_IO", "Win32_System_Ioctl"] }
 tempfile = "3.20"
+tokio = { version = "1.46", default-features = false, features = ["rt-multi-thread", "process"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 security-framework = { version = "3.2", optional = true }

--- a/bb-flasher-sd/src/flashing.rs
+++ b/bb-flasher-sd/src/flashing.rs
@@ -217,9 +217,7 @@ pub async fn flash<R: Read + Send + 'static>(
 
     tracing::info!("Opening Destination");
     let dst_clone = dst.to_path_buf();
-    let sd = tokio::task::spawn_blocking(move || crate::pal::open(&dst_clone))
-        .await
-        .unwrap()?;
+    let sd = crate::pal::open(&dst_clone).await?;
 
     let mut tasks = tokio::task::JoinSet::new();
 

--- a/bb-flasher-sd/src/pal/macos.rs
+++ b/bb-flasher-sd/src/pal/macos.rs
@@ -7,101 +7,114 @@ pub(crate) fn format(_dst: &Path) -> Result<()> {
 }
 
 #[cfg(not(feature = "macos_authopen"))]
-pub(crate) fn open(dst: &Path) -> Result<File> {
-    std::fs::OpenOptions::new()
+pub(crate) async fn open(dst: &Path) -> Result<File> {
+    let f = tokio::fs::OpenOptions::new()
         .read(true)
         .write(true)
         .create(false)
         .open(dst)
-        .map_err(Into::into)
+        .await?
+        .into_std()
+        .await;
+
+    Ok(f)
 }
 
 #[cfg(feature = "macos_authopen")]
-pub(crate) fn open(dst: &Path) -> Result<File> {
-    use nix::cmsg_space;
-    use nix::sys::socket::{ControlMessageOwned, MsgFlags};
-    use security_framework::authorization::{Authorization, AuthorizationItemSetBuilder, Flags};
-    use std::{
-        io::{IoSliceMut, Write},
-        os::{
-            fd::{AsRawFd, FromRawFd, OwnedFd, RawFd},
-            unix::net::UnixStream,
-        },
-        process::{Command, Stdio},
-    };
+pub(crate) async fn open(dst: &Path) -> Result<File> {
+    fn inner(dst: std::path::PathBuf) -> Result<File> {
+        use nix::cmsg_space;
+        use nix::sys::socket::{ControlMessageOwned, MsgFlags};
+        use security_framework::authorization::{
+            Authorization, AuthorizationItemSetBuilder, Flags,
+        };
+        use std::{
+            io::{IoSliceMut, Write},
+            os::{
+                fd::{AsRawFd, FromRawFd, OwnedFd, RawFd},
+                unix::net::UnixStream,
+            },
+            process::{Command, Stdio},
+        };
 
-    let rights = AuthorizationItemSetBuilder::new()
-        .add_right(format!("sys.openfile.readwrite.{}", dst.to_str().unwrap()))
-        .expect("Failed to create right")
-        .build();
+        let rights = AuthorizationItemSetBuilder::new()
+            .add_right(format!("sys.openfile.readwrite.{}", dst.to_str().unwrap()))
+            .expect("Failed to create right")
+            .build();
 
-    let auth = Authorization::new(
-        Some(rights),
-        None,
-        Flags::INTERACTION_ALLOWED | Flags::EXTEND_RIGHTS | Flags::PREAUTHORIZE,
-    )
-    .expect("Failed to create authorization");
+        let auth = Authorization::new(
+            Some(rights),
+            None,
+            Flags::INTERACTION_ALLOWED | Flags::EXTEND_RIGHTS | Flags::PREAUTHORIZE,
+        )
+        .expect("Failed to create authorization");
 
-    let form = auth
-        .make_external_form()
-        .expect("Failed to make external form");
-    let (pipe0, pipe1) = UnixStream::pair().expect("Failed to create socket");
+        let form = auth
+            .make_external_form()
+            .expect("Failed to make external form");
+        let (pipe0, pipe1) = UnixStream::pair().expect("Failed to create socket");
 
-    let _ = Command::new("diskutil")
-        .args(["unmountDisk", dst.to_str().unwrap()])
-        .output()
-        .map_err(|_| Error::FailedToOpenDestination("Failed to unmount disk".to_string()))?;
+        let _ = Command::new("diskutil")
+            .args(["unmountDisk", dst.to_str().unwrap()])
+            .output()
+            .map_err(|_| Error::FailedToOpenDestination("Failed to unmount disk".to_string()))?;
 
-    let mut cmd = Command::new("/usr/libexec/authopen")
-        .args(["-stdoutpipe", "-extauth", "-o", "2", dst.to_str().unwrap()])
-        .stdin(Stdio::piped())
-        .stdout(OwnedFd::from(pipe1))
-        .spawn()
-        .map_err(|_| Error::FailedToOpenDestination("Failed to open disk".to_string()))?;
+        let mut cmd = Command::new("/usr/libexec/authopen")
+            .args(["-stdoutpipe", "-extauth", "-o", "2", dst.to_str().unwrap()])
+            .stdin(Stdio::piped())
+            .stdout(OwnedFd::from(pipe1))
+            .spawn()
+            .map_err(|_| Error::FailedToOpenDestination("Failed to open disk".to_string()))?;
 
-    // Send authorization form
-    let mut stdin = cmd.stdin.take().expect("Missing stdin");
-    let form_bytes: Vec<u8> = form.bytes.into_iter().map(|x| x as u8).collect();
-    stdin
-        .write_all(&form_bytes)
-        .expect("Failed to write to stdin");
-    drop(stdin);
+        // Send authorization form
+        let mut stdin = cmd.stdin.take().expect("Missing stdin");
+        let form_bytes: Vec<u8> = form.bytes.into_iter().map(|x| x as u8).collect();
+        stdin
+            .write_all(&form_bytes)
+            .expect("Failed to write to stdin");
+        drop(stdin);
 
-    const IOV_BUF_SIZE: usize =
-        unsafe { nix::libc::CMSG_SPACE(std::mem::size_of::<std::ffi::c_int>() as u32) } as usize;
-    let mut iov_buf = [0u8; IOV_BUF_SIZE];
-    let mut iov = [IoSliceMut::new(&mut iov_buf)];
+        const IOV_BUF_SIZE: usize =
+            unsafe { nix::libc::CMSG_SPACE(std::mem::size_of::<std::ffi::c_int>() as u32) }
+                as usize;
+        let mut iov_buf = [0u8; IOV_BUF_SIZE];
+        let mut iov = [IoSliceMut::new(&mut iov_buf)];
 
-    let mut cmsg = cmsg_space!([RawFd; 1]);
+        let mut cmsg = cmsg_space!([RawFd; 1]);
 
-    match nix::sys::socket::recvmsg::<()>(
-        pipe0.as_raw_fd(),
-        &mut iov,
-        Some(&mut cmsg),
-        MsgFlags::empty(),
-    ) {
-        Ok(result) => {
-            tracing::info!("Result: {:#?}", result);
+        match nix::sys::socket::recvmsg::<()>(
+            pipe0.as_raw_fd(),
+            &mut iov,
+            Some(&mut cmsg),
+            MsgFlags::empty(),
+        ) {
+            Ok(result) => {
+                tracing::info!("Result: {:#?}", result);
 
-            for msg in result.cmsgs().expect("Unexpected error") {
-                if let ControlMessageOwned::ScmRights(scm_rights) = msg {
-                    if let Some(fd) = scm_rights.into_iter().next() {
-                        tracing::debug!("receive file descriptor");
-                        return Ok(unsafe { File::from_raw_fd(fd) });
+                for msg in result.cmsgs().expect("Unexpected error") {
+                    if let ControlMessageOwned::ScmRights(scm_rights) = msg {
+                        if let Some(fd) = scm_rights.into_iter().next() {
+                            tracing::debug!("receive file descriptor");
+                            return Ok(unsafe { File::from_raw_fd(fd) });
+                        }
                     }
                 }
             }
+            Err(e) => {
+                tracing::error!("Macos Error: {}", e);
+            }
         }
-        Err(e) => {
-            tracing::error!("Macos Error: {}", e);
-        }
+
+        let _ = cmd.wait();
+
+        Err(Error::FailedToOpenDestination(
+            "Authopen failed to open the file".to_string(),
+        ))
     }
 
-    let _ = cmd.wait();
-
-    Err(Error::FailedToOpenDestination(
-        "Authopen failed to open the file".to_string(),
-    ))
+    let p = dst.to_owned();
+    // TODO: Make this into a real async function
+    tokio::task::spawn_blocking(move || inner(p)).await.unwrap()
 }
 
 /// TODO: Implement real eject


### PR DESCRIPTION
- Since we now open sd card from an async version, better to make the action async as well.
- On linux and Windows, doing this is trivial.
- On macOS, just using spawn_blocking since I do not have any way to test if I break something.