### PR TITLE
System keyboard layout detection for GUI

### DIFF
--- a/bb-imager-gui/src/helpers.rs
+++ b/bb-imager-gui/src/helpers.rs
@@ -376,6 +376,32 @@ pub(crate) fn system_timezone() -> Option<&'static String> {
     (*SYSTEM_TIMEZONE).as_ref()
 }
 
+pub(crate) fn system_keymap() -> String {
+    static SYSTEM_KEYMAP: LazyLock<Option<String>> = LazyLock::new(|| {
+        let lang = whoami::langs().ok()?.next()?;
+        let lang_str = lang.to_string();
+
+        let base = lang_str.split('.').next().unwrap_or(&lang_str);
+        let mut parts = base.split(|c| c == '-' || c == '_' || c == '/');
+
+        parts.next(); 
+        if let Some(region) = parts.next() {
+            let region = region.split('@').next().unwrap_or(region).trim();
+            if !region.is_empty() {
+                if let Some(&canon) = crate::constants::KEYMAP_LAYOUTS
+                    .iter()
+                    .find(|k| k.eq_ignore_ascii_case(region))
+                {
+                    return Some(canon.to_string());
+                }
+            }
+        }
+
+        None
+    });
+    (*SYSTEM_KEYMAP).as_ref().cloned().unwrap_or_else(|| String::from("us"))
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct RemoteImage {
     name: Box<str>,

--- a/bb-imager-gui/src/main.rs
+++ b/bb-imager-gui/src/main.rs
@@ -42,6 +42,8 @@ fn main() -> iced::Result {
         .try_init()
         .expect("Failed to register tracing_subscriber");
 
+    tracing::info!("Resolved GUI keymap: {:?}", helpers::system_keymap());
+
     let icon = iced::window::icon::from_file_data(
         constants::WINDOW_ICON,
         Some(iced::advanced::graphics::image::image_rs::ImageFormat::Png),

--- a/bb-imager-gui/src/ui/configuration.rs
+++ b/bb-imager-gui/src/ui/configuration.rs
@@ -274,7 +274,11 @@ fn keymap_form<'a>(
         widget::toggler(config.keymap.is_some())
             .label("Set Keymap")
             .on_toggle(|t| {
-                let keymap = if t { Some(String::from("us")) } else { None };
+                let keymap = if t {
+                    Some(helpers::system_keymap())
+                } else {
+                    None
+                };
                 BBImagerMessage::UpdateFlashConfig(FlashingCustomization::LinuxSdSysconfig(
                     config.clone().update_keymap(keymap),
                 ))


### PR DESCRIPTION
# PR: Issue #105  — System keyboard layout detection (GUI)

## Summary
Adds automatic keyboard layout detection for the GUI. When users enable "Set Keymap" in the configuration UI, the system detects the keyboard layout from the locale and pre-populates the keymap field.

## Implementation

### Detection Logic (`bb-imager-gui/src/helpers.rs`)
Added `system_keymap()` function that:
1. Gets the first language tag from `whoami::langs()`
2. Strips encoding (`.UTF-8`) and splits on `-`, `_`, or `/`
3. Examines only the region token ( `pt_BR` → `BR`) because I noticed `KEYMAP_LAYOUTS` is region specific.
4. Strips any `@` modifier from the region (`BY@latin` → `BY`)
5. Matches the region (case-insensitive) against `KEYMAP_LAYOUTS`
6. Returns the canonical keymap or falls back to `"us"`

### UI Integration (`bb-imager-gui/src/ui/configuration.rs`)
The "Set Keymap" toggle calls `helpers::system_keymap()` to pre-populate the keymap field when enabled.

### Startup Logging (`bb-imager-gui/src/main.rs`) (Temporary)
Logs the resolved keymap at startup: `Resolved GUI keymap: <keymap>`

## Files Changed
- `bb-imager-gui/src/helpers.rs` — Added `system_keymap()` function
- `bb-imager-gui/src/ui/configuration.rs` — Wired detection to "Set Keymap" toggle
- `bb-imager-gui/src/main.rs` — Added startup logging (Temporary)

## Testing

### Runtime Verification
Tested with 4 different locales 
-Set locale and run GUI, verified on GUI (screenshots) and logs

###
```bash
sudo update-locale LANG=pt_BR.UTF-8
bb-imager-rs$ echo $LANG
pt_BR.UTF-8
```
```bash
2025-11-11T17:33:55.323355Z  INFO bb_imager_gui: Resolved GUI keymap: br
```
<img width="925" height="618" alt="Screenshot 2025-11-11 224147" src="https://github.com/user-attachments/assets/7ea677c4-9a71-4a0c-b89b-003dc228d7c0" />



###
```bash
sudo update-locale LANG=en_US.UTF-8
bb-imager-rs$ echo $LANG
en_US.UTF-8
```
```bash
2025-11-11T17:13:24.005666Z  INFO bb_imager_gui: Resolved GUI keymap: us
```
<img width="677" height="483" alt="Screenshot 2025-11-11 224400" src="https://github.com/user-attachments/assets/588cdb9d-1cae-4af6-82fe-660d0b21eb62" />



###
```bash
sudo update-locale LANG=be_BY.UTF-8@latin
bb-imager-rs$ echo $LANG
be_BY.UTF-8@latin
```
```bash
2025-11-11T17:24:42.052230Z  INFO bb_imager_gui: Resolved GUI keymap: by
```
<img width="676" height="481" alt="Screenshot 2025-11-11 225511" src="https://github.com/user-attachments/assets/b6189d5b-4f39-4189-b6bd-d7f7c3371752" />



###
```bash
sudo update-locale LANG=de_DE.UTF-8
bb-imager-rs$ echo $LANG
de_DE.UTF-8
```
```bash
2025-11-11T17:31:06.979250Z  INFO bb_imager_gui: Resolved GUI keymap: de
```
<img width="679" height="483" alt="Screenshot 2025-11-11 230148" src="https://github.com/user-attachments/assets/437d0ae3-8d36-48e2-b017-59b995ebe58a" />



## Notes
- Region-only matching: language-only locales (e.g., `de`) fall back to `us`
- Case-insensitive matching against `KEYMAP_LAYOUTS`
- GUI-only feature, CLI unchanged as mentioned by [Ayush1325](https://github.com/Ayush1325) that The CLI should not do defaults.

Please suggest any changes needed. 
There's a Temporary logging snippet, it is for your verification. Also I am unaware how the commit title should be formatted on this repo, please suggest.