### PR TITLE
fix: restore external drive/SD card detection on macOS Tahoe 26.1

### DIFF
--- a/bb-flasher-sd/Cargo.toml
+++ b/bb-flasher-sd/Cargo.toml
@@ -36,6 +36,7 @@ tokio = { version = "1.47", default-features = false, features = ["rt-multi-thre
 [target.'cfg(target_os = "macos")'.dependencies]
 security-framework = { version = "3.5", optional = true }
 nix = { version = "0.30", features = ["socket", "uio"], optional = true }
+plist = "1.0"
 
 [features]
 macos_authopen = ["dep:security-framework", "dep:nix"]


### PR DESCRIPTION
# Fix: macOS Tahoe 26.1 - External drives and SD cards not detected

## Problem

After upgrading to macOS Tahoe 26.1, the imager no longer shows external drives and SD cards in the destination selection. This is due to Apple's new security restrictions around accessory access that were introduced in macOS Tahoe 26.1.

## Root Cause

macOS Tahoe 26.1 introduced stricter security controls for external storage devices (USB, Thunderbolt, and SDXC accessories). The `bb-drivelist` crate, which is used to enumerate removable drives, may not detect external drives when:
1. The "Allow Accessories to Connect" setting in System Settings → Privacy & Security → Accessories is not properly configured
2. The system's accessory security restrictions block access to external drives
3. The drives are not yet authorized by the user

## Solution Approach

This fix implements a **dual-detection strategy**:

1. **Primary Method**: Continue using `bb-drivelist` as the primary detection mechanism (maintains compatibility and works in most cases)

2. **Fallback Method**: On macOS, add a fallback that uses `diskutil list -plist` to enumerate all disks and filter for external/removable drives. This method:
   - Uses the native macOS `diskutil` command which has better access to system-level disk information
   - Parses the plist output to identify external drives (non-internal disks)
   - Constructs the appropriate device paths (`/dev/rdiskX`) for raw access
   - Merges results with the primary method to ensure comprehensive detection

3. **Result Merging**: The solution merges results from both methods, ensuring that:
   - If `bb-drivelist` works, those drives are included
   - If `bb-drivelist` misses drives due to security restrictions, the `diskutil` fallback catches them
   - Duplicate entries are automatically handled by using a `HashSet`

## Implementation Details

- Added `get_devices_from_diskutil()` function that:
  - Executes `diskutil list -plist` to get all disks
  - Parses the plist output to find external drives (where `Internal` is `false` or missing)
  - Filters out partitions (only includes whole disks like `disk2`, not `disk2s1`)
  - Constructs device paths and verifies they exist before adding to the result set

- Modified `devices()` function to:
  - Try `bb-drivelist` first (existing behavior)
  - On macOS, also run the `diskutil` fallback
  - Merge results from both methods

- Added `plist` dependency for macOS to parse the `diskutil` output

## Testing

This solution should be tested on:
- macOS Tahoe 26.1 with external drives/SD cards connected
- Verify that drives appear in the destination list
- Test with both "Allow Accessories to Connect" enabled and disabled
- Verify backward compatibility with older macOS versions

## User Impact

Users on macOS Tahoe 26.1 will now be able to see external drives and SD cards in the imager's destination selection, even when the system's accessory security restrictions might prevent `bb-drivelist` from detecting them.

## Related Issues

Fixes #163
