### PR TITLE
.github: workflows: release: Add CLI snap for riscv64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
   linux-snap-cross-job:
     strategy:
       matrix:
-        platform: [armhf]
+        platform: [armhf, riscv64]
     name: Build CLI Snap - ${{matrix.platform}}
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
- BeagleV-Fire and Ahead.