### PR TITLE
docs: Add macOS log file path to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,4 +80,7 @@ Options:
 
 While creating new issues for bugs, please attach logs from the application. Log files are created automatically by the GUI from v0.0.12.
 
-On Linux the log file is stored in cache directory (eg. `$HOME/.cache/org.beagleboard.imagingutility.log`) and on Windows, it seems be at `C:\Users\ayush\AppData\Local\beagleboard\imagingutility\org.beagleboard.imagingutility.log`. If anyone can find out MacOS path, feel free to add here.
+Log file locations by platform:
+- **Linux**: `$HOME/.cache/org.beagleboard.imagingutility.log`
+- **Windows**: `C:\Users\ayush\AppData\Local\beagleboard\imagingutility\org.beagleboard.imagingutility.log`
+- **macOS**: `$HOME/Library/Caches/org.beagleboard.imagingutility.log`


### PR DESCRIPTION
Adds the macOS log file path to the "Creating Issues" section of the README, which was previously missing.

- Added macOS log file location: `$HOME/Library/Caches/org.beagleboard.imagingutility.log`
- Reformatted log file locations as a clearer bullet list for all three platforms