### PR TITLE
snapcraft.cli.yaml: Add version bump support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,6 +186,7 @@ ifeq (${VERSION}, ${_CARGO_TOML_VERSION})
 endif
 	sed -i '/\[workspace.package\]/,/^\[/{s/^\s*version\s*=.*/version = "${VERSION}"/}' Cargo.toml
 	sed -i "s/^VITE_BB_IMAGER_VERSION=.*/VITE_BB_IMAGER_VERSION=${VERSION}/" website/.env
+	sed -i "s/^version: .*/version: ${VERSION}/" snapcraft.cli.yml
 	sed -i '/<releases>/a \
 \t\t<release version="$(VERSION)" date="$(_DATE)">\
 \t\t\t<url>https://github.com/beagleboard/bb-imager-rs/releases/tag/$(VERSION)</url>\

--- a/snapcraft.cli.yaml
+++ b/snapcraft.cli.yaml
@@ -1,7 +1,7 @@
 name: bb-imager-cli
 title: BeagleBoard Imager CLI
 base: core24 # the base snap is the execution environment for this snap
-version: '1.0.0' # just for humans, typically '1.2+git' or '1.3.2'
+version: 1.0.0
 license: MIT
 contact:
   - https://www.beagleboard.org/about


### PR DESCRIPTION
- Add snapcraft.cli.yaml to version-bump recipe.