### PR TITLE
Fix crash when clicking Reset in empty Customization tab

### DIFF
--- a/bb-imager-gui/src/message.rs
+++ b/bb-imager-gui/src/message.rs
@@ -312,7 +312,9 @@ pub(crate) fn update(state: &mut BBImager, message: BBImagerMessage) -> Task<BBI
             });
         }
         BBImagerMessage::ResetCustomization => {
-            state.customization = Some(state.customization.clone().unwrap().reset());
+            if let Some(customization) = state.customization.clone() {
+                state.customization = Some(customization.reset());
+            }
         }
         BBImagerMessage::CancelCustomization => {
             state.screen.pop();


### PR DESCRIPTION
Fixes #240

The application panicked when clicking 'Reset' in the Customization tab without first selecting a board/image. This occurred because the code attempted to unwrap() a None value.

Changed the ResetCustomization message handler to safely check if state.customization exists before attempting to reset it. If it's None, the handler now does nothing instead of panicking.