### PR TITLE
feat(gui): rework UI to linear wizard flow and remove search bars

### DIFF
--- a/bb-flasher-sd/src/pal/mod.rs
+++ b/bb-flasher-sd/src/pal/mod.rs
@@ -6,8 +6,8 @@ mod macos;
 mod windows;
 
 #[cfg(target_os = "linux")]
-pub(crate) use linux::{open, format};
+pub(crate) use linux::{format, open};
 #[cfg(target_os = "macos")]
-pub(crate) use macos::{open, format};
+pub(crate) use macos::{format, open};
 #[cfg(windows)]
-pub(crate) use windows::{open, format};
+pub(crate) use windows::{format, open};

--- a/bb-flasher/src/flasher/mod.rs
+++ b/bb-flasher/src/flasher/mod.rs
@@ -1,9 +1,9 @@
 #[cfg(any(feature = "bcf_msp430", feature = "bcf"))]
 pub mod bcf;
 
-#[cfg(feature = "sd")]
-pub mod sd;
-#[cfg(any(feature = "pb2_mspm0", feature = "pb2_mspm0_dbus"))]
-pub mod pb2;
 #[cfg(feature = "dfu")]
 pub mod dfu;
+#[cfg(any(feature = "pb2_mspm0", feature = "pb2_mspm0_dbus"))]
+pub mod pb2;
+#[cfg(feature = "sd")]
+pub mod sd;

--- a/bb-imager-gui/src/constants.rs
+++ b/bb-imager-gui/src/constants.rs
@@ -1,6 +1,7 @@
 use iced::color;
 
-pub(crate) const LATEST_RELEASE_URL: &str = "https://api.github.com/repos/beagleboard/bb-imager-rs/releases/latest";
+pub(crate) const LATEST_RELEASE_URL: &str =
+    "https://api.github.com/repos/beagleboard/bb-imager-rs/releases/latest";
 
 pub(crate) const PACKAGE_QUALIFIER: (&str, &str, &str) = ("org", "beagleboard", "imagingutility");
 

--- a/bb-imager-gui/src/main.rs
+++ b/bb-imager-gui/src/main.rs
@@ -49,7 +49,6 @@ fn main() -> iced::Result {
         Some(iced::advanced::graphics::image::image_rs::ImageFormat::Png),
     )
     .ok();
-    assert!(icon.is_some());
 
     #[cfg(target_os = "macos")]
     // HACK: mac_notification_sys set application name (not an option in notify-rust)
