### PR TITLE
bb-flasher-mspm0: Clearer error message for connection fal

### DIFF
--- a/bb-flasher-mspm0/src/bsl.rs
+++ b/bb-flasher-mspm0/src/bsl.rs
@@ -296,7 +296,7 @@ where
     S: std::io::Read + std::io::Write,
 {
     pub(crate) fn new(mut port: S) -> Result<Self> {
-        Self::connect(&mut port)?;
+        Self::connect(&mut port).map_err(|_| Error::ConnectionFail)?;
         let info = Self::get_device_info(&mut port)?;
 
         Ok(Self {

--- a/bb-flasher-mspm0/src/lib.rs
+++ b/bb-flasher-mspm0/src/lib.rs
@@ -12,6 +12,8 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 #[derive(Error, Debug)]
 /// Errors for MSPM0
 pub enum Error {
+    #[error("Failed to connect to the bootloader (BSL). Please put the board in BSL mode.")]
+    ConnectionFail,
     /// Aborted before completing
     #[error("Aborted before completing.")]
     Aborted,


### PR DESCRIPTION
- Provide better error message when error is probably due to MSPM0 not being in BSL mode.
- Fixes #446 