### PR TITLE
.github: workflows: release: Use RISE runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
   linux-snap-job:
     strategy:
       matrix:
-        platform: [ubuntu-24.04, ubuntu-24.04-arm]
+        platform: [ubuntu-24.04, ubuntu-24.04-arm, ubuntu-26.04-riscv]
         package: [gui, cli]
     name: Build Snaps - ${{ matrix.package }} ${{ matrix.platform }}
     runs-on: ${{ matrix.platform }}
@@ -94,7 +94,7 @@ jobs:
   linux-snap-cross-job:
     strategy:
       matrix:
-        platform: [armhf, riscv64]
+        platform: [armhf]
     name: Build CLI Snap - ${{matrix.platform}}
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
- Free RISCV runners. Should speed up build.