### PR TITLE
mspm0: Add BSL invoke support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -615,6 +615,7 @@ version = "1.0.0"
 dependencies = [
  "bin_file",
  "crc-fast",
+ "gpiocdev",
  "i2cdev",
  "serialport",
  "thiserror 2.0.18",
@@ -2329,6 +2330,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "gpiocdev"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a6009ef6766dd62a7f5933d379d357ae89eaee4e9c2455b6596f359627660a1"
+dependencies = [
+ "gpiocdev-uapi",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gpiocdev-uapi"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb1a3ace06ef708255a33e738ec7a5e7718fe8e53bd9a39299b4f1cd4b13e9a3"
+dependencies = [
+ "bitflags 2.11.1",
+ "ioctl-sys",
+ "libc",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "gpt"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3154,6 +3177,12 @@ dependencies = [
  "core-foundation-sys",
  "mach2",
 ]
+
+[[package]]
+name = "ioctl-sys"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bd11f3a29434026f5ff98c730b668ba74b1033637b8817940b54d040696133c"
 
 [[package]]
 name = "ipnet"

--- a/bb-flasher-mspm0/Cargo.toml
+++ b/bb-flasher-mspm0/Cargo.toml
@@ -17,7 +17,8 @@ bin_file = "0.1"
 crc-fast = "1.10"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-i2cdev = { version = "0.6.2", optional = true }
+i2cdev = { version = "0.6", optional = true }
+gpiocdev = "0.8"
 
 [features]
 # Since uart is cross-platform, can be enabled by default.

--- a/bb-flasher-mspm0/src/helpers.rs
+++ b/bb-flasher-mspm0/src/helpers.rs
@@ -91,20 +91,24 @@ pub(crate) fn chan_send(chan: Option<&mut mpsc::Sender<Status>>, msg: Status) {
     }
 }
 
-pub fn flash<P, D>(
+pub fn flash<P, D, B>(
     firmware: &[u8],
     port_open: P,
     verify: bool,
     mut chan: Option<mpsc::Sender<Status>>,
     cancel: Option<tokio_util::sync::CancellationToken>,
+    prep_hook: B,
 ) -> crate::Result<()>
 where
     P: FnOnce() -> crate::Result<D>,
     D: std::io::Read + std::io::Write,
+    B: FnOnce() -> crate::Result<()>,
 {
-    let firmware = Firmware::parse(firmware)?;
-
     chan_send(chan.as_mut(), Status::Preparing);
+
+    prep_hook()?;
+
+    let firmware = Firmware::parse(firmware)?;
 
     let port = port_open()?;
     let mut mspm0 = crate::bsl::Mspm0::new(port)?;

--- a/bb-flasher-mspm0/src/i2c.rs
+++ b/bb-flasher-mspm0/src/i2c.rs
@@ -41,8 +41,16 @@ pub fn flash(
     verify: bool,
     chan: Option<mpsc::Sender<Status>>,
     cancel: Option<tokio_util::sync::CancellationToken>,
+    prep_hook: impl FnOnce() -> Result<()>,
 ) -> Result<()> {
-    crate::helpers::flash(firmware, || I2CDev::new(port), verify, chan, cancel)
+    crate::helpers::flash(
+        firmware,
+        || I2CDev::new(port),
+        verify,
+        chan,
+        cancel,
+        prep_hook,
+    )
 }
 
 /// Returns all paths to serial ports.

--- a/bb-flasher-mspm0/src/lib.rs
+++ b/bb-flasher-mspm0/src/lib.rs
@@ -2,12 +2,12 @@ use thiserror::Error;
 
 mod bsl;
 mod helpers;
-#[cfg(feature = "uart")]
-pub mod uart;
 #[cfg(all(feature = "i2c", target_os = "linux"))]
 pub mod i2c;
+#[cfg(feature = "uart")]
+pub mod uart;
 
-type Result<T, E = Error> = std::result::Result<T, E>;
+pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Error, Debug)]
 /// Errors for MSPM0
@@ -42,6 +42,16 @@ pub enum Error {
     /// Failed to open serial port
     #[error("Failed to open serial port.")]
     FailedToOpenPort,
+    #[error("Failed to set GPIO")]
+    #[cfg(target_os = "linux")]
+    GpioIoError {
+        #[from]
+        #[source]
+        source: gpiocdev::Error,
+    },
+    #[error("Failed to open {0}")]
+    #[cfg(target_os = "linux")]
+    GpioOpenError(String),
 }
 
 /// Flashing status
@@ -49,4 +59,44 @@ pub enum Status {
     Preparing,
     Flashing(f32),
     Verifying,
+}
+
+#[cfg(target_os = "linux")]
+pub fn bsl_gpio_cdev_by_name(reset: String, bsl: String) -> impl FnOnce() -> Result<()> {
+    use gpiocdev::line::Value;
+    use std::time::Duration;
+
+    fn open_gpio(name: String) -> crate::Result<gpiocdev::Request> {
+        let pin =
+            gpiocdev::find_named_line(&name).ok_or(crate::Error::GpioOpenError(name.clone()))?;
+        tracing::info!("Found Pin {name}: {:#?}", pin);
+        gpiocdev::Request::builder()
+            .with_found_line(&pin)
+            .as_output(Value::Inactive)
+            .request()
+            .map_err(Into::into)
+    }
+
+    move || {
+        let reset = open_gpio(reset)?;
+        let bsl = open_gpio(bsl)?;
+
+        tracing::info!("Starting BSL");
+
+        bsl.set_lone_value(gpiocdev::line::Value::Active)?;
+        std::thread::sleep(Duration::from_secs(1));
+
+        reset.set_lone_value(gpiocdev::line::Value::Active)?;
+        std::thread::sleep(Duration::from_secs(1));
+
+        reset.set_lone_value(gpiocdev::line::Value::Inactive)?;
+        reset.reconfigure(reset.config().as_input())?;
+
+        std::thread::sleep(Duration::from_secs(1));
+
+        bsl.set_lone_value(gpiocdev::line::Value::Inactive)?;
+        bsl.reconfigure(bsl.config().as_input())?;
+
+        Ok(())
+    }
 }

--- a/bb-flasher-mspm0/src/uart.rs
+++ b/bb-flasher-mspm0/src/uart.rs
@@ -15,6 +15,7 @@ pub fn flash(
     verify: bool,
     chan: Option<mpsc::Sender<Status>>,
     cancel: Option<tokio_util::sync::CancellationToken>,
+    prep_hook: impl FnOnce() -> Result<()>,
 ) -> Result<()> {
     helpers::flash(
         firmware,
@@ -30,6 +31,7 @@ pub fn flash(
         verify,
         chan,
         cancel,
+        prep_hook,
     )
 }
 

--- a/bb-flasher/src/flasher/mspm0/mod.rs
+++ b/bb-flasher/src/flasher/mspm0/mod.rs
@@ -94,32 +94,67 @@ impl Display for Target {
 /// - iHex
 /// - xz: Xz compressed files for any of the above
 #[derive(Debug, Clone)]
-pub struct Flasher<I> {
+pub struct Flasher<I, P> {
     img: I,
     port: Target,
     verify: bool,
     cancel: Option<tokio_util::sync::CancellationToken>,
+    prep_hook: P,
 }
 
-impl<I> Flasher<I> {
+impl<I, P> Flasher<I, P> {
     pub fn new(
         img: I,
         port: Target,
         verify: bool,
         cancel: Option<tokio_util::sync::CancellationToken>,
+        prep_hook: P,
     ) -> Self {
         Self {
             img,
             port: port,
             verify,
             cancel,
+            prep_hook,
         }
     }
 }
 
-impl<I> BBFlasher for Flasher<I>
+impl<I> Flasher<I, fn() -> Result<(), bb_flasher_mspm0::Error>> {
+    pub fn no_prep(
+        img: I,
+        port: Target,
+        verify: bool,
+        cancel: Option<tokio_util::sync::CancellationToken>,
+    ) -> Self {
+        Self::new(img, port, verify, cancel, || Ok(()))
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl<I> Flasher<I, Box<dyn FnOnce() -> bb_flasher_mspm0::Result<()> + Send>> {
+    pub fn gpio_by_name(
+        img: I,
+        port: Target,
+        verify: bool,
+        cancel: Option<tokio_util::sync::CancellationToken>,
+        reset: String,
+        bsl: String,
+    ) -> Self {
+        Self::new(
+            img,
+            port,
+            verify,
+            cancel,
+            Box::new(bb_flasher_mspm0::bsl_gpio_cdev_by_name(reset, bsl)),
+        )
+    }
+}
+
+impl<I, P> BBFlasher for Flasher<I, P>
 where
     I: Future<Output = std::io::Result<(crate::OsImage, u64)>>,
+    P: FnOnce() -> bb_flasher_mspm0::Result<()> + Send + 'static,
 {
     async fn flash(
         self,
@@ -145,11 +180,15 @@ where
 
         let curry = move |chan| match port {
             #[cfg(feature = "mspm0_uart")]
-            Target::Uart(x) => bb_flasher_mspm0::uart::flash(&img, &x, verify, chan, self.cancel)
-                .map_err(Into::into),
+            Target::Uart(x) => {
+                bb_flasher_mspm0::uart::flash(&img, &x, verify, chan, self.cancel, self.prep_hook)
+                    .map_err(Into::into)
+            }
             #[cfg(all(feature = "mspm0_i2c", target_os = "linux"))]
-            Target::I2c(x) => bb_flasher_mspm0::i2c::flash(&img, &x, verify, chan, self.cancel)
-                .map_err(Into::into),
+            Target::I2c(x) => {
+                bb_flasher_mspm0::i2c::flash(&img, &x, verify, chan, self.cancel, self.prep_hook)
+                    .map_err(Into::into)
+            }
             #[cfg(all(feature = "mspm0_i2c", not(target_os = "linux")))]
             Target::I2c(_) => Err(anyhow::anyhow!("Unsupported Os")),
         };

--- a/bb-imager-cli/src/cli.rs
+++ b/bb-imager-cli/src/cli.rs
@@ -10,7 +10,7 @@ pub struct Opt {
     pub command: Commands,
     #[arg(long)]
     /// Enable more logging.
-    pub verbose: bool
+    pub verbose: bool,
 }
 
 #[derive(Subcommand, Debug)]
@@ -160,6 +160,13 @@ pub enum TargetCommands {
         #[arg(long)]
         /// Disable checksum verification after flashing to speed up the process.
         no_verify: bool,
+        #[arg(long, requires = "bsl_gpio")]
+        /// RESET GPIO for MSPM0.
+        reset_gpio: Option<String>,
+        #[cfg(target_os = "linux")]
+        #[arg(long, requires = "reset_gpio")]
+        /// BSL GPIO for MSPM0.
+        bsl_gpio: Option<String>,
     },
 }
 

--- a/bb-imager-cli/src/main.rs
+++ b/bb-imager-cli/src/main.rs
@@ -210,13 +210,17 @@ async fn flash_internal(
                 .flash(chan)
                 .await
         }
-        #[cfg(any(feature = "zepto_uart", feature = "zepto_i2c"))]
+        #[cfg(all(
+            any(feature = "zepto_uart", feature = "zepto_i2c"),
+            not(target_os = "linux")
+        ))]
         TargetCommands::Zepto {
             img,
             dst,
             no_verify,
+            reset_gpio,
         } => {
-            bb_flasher::mspm0::Flasher::new(
+            bb_flasher::mspm0::Flasher::no_prep(
                 LocalImage::new(img).into_future(),
                 dst.into(),
                 !no_verify,
@@ -225,6 +229,41 @@ async fn flash_internal(
             .flash(chan)
             .await
         }
+        #[cfg(all(
+            any(feature = "zepto_uart", feature = "zepto_i2c"),
+            target_os = "linux"
+        ))]
+        TargetCommands::Zepto {
+            img,
+            dst,
+            no_verify,
+            reset_gpio,
+            bsl_gpio,
+        } => match (reset_gpio, bsl_gpio) {
+            (Some(reset), Some(bsl)) => {
+                bb_flasher::mspm0::Flasher::gpio_by_name(
+                    LocalImage::new(img).into_future(),
+                    dst.into(),
+                    !no_verify,
+                    None,
+                    reset,
+                    bsl,
+                )
+                .flash(chan)
+                .await
+            }
+            (None, None) => {
+                bb_flasher::mspm0::Flasher::no_prep(
+                    LocalImage::new(img).into_future(),
+                    dst.into(),
+                    !no_verify,
+                    None,
+                )
+                .flash(chan)
+                .await
+            }
+            _ => panic!("Invalid arguments"),
+        },
     }
 }
 

--- a/bb-imager-gui/src/helpers.rs
+++ b/bb-imager-gui/src/helpers.rs
@@ -446,7 +446,7 @@ pub(crate) async fn flash(
             FlashingCustomization::Zepto(customization),
             Destination::Mspm0(t),
         ) => {
-            bb_flasher::mspm0::Flasher::new(
+            bb_flasher::mspm0::Flasher::no_prep(
                 img.into_future(),
                 t,
                 customization.verify,


### PR DESCRIPTION
- Added a generic pre_hook to bb-flasher-mspm0 along with a function to generate the hook from GPIO names.
- No support in GUI.
- Added flags in CLI.
- Fixes #356 