### PR TITLE
Disable strip and panic-abort

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,8 @@ members = [
 ]
 
 [profile.release]
-strip = true
 lto = true
 codegen-units = 1
-panic = "abort"
 
 [workspace.package]
 version = "1.0.6"


### PR DESCRIPTION
- Most linux distro expect to strip binaries themselves.
- No need to over-optimize with panic-abort. Makes backtrace useless.