### PR TITLE
Optimize binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,9 @@ members = [
 
 [profile.release]
 strip = true
-lto = "thin"
+lto = true
+codegen-units = 1
+panic = "abort"
 
 [workspace.package]
 version = "0.0.20"


### PR DESCRIPTION
- Reduces binary size from 39018728 to 28678376 collectively.
- Will increase release build time, but now debug builds are fast enough for local testing (they were not during iced 0.13 days), so should not be a problem outside CI.