### PR TITLE
bb-flasher-sd: windows: Use Clear-Disk instead of diskpart

### DIFF
--- a/bb-flasher-sd/src/lib.rs
+++ b/bb-flasher-sd/src/lib.rs
@@ -85,6 +85,9 @@ pub enum Error {
     #[cfg(windows)]
     #[error("Windows Error: {0}")]
     WindowsError(#[from] windows::core::Error),
+    #[cfg(windows)]
+    #[error("Failed to clear SD Card: {0:?}")]
+    WindowsCleanError(std::process::Output),
     #[error("Writer thread has been closed")]
     WriterClosed,
 }


### PR DESCRIPTION
- It's a single powershell command with no stdin inputs.
- Much faster than using diskpart with Rust process.
- Fixes #91 