### PR TITLE
bb-flasher-sd: Add support for generic file customization

### DIFF
--- a/bb-flasher-sd/src/customization.rs
+++ b/bb-flasher-sd/src/customization.rs
@@ -6,21 +6,21 @@ use std::io::{Read, Seek, SeekFrom, Write};
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub enum Customization {
     Sysconf(SysconfCustomization),
-    Generic(GenericCustomization),
+    GenericFile(GenericFileCustomization),
 }
 
 impl Customization {
     pub(crate) fn customize(&self, dst: impl Write + Seek + Read + std::fmt::Debug) -> Result<()> {
         match self {
             Self::Sysconf(x) => x.customize(dst),
-            Self::Generic(x) => x.customize(dst),
+            Self::GenericFile(x) => x.customize(dst),
         }
     }
 
     pub(crate) fn validate(&self) -> bool {
         match self {
             Self::Sysconf(x) => x.validate(),
-            Self::Generic(x) => x.validate(),
+            Self::GenericFile(x) => x.validate(),
         }
     }
 }
@@ -128,12 +128,12 @@ fn sysconf_w(mut sysconf: impl Write, key: &'static str, value: &str) -> Result<
 
 #[derive(Clone, Debug, Default, Hash, PartialEq, Eq)]
 /// Post install customization options
-pub struct GenericCustomization {
+pub struct GenericFileCustomization {
     pub file_name: Box<str>,
     pub file_content: Option<Box<str>>,
 }
 
-impl GenericCustomization {
+impl GenericFileCustomization {
     pub(crate) fn customize(
         &self,
         mut dst: impl Write + Seek + Read + std::fmt::Debug,
@@ -141,18 +141,17 @@ impl GenericCustomization {
         let boot_partition = customization_partition(&mut dst)?;
         let boot_root = boot_partition.root_dir();
 
-        let mut file =
-            boot_root
-                .create_file(&self.file_name)
-                .map_err(|source| Error::GenericCreateFail {
-                    source,
-                    file: self.file_name.clone(),
-                })?;
+        let mut file = boot_root.create_file(&self.file_name).map_err(|source| {
+            Error::GenericFileCreateFail {
+                source,
+                file: self.file_name.clone(),
+            }
+        })?;
         file.seek(SeekFrom::End(0))
             .unwrap_or_else(|_| panic!("Failed to seek to end of {}", self.file_name));
         if let Some(content) = &self.file_content {
             file.write_all(content.as_bytes())
-                .map_err(|source| Error::GenericWriteFail {
+                .map_err(|source| Error::GenericFileWriteFail {
                     source,
                     file: self.file_name.clone(),
                 })?;

--- a/bb-flasher-sd/src/lib.rs
+++ b/bb-flasher-sd/src/lib.rs
@@ -47,7 +47,7 @@ mod flashing;
 mod helpers;
 pub(crate) mod pal;
 
-pub use customization::{Customization, GenericCustomization, SysconfCustomization};
+pub use customization::{Customization, GenericFileCustomization, SysconfCustomization};
 pub use flashing::flash;
 
 pub(crate) type Result<T, E = Error> = std::result::Result<T, E>;
@@ -75,13 +75,13 @@ pub enum Error {
         field: &'static str,
     },
     #[error("Failed to create {file}")]
-    GenericCreateFail {
+    GenericFileCreateFail {
         #[source]
         source: io::Error,
         file: Box<str>,
     },
     #[error("Failed to write to {file}")]
-    GenericWriteFail {
+    GenericFileWriteFail {
         #[source]
         source: io::Error,
         file: Box<str>,

--- a/bb-flasher/src/flasher/sd.rs
+++ b/bb-flasher/src/flasher/sd.rs
@@ -93,10 +93,10 @@ impl FlashingSdLinuxConfig {
         }
     }
 
-    pub const fn generic(file_name: Box<str>, file_content: Option<Box<str>>) -> Self {
+    pub const fn generic_file(file_name: Box<str>, file_content: Option<Box<str>>) -> Self {
         Self {
-            customization: Some(bb_flasher_sd::Customization::Generic(
-                bb_flasher_sd::GenericCustomization {
+            customization: Some(bb_flasher_sd::Customization::GenericFile(
+                bb_flasher_sd::GenericFileCustomization {
                     file_name,
                     file_content,
                 },


### PR DESCRIPTION
This PR adds support for generic file customization. I.e., the possibility to leave a file with the specified content in the boot partition (e.g. `ssh`, `custom.toml`, etc.). This is particularly useful in applications where the currently supported `sysconf.txt` customization option is not enough, adding more flexibility to the `bb-flasher-sd` crate.

Technically speaking, I added a `Generic(GenericCustomization)` variant to the `Customization` enum with the file name and content as struct fields. Moreover, I included the filesystem instantiation in the `customization_partition()` function to avoid code duplication.