### PR TITLE
Snap for CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,13 @@ jobs:
     - name: Build packages
       run: make package-host
 
+    - run: ln -sf snapcraft.cli.yaml snapcraft.yaml
+    - name: Build snap
+      uses: snapcore/action-build@v1
+
+    - run: |
+        mv bb-imager-cli_*.snap bb-imager-cli/dist/
+
     # Do not do versioning for Pre-Release packages
     - name: Rename Pre-Release Packages
       if: github.ref_type != 'tag'

--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,7 @@ clean:
 	rm -rf bb-imager-service/dist
 	rm -rf cargo-vendor.tar.gz
 	rm -rf vendor
+	rm -f *.snap
 
 ## housekeeping: packaging-checks: Some checks to ensure good packaging
 .PHONY: package-checks
@@ -380,3 +381,11 @@ package-gui-portable-exe: build-gui
 ## package: package-host: Build all packages for host platform.
 .PHONY: package-host
 package-host: package-$(_HOST_TARGET)
+
+## package: package-cli-snap: Build snap package for CLI.
+.PHONY: package-cli-snap
+package-cli-snap:
+	$(info Build snap package for CLI)
+	ln -sf snapcraft.cli.yaml snapcraft.yaml
+	snapcraft pack
+	unlink snapcraft.yaml

--- a/snapcraft.cli.yaml
+++ b/snapcraft.cli.yaml
@@ -1,0 +1,39 @@
+name: bb-imager-cli
+title: BeagleBoard Imager CLI
+base: core24 # the base snap is the execution environment for this snap
+version: '1.0.0' # just for humans, typically '1.2+git' or '1.3.2'
+license: MIT
+contact:
+  - https://www.beagleboard.org/about
+issues:
+  - https://github.com/beagleboard/bb-imager-rs/issues
+donation:
+  - https://github.com/sponsors/beagleboard
+website:
+  - https://www.beagleboard.org/bb-imager
+source-code:
+  - https://github.com/beagleboard/bb-imager-rs
+summary: Tool for creating, flashing, and managing OS images for BeagleBoard devices.
+description: |
+  A streamlined command line tool to flash SD cards and boards such as
+  BeagleConnect Freedom, BeagleConnect Zepto, etc.
+
+grade: stable # must be 'stable' to release into candidate/stable channels
+confinement: classic # use 'strict' once you have the right plugs and slots
+
+parts:
+  bb-imager-cli:
+    # See 'snapcraft plugins'
+    plugin: rust
+    source: .
+    build-packages:
+      - libudev-dev
+    build-attributes:
+      - enable-patchelf
+    override-build: |
+      make build-cli install-cli DESTDIR=${CRAFT_PART_INSTALL} PREFIX=/usr
+
+apps:
+  bb-imager-cli:
+    command: /usr/bin/bb-imager-cli
+    completer: /usr/share/bash-completion/completions/bb-imager-cli


### PR DESCRIPTION
- Using classic confinement. Here are the reasons:
  - Unrestricted serial access: You need access to all /dev/tty* devices since USB–UART adapters can’t be reliably filtered by vendor/product IDs.
  - Root-level operations by design: The tool is meant to run with sudo, and avoiding dynamic permission prompts (like udisk2 based) is an explicit goal in CLI.
  - Arbitrary I²C access: Flashing over I²C requires broad /dev/i2c-* access with no practical way to scope it down via interfaces.
  - Requiring user to connect proper plugs seems incorrect for a CLI, specially when they are also expected to use super user when required.
- Fixes #387 