@@ -60,6 +59,7 @@ fn main() -> iced::Result {
     let settings = iced::window::Settings {
         min_size: Some(constants::WINDOW_SIZE),
         size: constants::WINDOW_SIZE,
+        icon,
         ..Default::default()
     };
 
@@ -138,7 +138,7 @@ impl BBImager {
             customization: Default::default(),
         };
 
-        ans.screen.push(Screen::Home);
+        ans.screen.push(Screen::BoardSelection(Default::default()));
 
         // Fetch all board images
         let board_image_task = ans.fetch_board_images();

--- a/bb-imager-gui/src/pages.rs
+++ b/bb-imager-gui/src/pages.rs
@@ -25,25 +25,12 @@ impl Screen {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
-pub(crate) struct SearchState {
-    search_string: String,
-}
-
-impl SearchState {
-    pub(crate) const fn new(search_string: String) -> Self {
-        Self { search_string }
-    }
-
-    pub(crate) fn search_str(&self) -> &str {
-        &self.search_string
-    }
-}
+pub(crate) struct SearchState;
 
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub(crate) struct ImageSelectionState {
     flasher: bb_config::config::Flasher,
     idx: Vec<usize>,
-    search_string: String,
 }
 
 impl ImageSelectionState {
@@ -51,12 +38,7 @@ impl ImageSelectionState {
         Self {
             flasher,
             idx: Vec::new(),
-            search_string: String::new(),
         }
-    }
-
-    pub(crate) fn search_str(&self) -> &str {
-        &self.search_string
     }
 
     pub(crate) fn idx(&self) -> &[usize] {
@@ -65,11 +47,6 @@ impl ImageSelectionState {
 
     pub(crate) fn flasher(&self) -> bb_config::config::Flasher {
         self.flasher
-    }
-
-    pub(crate) fn with_search_string(mut self, search_str: String) -> Self {
-        self.search_string = search_str;
-        self
     }
 
     pub(crate) fn with_added_id(mut self, id: usize) -> Self {

--- a/bb-imager-gui/src/ui/board_selection.rs
+++ b/bb-imager-gui/src/ui/board_selection.rs
@@ -4,17 +4,14 @@ use iced::{
     widget::{self, button, text},
 };
 
-use crate::{BBImagerMessage, constants, pages};
-
-use super::helpers::search_bar;
+use crate::{BBImagerMessage, constants};
 
 pub(crate) fn view<'a>(
     devices: impl Iterator<Item = (usize, &'a config::Device)>,
-    search_str: &'a str,
     downloader: &'a bb_downloader::Downloader,
+    enable_back: bool,
 ) -> Element<'a, BBImagerMessage> {
     let items = devices
-        .filter(|(_, x)| x.name.to_lowercase().contains(&search_str.to_lowercase()))
         .map(|(id, dev)| {
             let image: Element<BBImagerMessage> = match &dev.icon {
                 Some(url) => match downloader.clone().check_cache_from_url(url.clone()) {
@@ -50,16 +47,16 @@ pub(crate) fn view<'a>(
         })
         .map(Into::into);
 
-    widget::column![
-        search_bar(search_str, |x| BBImagerMessage::ReplaceScreen(
-            pages::Screen::BoardSelection(pages::SearchState::new(x))
-        )),
-        widget::horizontal_rule(2),
-        widget::scrollable(widget::column(items).spacing(10))
-    ]
-    .spacing(10)
-    .padding(10)
-    .into()
+    let mut col = widget::column![];
+    if enable_back {
+        col = col.push(super::helpers::nav_header(false));
+        col = col.push(widget::horizontal_rule(2));
+    }
+
+    col.push(widget::scrollable(widget::column(items).spacing(10)))
+        .spacing(10)
+        .padding(10)
+        .into()
 }
 
 pub(crate) fn img_or_svg<'a>(path: std::path::PathBuf, width: u16) -> Element<'a, BBImagerMessage> {

--- a/bb-imager-gui/src/ui/destination_selection.rs
+++ b/bb-imager-gui/src/ui/destination_selection.rs
@@ -3,12 +3,10 @@ use iced::{
     widget::{self, button, text},
 };
 
-use super::helpers::search_bar;
 use crate::{BBImagerMessage, constants, helpers};
 
 pub(crate) fn view<'a, D>(
     destinations: D,
-    search_str: &'a str,
     file_name: Option<String>,
 ) -> Element<'a, BBImagerMessage>
 where
@@ -16,11 +14,6 @@ where
 {
     let items = destinations
         .into_iter()
-        .filter(|x| {
-            x.to_string()
-                .to_lowercase()
-                .contains(&search_str.to_lowercase())
-        })
         .map(|x| {
             let mut row2 = widget::column![text(x.to_string())];
 
@@ -67,9 +60,7 @@ where
     let row3: iced::Element<_> = widget::scrollable(col.spacing(10)).into();
 
     widget::column![
-        search_bar(search_str, |x| BBImagerMessage::ReplaceScreen(
-            crate::pages::Screen::DestinationSelection(crate::pages::SearchState::new(x))
-        )),
+        super::helpers::nav_header(false),
         widget::horizontal_rule(2),
         row3
     ]

--- a/bb-imager-gui/src/ui/helpers.rs
+++ b/bb-imager-gui/src/ui/helpers.rs
@@ -4,23 +4,27 @@ use crate::constants;
 
 use super::BBImagerMessage;
 
-pub(crate) fn search_bar<'a>(
-    cur_search: &'a str,
-    f: impl Fn(String) -> BBImagerMessage + 'a,
-) -> Element<'a, BBImagerMessage> {
-    widget::row![
-        widget::button(
-            widget::svg(widget::svg::Handle::from_memory(constants::ARROW_BACK_ICON)).width(22)
-        )
-        .on_press(BBImagerMessage::PopScreen)
-        .style(widget::button::secondary),
-        widget::button(widget::svg(widget::svg::Handle::from_memory(constants::REFRESH)).width(22))
+pub(crate) fn nav_header<'a>(refresh: bool) -> Element<'a, BBImagerMessage> {
+    let back_btn = widget::button(
+        widget::svg(widget::svg::Handle::from_memory(constants::ARROW_BACK_ICON)).width(22),
+    )
+    .on_press(BBImagerMessage::PopScreen)
+    .style(widget::button::secondary);
+
+    if refresh {
+        widget::row![
+            back_btn,
+            widget::button(
+                widget::svg(widget::svg::Handle::from_memory(constants::REFRESH)).width(22)
+            )
             .on_press(BBImagerMessage::RefreshConfig)
             .style(widget::button::secondary),
-        widget::text_input("Search", cur_search).on_input(f)
-    ]
-    .spacing(10)
-    .into()
+        ]
+        .spacing(10)
+        .into()
+    } else {
+        widget::row![back_btn].into()
+    }
 }
 
 pub(crate) fn home_btn_text<'a>(

--- a/bb-imager-gui/src/ui/home.rs
+++ b/bb-imager-gui/src/ui/home.rs
@@ -3,7 +3,7 @@ use iced::{
     widget::{self, text},
 };
 
-use crate::{BBImagerMessage, constants, helpers, pages::ImageSelectionState};
+use crate::{BBImagerMessage, constants, helpers};
 
 use super::helpers::home_btn_text;
 use crate::pages::Screen;
@@ -21,20 +21,14 @@ pub(crate) fn view<'a>(
             None => home_btn_text("CHOOSE DEVICE", true, iced::Length::Fill),
         }
         .width(iced::Length::Fill)
-        .on_press(BBImagerMessage::PushScreen(Screen::BoardSelection(
-            Default::default(),
-        )));
+        .on_press(BBImagerMessage::JumpToStep(0));
 
         let choose_image_btn = match selected_image {
             Some(x) => home_btn_text(x.to_string(), true, iced::Length::Fill),
             None => home_btn_text("CHOOSE IMAGE", selected_board.is_some(), iced::Length::Fill),
         }
         .width(iced::Length::Fill)
-        .on_press_maybe(selected_board.map(|board| {
-            BBImagerMessage::PushScreen(Screen::ImageSelection(ImageSelectionState::new(
-                board.flasher,
-            )))
-        }));
+        .on_press_maybe(selected_board.map(|_board| BBImagerMessage::JumpToStep(1)));
 
         let choose_dst_btn = match selected_dst {
             Some(x) => {
@@ -53,9 +47,7 @@ pub(crate) fn view<'a>(
         .on_press_maybe(if selected_image.is_none() || !destination_selectable {
             None
         } else {
-            Some(BBImagerMessage::PushScreen(Screen::DestinationSelection(
-                Default::default(),
-            )))
+            Some(BBImagerMessage::JumpToStep(2))
         });
 
         let reset_btn = home_btn_text("RESET", true, iced::Length::Fill)

--- a/bb-imager-gui/src/ui/image_selection.rs
+++ b/bb-imager-gui/src/ui/image_selection.rs
@@ -36,11 +36,6 @@ pub(crate) fn view<'a>(
     let row3: Element<_> = if let Some(imgs) = images {
         let items = imgs
             .into_iter()
-            .filter(|(_, x)| {
-                x.name()
-                    .to_lowercase()
-                    .contains(&state.search_str().to_lowercase())
-            })
             .map(|(id, x)| entry(state, x, downloader, id))
             .chain(
                 extra_entries
@@ -62,15 +57,7 @@ pub(crate) fn view<'a>(
     };
 
     widget::column![
-        search_bar(
-            state.search_str(),
-            |x| BBImagerMessage::ReplaceScreen(pages::Screen::ImageSelection(
-                state.clone().with_search_string(x)
-            )),
-            // Only show refresh button on the initial page. Refreshing from a submenu can lead to
-            // a bad state
-            state.idx().is_empty()
-        ),
+        super::helpers::nav_header(state.idx().is_empty()),
         widget::horizontal_rule(2),
         row3
     ]
@@ -225,33 +212,4 @@ pub(crate) fn img_or_svg<'a>(path: std::path::PathBuf, width: u16) -> Element<'a
             .height(width)
             .into(),
     }
-}
-
-pub(crate) fn search_bar<'a>(
-    cur_search: &'a str,
-    f: impl Fn(String) -> BBImagerMessage + 'a,
-    refresh: bool,
-) -> Element<'a, BBImagerMessage> {
-    let back_btn = widget::button(
-        widget::svg(widget::svg::Handle::from_memory(constants::ARROW_BACK_ICON)).width(22),
-    )
-    .on_press(BBImagerMessage::PopScreen)
-    .style(widget::button::secondary);
-    let search_bar = widget::text_input("Search", cur_search).on_input(f);
-
-    if refresh {
-        widget::row![
-            back_btn,
-            widget::button(
-                widget::svg(widget::svg::Handle::from_memory(constants::REFRESH)).width(22)
-            )
-            .on_press(BBImagerMessage::RefreshConfig)
-            .style(widget::button::secondary),
-            search_bar
-        ]
-    } else {
-        widget::row![back_btn, search_bar]
-    }
-    .spacing(10)
-    .into()
 }

--- a/bb-imager-gui/src/ui/mod.rs
+++ b/bb-imager-gui/src/ui/mod.rs
@@ -21,8 +21,8 @@ pub(crate) fn view(state: &BBImager) -> Element<'_, BBImagerMessage> {
             state.is_destionation_selectable(),
             state.is_download_action(),
         ),
-        Screen::BoardSelection(p) => {
-            board_selection::view(state.devices(), p.search_str(), state.downloader())
+        Screen::BoardSelection(_p) => {
+            board_selection::view(state.devices(), state.downloader(), state.screen.len() > 1)
         }
         Screen::ImageSelection(page) => {
             let mut extra_entries = Vec::from([image_selection::ExtraImageEntry::new(
@@ -45,9 +45,8 @@ pub(crate) fn view(state: &BBImager) -> Element<'_, BBImagerMessage> {
                 extra_entries,
             )
         }
-        Screen::DestinationSelection(s) => destination_selection::view(
+        Screen::DestinationSelection(_s) => destination_selection::view(
             state.destinations(),
-            s.search_str(),
             state.selected_image().unwrap().file_name(),
         ),
         Screen::ExtraConfiguration(id) => configuration::view(


### PR DESCRIPTION
Implements a linear Board -> Image -> Destination -> Review flow. Removes search bars from selection screens.
Fixes #173.