### PR TITLE
bb-imager-gui: Get instructions from config file

### DIFF
--- a/bb-config/src/config.rs
+++ b/bb-config/src/config.rs
@@ -68,6 +68,8 @@ pub struct Device {
     pub flasher: Flasher,
     /// Link to board documentation
     pub documentation: Option<Url>,
+    /// Special Instructions for flashing board.
+    pub instructions: Option<String>
 }
 
 /// Types of customization Initialization formats
@@ -164,6 +166,8 @@ pub struct OsImage {
     pub init_format: Option<InitFormat>,
     /// Bmap file for the image
     pub bmap: Option<Url>,
+    /// Special Instructions for flashing board.
+    pub info_text: Option<String>
 }
 
 /// Types of flashers Os Image(s) support

--- a/bb-imager-gui/src/constants.rs
+++ b/bb-imager-gui/src/constants.rs
@@ -1,9 +1,3 @@
-/// Instructions for BeagleV-Fire board
-pub(crate) const BEAGLEV_FIRE_INSTRUCTIONS: &str = "
-1. Connect the BeagleV-Fire board to your computer via USB.
-2. While powering on the board, click the USER button on the board as soon as you power it on.
-3. BeagleV-Fire must appear as a USB device in the destination list.
-";
 use iced::color;
 
 pub(crate) const PACKAGE_QUALIFIER: (&str, &str, &str) = ("org", "beagleboard", "imagingutility");

--- a/bb-imager-gui/src/helpers.rs
+++ b/bb-imager-gui/src/helpers.rs
@@ -294,6 +294,7 @@ pub(crate) enum BoardImage {
         init_format: Option<config::InitFormat>,
         img: SelectedImage,
         bmap: Option<Bmap>,
+        info_text: Option<String>,
     },
 }
 
@@ -305,6 +306,7 @@ impl BoardImage {
             flasher,
             // Do not try to apply customization for local images
             init_format: None,
+            info_text: None,
         }
     }
 
@@ -328,6 +330,7 @@ impl BoardImage {
             }),
             flasher,
             init_format: image.init_format,
+            info_text: image.info_text,
         }
     }
 
@@ -341,6 +344,13 @@ impl BoardImage {
     pub(crate) const fn init_format(&self) -> Option<config::InitFormat> {
         match self {
             BoardImage::Image { init_format, .. } => *init_format,
+            BoardImage::SdFormat => None,
+        }
+    }
+
+    pub(crate) fn info_text(&self) -> Option<String> {
+        match self {
+            BoardImage::Image { info_text, .. } => info_text.clone(),
             BoardImage::SdFormat => None,
         }
     }

--- a/bb-imager-gui/src/ui/home.rs
+++ b/bb-imager-gui/src/ui/home.rs
@@ -104,17 +104,16 @@ pub(crate) fn view<'a>(
         .width(iced::Length::Fill)
         .align_y(iced::Alignment::Center);
 
-        // Check if BeagleV-Fire is selected
-        let show_beaglev_fire_instructions = selected_board
-            .map(|board| board.name.to_lowercase().contains("beaglev-fire"))
-            .unwrap_or(false);
-
-        let instructions_widget = if show_beaglev_fire_instructions {
-            Some(widget::container(
-                text(constants::BEAGLEV_FIRE_INSTRUCTIONS)
-                    .size(16)
-                    .color(iced::Color::BLACK),
-            ))
+        let instructions_widget = if selected_image.is_some() && selected_board.is_some() {
+            match (
+                selected_board.map(|x| x.instructions.clone()).flatten(),
+                selected_image.map(|x| x.info_text()).flatten(),
+            ) {
+                (_, Some(x)) | (Some(x), None) => Some(widget::container(
+                    text(x).size(16).color(iced::Color::BLACK),
+                )),
+                _ => None,
+            }
         } else {
             None
         };

--- a/config.json
+++ b/config.json
@@ -62,7 +62,8 @@
 				"description": "BeagleV-Fire based on Microchip PolarFire SoC",
 				"icon": "https://media.githubusercontent.com/media/beagleboard/bb-imager-rs/refs/heads/main/assets/boards/beaglevfire.png",
 				"flasher": "SdCard",
-				"documentation": "https://docs.beagleboard.org/boards/beaglev/fire/index.html#beaglev-fire-home"
+				"documentation": "https://docs.beagleboard.org/boards/beaglev/fire/index.html#beaglev-fire-home",
+				"instructions": "1. Connect the BeagleV-Fire board to your computer via USB.\n2. While powering on the board, click the USER button on the board as soon as you power it on.\n3. BeagleV-Fire must appear as a USB device in the destination list."
 			},
 			{
 				"name": "BeagleBone Black",


### PR DESCRIPTION
- Allow specifying instructions for a board or image in os_list.json.
- Image info_text will take precedence over board info text.
- Only shows instructions after both board and image are selected.
- Fix #95 