### PR TITLE
bb-imager-gui: ui: flash_fail: Fix padding

### DIFF
--- a/bb-imager-gui/src/ui/flash_fail.rs
+++ b/bb-imager-gui/src/ui/flash_fail.rs
@@ -37,5 +37,6 @@ pub(crate) fn info_view(state: &FlashingFailState) -> Element<'_, BBImagerMessag
         selectable_text(&state.logs)
     ]
     .spacing(8)
+    .padding(VIEW_COL_PADDING)
     .into()
 }


### PR DESCRIPTION
- Fail screen had bad padding.