### PR TITLE
bb-downloader: Enable SHA2 ASM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5358,6 +5358,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+ "sha2-asm",
+]
+
+[[package]]
+name = "sha2-asm"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b845214d6175804686b2bd482bcffe96651bb2d1200742b712003504a2dac1ab"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/bb-downloader/Cargo.toml
+++ b/bb-downloader/Cargo.toml
@@ -28,5 +28,8 @@ json = ["reqwest/json", "dep:serde"]
 [dev-dependencies]
 tokio = { version = "1.47", features = ["macros", "rt-multi-thread"] }
 
+[target.'cfg(not(windows))'.dependencies]
+sha2 = { version = "0.10", features = ["asm"] }
+
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
- Will fail to compile on windows msvc, so only enable it when target is not windows.