### PR TITLE
bb-flasher-pb2-mspm0: Improve error messages and logging (Fixes #175)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -605,6 +605,7 @@ dependencies = [
  "serde",
  "thiserror 2.0.17",
  "tokio",
+ "tracing",
  "zvariant 5.8.0",
 ]
 

--- a/bb-flasher-pb2-mspm0/Cargo.toml
+++ b/bb-flasher-pb2-mspm0/Cargo.toml
@@ -13,6 +13,7 @@ keywords = ["pocketbeagle", "mspm0", "flasher", "beagle"]
 serde = { version = "1.0", optional = true, features = ["derive"] }
 thiserror = "2.0"
 tokio = { version = "1.48", features = ["fs", "io-util", "sync"] }
+tracing = "0.1"
 zvariant = { version = "5.8", optional = true }
 
 [features]

--- a/bb-flasher-pb2-mspm0/src/lib.rs
+++ b/bb-flasher-pb2-mspm0/src/lib.rs
@@ -39,6 +39,35 @@ pub enum Error {
     InvalidFirmware,
 }
 
+impl Error {
+    /// Get user-friendly error message suitable for GUI display
+    pub fn user_message(&self) -> String {
+        match self {
+            Error::FailedToOpen("loading") | Error::FailedToOpen("data") | Error::FailedToOpen("status") => {
+                "Cannot access PocketBeagle 2 firmware interface. Please ensure:\n\
+                 - Your board is properly connected via USB\n\
+                 - You have the required permissions (try running with sudo)\n\
+                 - The kernel driver is loaded".to_string()
+            }
+            Error::FailedToOpen("EEPROM") => {
+                "Cannot access EEPROM on PocketBeagle 2. The board may not be properly detected.".to_string()
+            }
+            Error::FailedToRead(entry) | Error::FailedToWrite(entry) | Error::FailedToSeek(entry) => {
+                format!("Communication error with PocketBeagle 2 ({}). Try reconnecting the board.", entry)
+            }
+            Error::FlashingError { stage, code } => {
+                format!("Flashing failed during {} stage: {}. Check the firmware file and try again.", stage, code)
+            }
+            Error::InvalidFirmware => {
+                "The firmware file is invalid or corrupted. Please download a valid firmware file.".to_string()
+            }
+            Error::FailedToOpen(other) => {
+                format!("Cannot access system resource: {}. Check permissions and connections.", other)
+            }
+        }
+    }
+}
+
 type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// Flash firmware to MSPM0. Also provides live [`Status`] using a channel.
