### PR TITLE
Fix BCF destination flickering by adding change detection

### DIFF
--- a/bb-imager-gui/src/message.rs
+++ b/bb-imager-gui/src/message.rs
@@ -255,7 +255,6 @@ pub(crate) fn update(state: &mut BBImager, message: BBImagerMessage) -> Task<BBI
                 let old_set: HashSet<_> = state.destinations.iter().collect();
                 !x.iter().all(|item| old_set.contains(item))
             };
-            
             if changed {
                 if !state.is_destionation_selectable() {
                     assert_eq!(x.len(), 1);


### PR DESCRIPTION
The BCF destination list was constantly flickering due to HashSet's non-deterministic iteration order. Even when the same ports were detected, they would come in different orders, causing unnecessary UI updates.

This fix adds change detection before updating the destinations list:
- First checks if the length differs
- Then compares the actual port contents using HashSet (order-independent)
- Only triggers UI update when ports actually change

Fixes #226


https://github.com/user-attachments/assets/15180c4d-0049-4441-9c0f-83c95e8f7556