### PR TITLE
bb-imager-gui: Do not set default hostname

### DIFF
--- a/bb-imager-gui/src/ui/configuration.rs
+++ b/bb-imager-gui/src/ui/configuration.rs
@@ -203,7 +203,7 @@ fn linux_sd_card<'a>(
     let toggle = widget::toggler(config.hostname.is_some())
         .label("Set Hostname")
         .on_toggle(|t| {
-            let hostname = if t { whoami::hostname().ok() } else { None };
+            let hostname = if t { Some(String::new()) } else { None };
             BBImagerMessage::UpdateFlashConfig(FlashingCustomization::LinuxSdSysconfig(
                 config.clone().update_hostname(hostname),
             ))


### PR DESCRIPTION
- Having same hostname can be problematic. See [0]
- Fixes #351 

[0]: https://forum.beagleboard.org/t/difficulties-with-pocketbeagle-2/43864/17?u=robertcnelson