### PR TITLE
Makefile: Use normal cargo-packager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,7 @@ setup-fedora-deps:
 .PHONY: setup-packaging-deps
 setup-packaging-deps:
 	$(info "Installing dependencies required for packaging")
-	$(CARGO_PATH) install cargo-packager --locked --git https://github.com/crabnebula-dev/cargo-packager.git
+	$(CARGO_PATH) install cargo-packager --locked
 
 
 ## housekeeping: package-rename: Replace package version with `_alpha_`. Intended for use in CI.


### PR DESCRIPTION
- Since all the changes have been merged, and new release has been created, no need to use main branch anymore.