### PR TITLE
snapcraft: Fix app paths

### DIFF
--- a/snapcraft.cli.yaml
+++ b/snapcraft.cli.yaml
@@ -35,5 +35,5 @@ parts:
 
 apps:
   bb-imager-cli:
-    command: /usr/bin/bb-imager-cli
-    completer: /usr/share/bash-completion/completions/bb-imager-cli
+    command: usr/bin/bb-imager-cli
+    completer: usr/share/bash-completion/completions/bb-imager-cli

--- a/snapcraft.gui.yaml
+++ b/snapcraft.gui.yaml
@@ -26,7 +26,7 @@ parts:
 
 apps:
   bb-imager:
-    command: /usr/bin/bb-imager-gui
+    command: usr/bin/bb-imager-gui
     common-id: org.beagleboard.imagingutility
     plugs:
       # Access to local firmware/iso files for flashing.


### PR DESCRIPTION
- Seems we need to use relative paths. Using absolute path causes auto rejection.