### PR TITLE
Add dedicated job for GitHub release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,19 @@ defaults:
     shell: bash
 
 jobs:
+  create-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+    - name: Create Release
+      uses: softprops/action-gh-release@v2
+      with:
+        generate_release_notes: true
+
   native:
+    needs: [create-release]
+    if: always() && (needs.create-release.result == 'success' || !startsWith(github.ref, 'refs/tags/'))
     strategy:
       matrix:
         platform:
@@ -91,7 +103,7 @@ jobs:
       uses: softprops/action-gh-release@v2
       if: startsWith(github.ref, 'refs/tags/')
       with:
-        generate_release_notes: true
+        generate_release_notes: false
         files: |
           bb-imager-gui/dist/*
           bb-imager-cli/dist/*
@@ -108,6 +120,8 @@ jobs:
           bb-imager-service/dist/*
 
   linux-cross:
+    needs: [create-release]
+    if: always() && (needs.create-release.result == 'success' || !startsWith(github.ref, 'refs/tags/'))
     name: Build Artifacts - armv7-unknown-linux-gnueabihf
     runs-on: ubuntu-24.04
     env:
@@ -162,7 +176,7 @@ jobs:
       uses: softprops/action-gh-release@v2
       if: startsWith(github.ref, 'refs/tags/')
       with:
-        generate_release_notes: true
+        generate_release_notes: false
         files: |
           bb-imager-gui/dist/*
           bb-imager-cli/dist/*
@@ -181,6 +195,7 @@ jobs:
   vendor-deps:
     name: Vendor dependencies
     runs-on: ubuntu-24.04
+    needs: [create-release]
     if: startsWith(github.ref, 'refs/tags/')
     steps:
     - name: Checkout
@@ -196,10 +211,12 @@ jobs:
     - name: Release
       uses: softprops/action-gh-release@v2
       with:
-        generate_release_notes: true
+        generate_release_notes: false
         files: cargo-vendor.tar.gz
 
   macos-job:
+    needs: [create-release]
+    if: always() && (needs.create-release.result == 'success' || !startsWith(github.ref, 'refs/tags/'))
     name: Build MacOS Artifacts
     runs-on: macos-latest
     steps:
@@ -269,7 +286,7 @@ jobs:
       uses: softprops/action-gh-release@v2
       if: startsWith(github.ref, 'refs/tags/')
       with:
-        generate_release_notes: true
+        generate_release_notes: false
         files: |
           bb-imager-gui/dist/*
 
@@ -282,6 +299,8 @@ jobs:
           bb-imager-gui/dist/*
 
   windows-job:
+    needs: [create-release]
+    if: always() && (needs.create-release.result == 'success' || !startsWith(github.ref, 'refs/tags/'))
     name: Build Windows Artifacts
     runs-on: windows-latest
     env:
@@ -339,7 +358,7 @@ jobs:
       uses: softprops/action-gh-release@v2
       if: startsWith(github.ref, 'refs/tags/')
       with:
-        generate_release_notes: true
+        generate_release_notes: false
         files: |
           bb-imager-gui/dist/*
 


### PR DESCRIPTION
Added a dedicated job to create GitHub releases and generate release notes. Updated existing jobs to depend on the new release job and adjusted release note generation settings.

This should now fix the issue of multiple log generation as listed in issue no #191 