### PR TITLE
bb-imager-gui: Add retry button on fail

### DIFF
--- a/bb-imager-gui/src/main.rs
+++ b/bb-imager-gui/src/main.rs
@@ -264,13 +264,14 @@ impl BBImager {
     fn start_flashing(&mut self) -> Task<BBImagerMessage> {
         let state = match std::mem::take(self) {
             Self::Review(inner) => inner,
+            Self::FlashingFail(inner) => inner.into(),
             _ => panic!("Unexpected page"),
         };
 
         let is_download = state.is_download();
-        let customization = state.customization;
+        let customization = state.customization.clone();
         let img = state.selected_image.1.clone();
-        let dst = state.selected_dest;
+        let dst = state.selected_dest.clone();
 
         tracing::info!("Starting Flashing Process");
         tracing::info!("Selected Board: {:#?}", state.selected_board);
@@ -323,6 +324,9 @@ impl BBImager {
             cancel_flashing: h,
             progress: bb_flasher::DownloadFlashingStatus::Preparing,
             start_timestamp: None,
+            selected_image: state.selected_image,
+            selected_dest: state.selected_dest,
+            customization: state.customization,
         });
 
         t

--- a/bb-imager-gui/src/message.rs
+++ b/bb-imager-gui/src/message.rs
@@ -54,6 +54,8 @@ pub(crate) enum BBImagerMessage {
 
     // Reset to start from beginning.
     Restart,
+    // Retry flashing
+    Retry,
 
     /// Open URL in browser
     OpenUrl(url::Url),
@@ -395,6 +397,10 @@ pub(crate) fn update(state: &mut BBImager, message: BBImagerMessage) -> Task<BBI
                         common: inner.common,
                         err,
                         logs,
+                        selected_board: inner.selected_board,
+                        selected_image: inner.selected_image,
+                        selected_dest: inner.selected_dest,
+                        customization: inner.customization,
                     })
                 }
                 BBImager::AppInfo(inner) => match inner.page {
@@ -408,6 +414,10 @@ pub(crate) fn update(state: &mut BBImager, message: BBImagerMessage) -> Task<BBI
                                 common: flashing_state.common,
                                 err,
                                 logs,
+                                selected_board: flashing_state.selected_board,
+                                selected_image: flashing_state.selected_image,
+                                selected_dest: flashing_state.selected_dest,
+                                customization: flashing_state.customization,
                             }),
                             ..inner
                         })
@@ -429,7 +439,7 @@ pub(crate) fn update(state: &mut BBImager, message: BBImagerMessage) -> Task<BBI
             },
             _ => panic!("Unexpected message"),
         },
-        BBImagerMessage::FlashStart => {
+        BBImagerMessage::FlashStart | BBImagerMessage::Retry => {
             return state.start_flashing();
         }
         BBImagerMessage::FlashSuccess => {

--- a/bb-imager-gui/src/state.rs
+++ b/bb-imager-gui/src/state.rs
@@ -388,6 +388,9 @@ pub(crate) struct FlashingState {
     pub(crate) progress: bb_flasher::DownloadFlashingStatus,
     pub(crate) start_timestamp: Option<Instant>,
     pub(crate) is_download: bool,
+    pub(crate) selected_image: (OsImageId, helpers::BoardImage),
+    pub(crate) selected_dest: helpers::Destination,
+    pub(crate) customization: helpers::FlashingCustomization,
 }
 
 impl FlashingState {
@@ -458,6 +461,22 @@ pub(crate) struct FlashingFailState {
     pub(crate) common: BBImagerCommon,
     pub(crate) err: String,
     pub(crate) logs: widget::text_editor::Content,
+    pub(crate) selected_board: Board,
+    pub(crate) selected_image: (OsImageId, helpers::BoardImage),
+    pub(crate) selected_dest: helpers::Destination,
+    pub(crate) customization: helpers::FlashingCustomization,
+}
+
+impl From<FlashingFailState> for CustomizeState {
+    fn from(value: FlashingFailState) -> Self {
+        Self {
+            common: value.common,
+            selected_board: value.selected_board,
+            selected_image: value.selected_image,
+            selected_dest: value.selected_dest,
+            customization: value.customization,
+        }
+    }
 }
 
 // State for Pages that can be opened from any of the normal pages but are not part of normal flow.

--- a/bb-imager-gui/src/ui/flash_fail.rs
+++ b/bb-imager-gui/src/ui/flash_fail.rs
@@ -13,9 +13,14 @@ pub(crate) fn view(state: &FlashingFailState) -> Element<'_, BBImagerMessage> {
     page_type1(
         info_view(state),
         progress_view(state),
-        [button("Restart")
-            .style(widget::button::danger)
-            .on_press(BBImagerMessage::Restart)],
+        [
+            button("Flash New")
+                .style(widget::button::danger)
+                .on_press(BBImagerMessage::Restart),
+            button("Retry")
+                .style(widget::button::primary)
+                .on_press(BBImagerMessage::Retry),
+        ],
     )
 }
 


### PR DESCRIPTION
- Useful for cases like Zepto where the problem is just that the user forgot to put it in BSL mode.
- Fixes #445 