### PR TITLE
assets: os: Update images

### DIFF
--- a/assets/os/armbian.png
+++ b/assets/os/armbian.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:02354364c2eecbee5384bcc37d885e818279befad24a9c177306dceeba5b9c25
-size 2361

--- a/assets/os/armbian.webp
+++ b/assets/os/armbian.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ca4f171ade15741fa26d0ad6876e9fa8a620bd39cc1cf0e5bf4cdfbf2d35f09
+size 1518

--- a/assets/os/microblocks.svg
+++ b/assets/os/microblocks.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:25d1645efaa383bfb7801159a04c46e137319a37ba48f15577c4dd715d88bb04
+size 15983

--- a/assets/os/micropython.webp
+++ b/assets/os/micropython.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:87087fa91d29e4df36ff2bbcadc6d9a78aab3ed16c3dc00f367b06f09f6893e4
+size 1874

--- a/assets/os/template.psd
+++ b/assets/os/template.psd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ecce17c20f54a089dd5debcffeb1d5eb04c5e790246fcc4e99bd64acc48b6e34
-size 26634

--- a/assets/os/zephyr.png
+++ b/assets/os/zephyr.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:967e95f577be8a017387a8ef24e414c7910bf5e26a6adfc4d40501cb16fc9078
-size 1596

--- a/assets/os/zephyr.webp
+++ b/assets/os/zephyr.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68f969eae58a51ac50af5de937e0b4ed98084e90c33107ca802ff17249597c99
+size 882


### PR DESCRIPTION
- Using transparent background.
- Not using lfs for the svgs because they are more text (and less blobby) than a lot of svgs I have seen in the past. So seems like they will do wall being tracked by git.