### PR TITLE
bb-flasher: mspm0: Use spawn_blocking for destinations

### DIFF
--- a/bb-flasher/src/flasher/mspm0/mod.rs
+++ b/bb-flasher/src/flasher/mspm0/mod.rs
@@ -49,16 +49,20 @@ impl From<String> for Target {
 impl BBFlasherTarget for Target {
     const FILE_TYPES: &[&str] = &["bin", "hex", "txt", "xz"];
 
-    fn destinations(_: bool) -> impl Future<Output = std::collections::HashSet<Self>> {
-        let mut dsts = std::collections::HashSet::new();
+    async fn destinations(_: bool) -> std::collections::HashSet<Self> {
+        tokio::task::spawn_blocking(|| {
+            let mut dsts = std::collections::HashSet::new();
 
-        #[cfg(feature = "mspm0_uart")]
-        dsts.extend(bb_flasher_mspm0::uart::ports().into_iter().map(Self::Uart));
+            #[cfg(feature = "mspm0_uart")]
+            dsts.extend(bb_flasher_mspm0::uart::ports().into_iter().map(Self::Uart));
 
-        #[cfg(all(feature = "mspm0_i2c", target_os = "linux"))]
-        dsts.extend(bb_flasher_mspm0::i2c::ports().into_iter().map(Self::I2c));
+            #[cfg(all(feature = "mspm0_i2c", target_os = "linux"))]
+            dsts.extend(bb_flasher_mspm0::i2c::ports().into_iter().map(Self::I2c));
 
-        std::future::ready(dsts)
+            dsts
+        })
+        .await
+        .unwrap()
     }
 
     fn identifier(&self) -> Cow<'_, str> {

--- a/bb-imager-cli/src/main.rs
+++ b/bb-imager-cli/src/main.rs
@@ -102,7 +102,7 @@ async fn flash(target: TargetCommands, quite: bool) {
 
         flash_internal(target, Some(tx)).await
     }
-    .expect("Filed to flash")
+    .expect("Failed to flash")
 }
 
 async fn flash_internal(


### PR DESCRIPTION
- Original goal was to add mspm0 bsl detection, but well, does not seem like that is possible.