### PR TITLE
bb-imager-cli: Remove url dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,7 +678,6 @@ dependencies = [
  "indicatif",
  "tokio",
  "tracing-subscriber",
- "url",
 ]
 
 [[package]]
@@ -8825,7 +8824,6 @@ dependencies = [
  "clap",
  "clap_complete",
  "clap_mangen",
- "url",
 ]
 
 [[package]]

--- a/bb-imager-cli/Cargo.toml
+++ b/bb-imager-cli/Cargo.toml
@@ -13,7 +13,6 @@ bb-flasher = { path = "../bb-flasher" }
 tokio = { version = "1.52", features = ["macros", "rt-multi-thread"] }
 indicatif = "0.18"
 console = "0.16"
-url = "2.5.4"
 const-hex = "1.17"
 clap_complete = "4.6"
 anyhow = "1.0"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -10,7 +10,6 @@ license.workspace = true
 clap = { version = "4.5", features = ["derive"] }
 clap_mangen = "0.3"
 clap_complete = "4.6"
-url = "2.5"
 cargo_toml = "0.22"
 
 [features]


### PR DESCRIPTION
- Since remove image support was removed a while ago, remove url as dependency.