### PR TITLE
Fix BeagleConnect Freedom support on macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,6 +201,9 @@ jobs:
   macos-job:
     name: Build MacOS Artifacts
     runs-on: macos-latest
+    env:
+      BCF_CC1352P7: 1
+      BCF_MSP430: 1
     steps:
     - name: Checkout
       uses: actions/checkout@v6


### PR DESCRIPTION
Addresses intermittent flashing failures on macOS by implementing:

1. Retry logic for bootloader invocation (up to 3 attempts with 500ms delays)
   - Handles timing-sensitive MSP430 BSL trigger sequence
   - Adds detailed logging for each attempt

2. Increased serial timeout from 500ms to 2000ms
   - Improves reliability on macOS where timing varies
   - Suggested by @lorforlinux in issue discussion

3. Enhanced CRC32 verification
   - Added 100ms delay before verification
   - Detailed logging showing expected vs actual CRC32 values
   - Helps debug InvalidImage errors

4. Enabled BCF support in macOS CI builds
   - Added BCF_CC1352P7 and BCF_MSP430 env vars to release.yml
   - Ensures macOS releases include BCF functionality

Tested successfully on macOS with Apple M4, flashing MicroPython to BeagleConnect Freedom without errors.

Fixes #8


<img width="681" height="491" alt="Screenshot 2026-01-24 at 5 38 56 PM" src="https://github.com/user-attachments/assets/8d869697-0b49-48d0-8835-847bb9448db5" />
<img width="689" height="487" alt="Screenshot 2026-01-24 at 5 39 20 PM" src="https://github.com/user-attachments/assets/4ba13565-4b78-4be3-b0df-9c52448ec739" />
<img width="681" height="485" alt="Screenshot 2026-01-24 at 5 40 07 PM" src="https://github.com/user-attachments/assets/68198804-9191-4c15-b0e0-39b5500e7556" />
<img width="839" height="343" alt="Screenshot 2026-01-24 at 5 46 09 PM" src="https://github.com/user-attachments/assets/0255c92f-d036-4d6e-bcde-cd0fc38032c3" />
<img width="825" height="303" alt="Screenshot 2026-01-24 at 5 47 12 PM" src="https://github.com/user-attachments/assets/3d556760-8c3f-4f41-a59d-a6c0a5abb539" />
