### PR TITLE
bb-drivelist: Exclude loop devices from `lsblk` command

### DIFF
--- a/bb-drivelist/src/pal/linux.rs
+++ b/bb-drivelist/src/pal/linux.rs
@@ -145,7 +145,14 @@ impl From<Child> for MountPoint {
 
 pub(crate) fn lsblk() -> anyhow::Result<Vec<DeviceDescriptor>> {
     let output = Command::new("lsblk")
-        .args(["-e7", "--bytes", "--all", "--json", "--paths", "--output-all"])
+        .args([
+            "-e7",
+            "--bytes",
+            "--all",
+            "--json",
+            "--paths",
+            "--output-all",
+        ])
         .output()?;
 
     if !output.status.success() {


### PR DESCRIPTION
Running `bb-flasher` on Linux machines with loop devices (e.g. Ubuntu with Snap) might result in the following panic:

```
thread 'tokio-runtime-worker' (5761) panicked at /Users/matteocarnelos/.cargo/git/checkouts/bb-imager-rs-6523e6338f60921b/4cd7adf/bb-drivelist/src/pal/linux.rs:150:63:
called `Result::unwrap()` on an `Err` value: Error("invalid type: null, expected u64", line: 26, column: 405)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This happens because the `lsblk` command might return `"size": null` for some loop devices, for example:

```
...
{"name":"/dev/loop23", "kname":"/dev/loop23", "path":"/dev/loop23", "maj:min":"7:23", "fsavail":null, "fssize":null, "fstype":null, "fsused":null, "fsuse%":null, "mountpoint":null, "label":null, "uuid":null, "ptuuid":null, "pttype":null, "parttype":null, "partlabel":null, "partuuid":null, "partflags":null, "ra":128, "ro":false, "rm":false, "hotplug":false, "model":null, "serial":null, "size":null, "state":null, "owner":"root", "group":"disk", "mode":"brw-rw----", "alignment":0, "min-io":512, "opt-io":0, "phy-sec":512, "log-sec":512, "rota":false, "sched":"none", "rq-size":128, "type":"loop", "disc-aln":0, "disc-gran":4096, "disc-max":4294966784, "disc-zero":false, "wsame":0, "wwn":null, "rand":false, "pkname":null, "hctl":null, "tran":null, "subsystems":"block", "rev":null, "vendor":null, "zoned":"none"},
...
```

This PR fixes this by adding the `-e7` argument to the `lsblk` command, making it exclude all loop devices from the output.