### PR TITLE
bb-flasher-sd: Add macos format support

### DIFF
--- a/bb-flasher-sd/src/pal/macos.rs
+++ b/bb-flasher-sd/src/pal/macos.rs
@@ -2,8 +2,12 @@ use std::{fs::File, path::Path};
 
 use crate::{Error, Result};
 
-pub(crate) async fn format(_dst: &Path) -> Result<()> {
-    unimplemented!()
+pub(crate) async fn format(dst: &Path) -> Result<()> {
+    let sd = open(dst).await?;
+    tokio::task::spawn_blocking(|| fatfs::format_volume(sd, fatfs::FormatVolumeOptions::default()))
+        .await
+        .unwrap()
+        .map_err(|e| Error::FailedToFormat(e.to_string()))
 }
 
 #[cfg(not(feature = "macos_authopen"))]


### PR DESCRIPTION
- No idea if it works, but technically I don't see any reason it shouldn't.
- Fixes #24 