### PR TITLE
fix(macos): relax drive detection filter and update dependency

### DIFF
--- a/bb-flasher-sd/src/lib.rs
+++ b/bb-flasher-sd/src/lib.rs
@@ -111,11 +111,13 @@ pub enum Error {
 
 /// Enumerate all SD Cards in system
 pub fn devices() -> std::collections::HashSet<Device> {
-    bb_drivelist::drive_list()
-        .expect("Unsupported OS for Sd Card")
+    let devices = bb_drivelist::drive_list().expect("Unsupported OS for Sd Card");
+    tracing::info!("Found devices: {:#?}", devices);
+    devices
         .into_iter()
-        .filter(|x| x.is_removable)
+        .filter(|x| x.is_removable || x.is_card || x.bus_type.as_deref() == Some("USB"))
         .filter(|x| !x.is_virtual)
+        .filter(|x| !x.is_system)
         .map(|x| Device::new(x.description, x.raw.into(), x.size))
         .collect()
 }


### PR DESCRIPTION
Fixes macOS drive detection issues where external drives were hidden.

#163 

**Changes Made**
 Updates `bb-drivelist` to v0.3.1.
 Changed drive filter to include devices marked as SD cards, even if the OS reports them as non-removable.

Succesfully detected my external SSD(detected as FDisk_partition_scheme with size 256060514304 or ~256GB) 
Tested on MacOS 26.2
<img width="765" height="425" alt="2026-01-24_17-09-14" src="https://github.com/user-attachments/assets/207262f8-5c8a-424c-81b7-2f619a8a70ea" />


