### PR TITLE
.github: workflows: release: Do not cross build snap in PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,7 @@ jobs:
         platform: [armhf, riscv64]
     name: Build CLI Snap - ${{matrix.platform}}
     runs-on: ubuntu-24.04
+    if: github.event_name != 'pull_request'
     steps:
     - name: Checkout
       uses: actions/checkout@v6


### PR DESCRIPTION
- Takes too long for little gain.
- We are still bulding snap for aarch64 and amd64 in PRs. Just not armhf and riscv64.