### PR TITLE
bb-helper: file_stream: Fix seek

### DIFF
--- a/bb-helper/Cargo.toml
+++ b/bb-helper/Cargo.toml
@@ -10,5 +10,8 @@ license.workspace = true
 tempfile = "3.27"
 tokio = { version = "1.52", default-features = false }
 
+[dev-dependencies]
+tokio = { version = "1.52", features = ["macros", "rt-multi-thread"] }
+
 [features]
 file_stream = ["tokio/fs", "tokio/io-util"]

--- a/bb-helper/src/file_stream.rs
+++ b/bb-helper/src/file_stream.rs
@@ -114,9 +114,51 @@ impl std::io::Read for ReaderFileStream {
     }
 }
 
+// ReaderFileStream behaves like a stream backed by a growing file rather than
+// a normal fully materialized file.
+//
+// Seeking within the currently written region works normally. However:
+//
+// - Seeking beyond the current file length waits until the writer produces
+//   enough data or closes.
+// - SeekFrom::End is unsupported while the writer is still active because the
+//   final file length is not yet known, so offsets relative to the end cannot
+//   be resolved correctly.
+// - Once the writer is dropped, seek behavior matches normal file semantics.
 impl std::io::Seek for ReaderFileStream {
     fn seek(&mut self, pos: io::SeekFrom) -> io::Result<u64> {
-        self.file.seek(pos)
+        loop {
+            let (lock, cvar) = &*self.writing;
+            let writing = lock.lock().unwrap();
+
+            // If writing done, use normal file seek.
+            if !*writing {
+                return self.file.seek(pos);
+            }
+
+            let len = self.file.metadata()?.len();
+            let target = match pos {
+                io::SeekFrom::Start(x) => x,
+                io::SeekFrom::End(_) => {
+                    // We don't know true file len yet. So just return
+                    // unsupported. Not sure if we should just wait for writing to finish.
+                    return Err(io::Error::new(
+                        io::ErrorKind::Unsupported,
+                        "Seek from end is unsupported",
+                    ));
+                }
+                io::SeekFrom::Current(x) => self
+                    .file
+                    .stream_position()?
+                    .checked_add_signed(x)
+                    .ok_or(io::Error::new(io::ErrorKind::InvalidInput, "invalid seek"))?,
+            };
+
+            if target <= len {
+                return self.file.seek(pos);
+            }
+            drop(cvar.wait(writing));
+        }
     }
 }
 
@@ -132,4 +174,93 @@ pub fn file_stream() -> io::Result<(WriterFileStream, ReaderFileStream)> {
     let writer = WriterFileStream::new(file.into_file().into(), flag);
 
     Ok((writer, reader))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Read, Seek, SeekFrom};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn seek_from_start_works() {
+        let (mut writer, mut reader) = file_stream().unwrap();
+
+        writer.write_all(b"abcdef").await.unwrap();
+
+        tokio::task::spawn_blocking(move || {
+            reader.seek(SeekFrom::Start(2)).unwrap();
+
+            let mut buf = [0u8; 2];
+            reader.read_exact(&mut buf).unwrap();
+
+            assert_eq!(&buf, b"cd");
+        })
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn seek_from_current_works() {
+        let (mut writer, mut reader) = file_stream().unwrap();
+
+        writer.write_all(b"abcdef").await.unwrap();
+
+        tokio::task::spawn_blocking(move || {
+            reader.seek(SeekFrom::Start(1)).unwrap();
+            reader.seek(SeekFrom::Current(2)).unwrap();
+
+            let mut buf = [0u8; 1];
+            reader.read_exact(&mut buf).unwrap();
+
+            assert_eq!(&buf, b"d");
+        })
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn seek_from_end_fails_while_writer_alive() {
+        let (_writer, mut reader) = file_stream().unwrap();
+
+        tokio::task::spawn_blocking(move || {
+            let err = reader.seek(SeekFrom::End(0)).unwrap_err();
+            assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+        })
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn seek_from_end_works_after_writer_drop() {
+        let (mut writer, mut reader) = file_stream().unwrap();
+
+        writer.write_all(b"abcdef").await.unwrap();
+        drop(writer);
+
+        tokio::task::spawn_blocking(move || {
+            let pos = reader.seek(SeekFrom::End(-2)).unwrap();
+            assert_eq!(pos, 4);
+
+            let mut buf = [0u8; 2];
+            reader.read_exact(&mut buf).unwrap();
+
+            assert_eq!(&buf, b"ef");
+        })
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn invalid_negative_seek_fails() {
+        let (mut writer, mut reader) = file_stream().unwrap();
+        writer.write_all(b"abc").await.unwrap();
+
+        tokio::task::spawn_blocking(move || {
+            let err = reader.seek(SeekFrom::Current(-10)).unwrap_err();
+            assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        })
+        .await
+        .unwrap()
+    }
 }


### PR DESCRIPTION
ReaderFileStream behaves like a stream backed by a growing file rather than a normal fully materialized file.

Seeking within the currently written region works normally. However:

- Seeking beyond the current file length waits until the writer produces enough data or closes.
- SeekFrom::End is unsupported while the writer is still active because the final file length is not yet known, so offsets relative to the end cannot be resolved correctly.
- Once the writer is dropped, seek behavior matches normal file semantics.