### PR TITLE
config.json: Use top-level os-list for zephyr images

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,7 +5,8 @@
 			"https://raw.githubusercontent.com/beagleboard/distros/refs/heads/main/os_list.json",
 			"https://github.com/beagleboard/micropython-builder/releases/download/continuous-release/os_list.json",
 			"https://github.com/beagleboard/bb-armbian-watcher/releases/download/continuous-release/os_list.json",
-			"https://raw.githubusercontent.com/FalconChristmas/fpp/refs/heads/master/rpi-imager/rpi-imager_falcon_player.json"
+			"https://raw.githubusercontent.com/FalconChristmas/fpp/refs/heads/master/rpi-imager/rpi-imager_falcon_player.json",
+			"https://github.com/beagleboard/bb-zephyr-images/releases/download/continuous-release/os_list.json"
 		],
 		"devices": [
 			{
@@ -148,16 +149,6 @@
 					]
 				}
 			]
-		},
-		{
-			"name": "Zephyr SD Card Images",
-			"description": "Images to use Zephyr on A53 Cores",
-			"icon": "https://media.githubusercontent.com/media/beagleboard/bb-imager-rs/refs/heads/main/assets/os/zephyr.webp",
-			"flasher": "SdCard",
-			"devices": [
-				"pocketbeagle2-am62"
-			],
-			"subitems_url": "https://github.com/beagleboard/bb-zephyr-images/releases/download/continuous-release/os_list.json"
 		}
 	]
 }


### PR DESCRIPTION
- Should work better for this case.