### PR TITLE
bb-drivelist: Make size optional

### DIFF
--- a/bb-drivelist/src/device.rs
+++ b/bb-drivelist/src/device.rs
@@ -30,7 +30,7 @@ pub struct DeviceDescriptor {
     pub description: String,
     pub error: Option<String>,
     pub partition_table_type: Option<String>,
-    pub size: u64,
+    pub size: Option<u64>,
     pub block_size: u32,
     pub logical_block_size: u32,
     pub mountpoints: Vec<MountPoint>,

--- a/bb-drivelist/src/pal/linux.rs
+++ b/bb-drivelist/src/pal/linux.rs
@@ -10,7 +10,7 @@ struct Devices {
 
 #[derive(Deserialize, Debug)]
 struct Device {
-    size: u64,
+    size: Option<u64>,
     #[serde(default = "Device::name_default")]
     kname: String,
     #[serde(default = "Device::name_default")]
@@ -155,4 +155,75 @@ pub(crate) fn lsblk() -> anyhow::Result<Vec<DeviceDescriptor>> {
     let res: Devices = serde_json::from_slice(&output.stdout).unwrap();
 
     Ok(res.blockdevices.into_iter().map(Into::into).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::DeviceDescriptor;
+
+    #[test]
+    fn loop_dev() {
+        let data = r#"
+        {
+            "blockdevices": [
+                {
+                    "name":"/dev/loop23", 
+                    "kname":"/dev/loop23", 
+                    "path":"/dev/loop23", 
+                    "maj:min":"7:23", 
+                    "fsavail":null, 
+                    "fssize":null, 
+                    "fstype":null, 
+                    "fsused":null, 
+                    "fsuse%":null, 
+                    "mountpoint":null, 
+                    "label":null, 
+                    "uuid":null, 
+                    "ptuuid":null, 
+                    "pttype":null, 
+                    "parttype":null, 
+                    "partlabel":null, 
+                    "partuuid":null, 
+                    "partflags":null, 
+                    "ra":128, 
+                    "ro":false, 
+                    "rm":false, 
+                    "hotplug":false, 
+                    "model":null, 
+                    "serial":null, 
+                    "size":null, 
+                    "state":null, 
+                    "owner":"root", 
+                    "group":"disk", 
+                    "mode":"brw-rw----", 
+                    "alignment":0, 
+                    "min-io":512, 
+                    "opt-io":0, 
+                    "phy-sec":512, 
+                    "log-sec":512, 
+                    "rota":false, 
+                    "sched":"none", 
+                    "rq-size":128, 
+                    "type":"loop", 
+                    "disc-aln":0, 
+                    "disc-gran":4096, 
+                    "disc-max":4294966784, 
+                    "disc-zero":false, 
+                    "wsame":0, 
+                    "wwn":null, 
+                    "rand":false, 
+                    "pkname":null, 
+                    "hctl":null, 
+                    "tran":null, 
+                    "subsystems":"block", 
+                    "rev":null, 
+                    "vendor":null, 
+                    "zoned":"none"
+                }
+            ]
+        }"#;
+
+        let res: super::Devices = serde_json::from_str(data).unwrap();
+        let _: Vec<DeviceDescriptor> = res.blockdevices.into_iter().map(Into::into).collect();
+    }
 }

--- a/bb-drivelist/src/pal/macos.rs
+++ b/bb-drivelist/src/pal/macos.rs
@@ -306,8 +306,7 @@ impl DeviceDescriptorFromDiskDescription for DeviceDescriptor {
 
         device.size = disk_description
             .get_number(unsafe { kDADiskDescriptionMediaSizeKey })
-            .map(|n| n.unsignedLongValue())
-            .unwrap_or(0);
+            .map(|n| n.unsignedLongValue());
 
         device.is_readonly = !disk_description
             .get_number(unsafe { kDADiskDescriptionMediaWritableKey })

--- a/bb-drivelist/src/pal/windows.rs
+++ b/bb-drivelist/src/pal/windows.rs
@@ -417,7 +417,7 @@ fn get_device_size(
         )
     }?;
 
-    device_descriptor.size = disk_geometry.DiskSize as u64;
+    device_descriptor.size = Some(disk_geometry.DiskSize as u64);
     device_descriptor.block_size = disk_geometry.Geometry.BytesPerSector;
 
     Ok(())

--- a/bb-flasher-sd/src/lib.rs
+++ b/bb-flasher-sd/src/lib.rs
@@ -121,7 +121,7 @@ pub fn devices(filter: bool) -> std::collections::HashSet<Device> {
                 true
             }
         })
-        .map(|x| Device::new(x.description, x.raw.into(), x.size))
+        .map(|x| Device::new(x.description, x.raw.into(), x.size.unwrap_or_default()))
         .collect()
 }
 


### PR DESCRIPTION
- Size field in loop devices is set to NULL on linux. So make it optional.
- Also add a test
- Fixes #263 