### PR TITLE
bb-imager-gui: ui: flash_success: Change btn label

### DIFF
--- a/bb-imager-gui/src/ui/flash_success.rs
+++ b/bb-imager-gui/src/ui/flash_success.rs
@@ -13,7 +13,7 @@ pub(crate) fn view(state: &FlashingFinishState) -> Element<'_, BBImagerMessage> 
     page_type1(
         info_view(state),
         progress_view(state),
-        [button("Restart")
+        [button("Flash Another")
             .style(widget::button::primary)
             .on_press(BBImagerMessage::Restart)],
     )


### PR DESCRIPTION
- Etcher seems to call it "Flash Another". So use the same name.
- Fixes #402 