@@ -53,6 +82,11 @@ pub async fn flash(
     persist_eeprom: bool,
 ) -> Result<()> {
     if firmware.len() > FIRMWARE_SIZE {
+        tracing::error!(
+            "Firmware size {} bytes exceeds maximum {} bytes",
+            firmware.len(),
+            FIRMWARE_SIZE
+        );
         return Err(Error::InvalidFirmware);
     }
 
@@ -60,26 +94,42 @@ pub async fn flash(
 
     // Copy the current EEPROM contents
     if persist_eeprom {
+        tracing::debug!("Reading EEPROM contents for preservation");
         let mut eeprom = File::open(EEPROM)
             .await
-            .map_err(|_| Error::FailedToOpen("EEPROM"))?;
+            .map_err(|e| {
+                tracing::error!("Failed to open EEPROM at {}: {}", EEPROM, e);
+                Error::FailedToOpen("EEPROM")
+            })?;
         eeprom
             .read_to_end(&mut eeprom_contents)
             .await
-            .map_err(|_| Error::FailedToRead("EEPROM"))?;
+            .map_err(|e| {
+                tracing::error!("Failed to read EEPROM contents: {}", e);
+                Error::FailedToRead("EEPROM")
+            })?;
+        tracing::debug!("Read {} bytes from EEPROM", eeprom_contents.len());
     }
 
     flash_fw_api(Path::new(PATH), firmware, chan).await?;
 
     // Write back EEPROM contents
     if persist_eeprom {
+        tracing::debug!("Restoring EEPROM contents");
         let mut eeprom = sysfs_w_open(Path::new(EEPROM))
             .await
-            .map_err(|_| Error::FailedToOpen("EEPROM"))?;
+            .map_err(|e| {
+                tracing::error!("Failed to open EEPROM for writing: {}", e);
+                Error::FailedToOpen("EEPROM")
+            })?;
         eeprom
             .write_all(&eeprom_contents)
             .await
-            .map_err(|_| Error::FailedToWrite("EEPROM"))?;
+            .map_err(|e| {
+                tracing::error!("Failed to restore EEPROM contents: {}", e);
+                Error::FailedToWrite("EEPROM")
+            })?;
+        tracing::debug!("Successfully restored EEPROM contents");
     }
 
     Ok(())
@@ -110,11 +160,15 @@ pub async fn check() -> Result<()> {
 async fn check_file(name: &'static str, path: &Path) -> Result<()> {
     let temp = tokio::fs::try_exists(path)
         .await
-        .map_err(|_| Error::FailedToOpen(name))?;
+        .map_err(|e| {
+            tracing::error!("Failed to check existence of {} at {:?}: {}", name, path, e);
+            Error::FailedToOpen(name)
+        })?;
 
     if temp {
         Ok(())
     } else {
+        tracing::error!("Sysfs entry {} does not exist at {:?}", name, path);
         Err(Error::FailedToOpen(name))
     }
 }
@@ -134,70 +188,110 @@ async fn flash_fw_api(
 
     // Initial firmware upload
     {
+        tracing::info!("Starting firmware upload ({} bytes)", firmware.len());
         let mut loading_file = sysfs_w_open(&loading_path)
             .await
-            .map_err(|_| Error::FailedToOpen("loading"))?;
+            .map_err(|e| {
+                tracing::error!("Failed to open loading sysfs entry at {:?}: {}", loading_path, e);
+                Error::FailedToOpen("loading")
+            })?;
         loading_file
             .write_all(b"1")
             .await
-            .map_err(|_| Error::FailedToWrite("loading"))?;
+            .map_err(|e| {
+                tracing::error!("Failed to write '1' to loading entry: {}", e);
+                Error::FailedToWrite("loading")
+            })?;
         loading_file
             .flush()
             .await
-            .map_err(|_| Error::FailedToWrite("loading"))?;
+            .map_err(|e| {
+                tracing::error!("Failed to flush loading entry: {}", e);
+                Error::FailedToWrite("loading")
+            })?;
 
         let mut data_file = sysfs_w_open(&data_path)
             .await
-            .map_err(|_| Error::FailedToOpen("data"))?;
+            .map_err(|e| {
+                tracing::error!("Failed to open data sysfs entry at {:?}: {}", data_path, e);
+                Error::FailedToOpen("data")
+            })?;
         data_file
             .write_all(firmware)
             .await
-            .map_err(|_| Error::FailedToWrite("data"))?;
+            .map_err(|e| {
+                tracing::error!("Failed to write firmware data: {}", e);
+                Error::FailedToWrite("data")
+            })?;
 
         loading_file
             .write_all(b"0")
             .await
-            .map_err(|_| Error::FailedToWrite("loading"))?;
+            .map_err(|e| {
+                tracing::error!("Failed to write '0' to loading entry: {}", e);
+                Error::FailedToWrite("loading")
+            })?;
+        tracing::debug!("Firmware upload initiated successfully");
     }
 
     // Wait for flashing to finish
+    tracing::debug!("Monitoring flashing progress");
     loop {
         // sysfs entries cause weird stuff if kept open after a single read/write
         let mut status_file = File::open(&status_path)
             .await
-            .map_err(|_| Error::FailedToOpen("status"))?;
+            .map_err(|e| {
+                tracing::error!("Failed to open status sysfs entry: {}", e);
+                Error::FailedToOpen("status")
+            })?;
 
         inp.clear();
         status_file
             .read_to_string(&mut inp)
             .await
-            .map_err(|_| Error::FailedToRead("status"))?;
+            .map_err(|e| {
+                tracing::error!("Failed to read status: {}", e);
+                Error::FailedToRead("status")
+            })?;
 
         match inp.trim() {
-            "idle" => break,
+            "idle" => {
+                tracing::info!("Flashing completed successfully");
+                break;
+            }
             "preparing" => {
+                tracing::debug!("Status: preparing");
                 let _ = chan.try_send(Status::Preparing);
             }
             "transferring" => {
                 let mut prog = String::with_capacity(3);
                 let mut size_file = File::open(&remaining_size_path)
                     .await
-                    .map_err(|_| Error::FailedToOpen("remaining_size"))?;
+                    .map_err(|e| {
+                        tracing::warn!("Failed to open remaining_size: {}", e);
+                        Error::FailedToOpen("remaining_size")
+                    })?;
                 size_file
                     .read_to_string(&mut prog)
                     .await
-                    .map_err(|_| Error::FailedToRead("remaining_size"))?;
+                    .map_err(|e| {
+                        tracing::warn!("Failed to read remaining_size: {}", e);
+                        Error::FailedToRead("remaining_size")
+                    })?;
 
                 if let Ok(p) = prog.trim().parse::<usize>() {
-                    let _ = chan.try_send(Status::Flashing(
-                        (firmware.len() - p) as f32 / firmware.len() as f32,
-                    ));
+                    let progress_pct = (firmware.len() - p) as f32 / firmware.len() as f32;
+                    tracing::debug!("Flashing progress: {:.1}%", progress_pct * 100.0);
+                    let _ = chan.try_send(Status::Flashing(progress_pct));
                 }
             }
             "programming" => {
+                tracing::debug!("Status: programming (verifying)");
                 let _ = chan.try_send(Status::Verifying);
             }
-            _ => {}
+            other => {
+                tracing::debug!("Unknown status: {}", other);
+            }
         }
     }
 
@@ -205,22 +299,37 @@ async fn flash_fw_api(
     {
         let mut error_file = File::open(&error_path)
             .await
-            .map_err(|_| Error::FailedToOpen("error"))?;
+            .map_err(|e| {
+                tracing::error!("Failed to open error sysfs entry: {}", e);
+                Error::FailedToOpen("error")
+            })?;
 
         inp.clear();
         error_file
             .read_to_string(&mut inp)
             .await
-            .map_err(|_| Error::FailedToRead("error"))?;
+            .map_err(|e| {
+                tracing::error!("Failed to read error status: {}", e);
+                Error::FailedToRead("error")
+            })?;
 
         let temp = inp.trim();
         match temp {
             "none" | "" => {}
             // Skipped since firmware is the same
-            "preparing:firmware-invalid" => return Ok(()),
+            "preparing:firmware-invalid" => {
+                tracing::info!("Firmware already up to date, skipping flash");
+                return Ok(());
+            }
             _ => {
                 let resp: Vec<&str> = temp.split(':').collect();
                 assert_eq!(resp.len(), 2);
+
+                tracing::error!(
+                    "Flashing error at stage '{}': code '{}'",
+                    resp[0],
+                    resp[1]
+                );
 
                 return Err(Error::FlashingError {
                     stage: resp[0].to_string(),

--- a/bb-flasher/src/flasher/pb2/mspm0/mod.rs
+++ b/bb-flasher/src/flasher/pb2/mspm0/mod.rs
@@ -112,6 +112,11 @@ where
 
         flash(bin, chan, self.persist_eeprom)
             .await
-            .map_err(std::io::Error::other)
+            .map_err(|e| {
+                // Log the technical error for debugging
+                tracing::error!("PB2 MSPM0 flashing error: {:?}", e);
+                // Return user-friendly message for GUI
+                std::io::Error::other(e.user_message())
+            })
     }
 }


### PR DESCRIPTION
## Description

This PR improves error handling and logging for the PocketBeagle 2 MSPM0 flasher library as suggested in issue #175. The changes focus on making error messages user-friendly for GUI display while maintaining detailed logging for developers.

## Problem

Currently, when flashing fails, users see technical error messages like "Failed to open loading" which don't provide actionable guidance. Additionally, errors are not logged at their source, making debugging difficult.

## Solution

1. **User-Friendly Error Messages**: Added `user_message()` method to the `Error` enum that converts technical errors into clear, actionable messages for end users.

2. **Detailed Logging**: Added structured logging using the `tracing` crate at error points with full context (file paths, error details).

3. **Error Context Preservation**: Errors are now logged where they occur, not just at the top level, making debugging easier.

## Changes

- Add `user_message()` method to Error enum for GUI-friendly messages
- Add tracing dependency for structured logging
- Log errors at the point they occur with full context
- Convert technical errors to actionable user messages in flasher
- Add debug logging for flashing progress tracking

## Example

**Before:**
```
Failed to open loading
```

**After:**
```
Cannot access PocketBeagle 2 firmware interface. Please ensure:
 - Your board is properly connected via USB
 - You have the required permissions (try running with sudo)
 - The kernel driver is loaded
```

## Testing

- Compiles successfully for `bb-flasher-pb2-mspm0`
- Compiles successfully for `bb-flasher` with `pb2_mspm0` feature
- Full GUI (`bb-imager-gui`) compiles successfully
- No existing tests were broken (0 tests in library)

## Next Steps

This PR addresses the pb2_mspm0 flasher as suggested in the issue. Similar improvements can be made to other flasher libraries (bcf, dfu, sd) in follow-up PRs.

Fixes #175