### PR TITLE
Fix duplicate changelog by enabling notes only on vendor-deps job 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
       uses: softprops/action-gh-release@v2
       if: startsWith(github.ref, 'refs/tags/')
       with:
-        generate_release_notes: true
+        generate_release_notes: false
         files: |
           bb-imager-gui/dist/*
           bb-imager-cli/dist/*
@@ -161,7 +161,7 @@ jobs:
       uses: softprops/action-gh-release@v2
       if: startsWith(github.ref, 'refs/tags/')
       with:
-        generate_release_notes: true
+        generate_release_notes: false
         files: |
           bb-imager-gui/dist/*
           bb-imager-cli/dist/*
@@ -268,7 +268,7 @@ jobs:
       uses: softprops/action-gh-release@v2
       if: startsWith(github.ref, 'refs/tags/')
       with:
-        generate_release_notes: true
+        generate_release_notes: false
         files: |
           bb-imager-gui/dist/*
 
@@ -338,7 +338,7 @@ jobs:
       uses: softprops/action-gh-release@v2
       if: startsWith(github.ref, 'refs/tags/')
       with:
-        generate_release_notes: true
+        generate_release_notes: false
         files: |
           bb-imager-gui/dist/*
 


### PR DESCRIPTION
Instead of creating a dedicated create-release job that all other jobs had to wait for, Now, the release notes are generated only within the windows-job as suggested by **Ayush1325.**

 All other jobs still upload their artifacts to the release but have notes generation disabled Closied the previous PR and opened this fresh one to provide a clean rebased history