### PR TITLE
bb-flasher: img: Make osimg abstraction layered

### DIFF
--- a/bb-flasher/src/img.rs
+++ b/bb-flasher/src/img.rs
@@ -1,114 +1,53 @@
 //! Module to handle extraction of compressed firmware, auto detection of type of extraction, etc
 
 use bb_helper::file_stream::ReaderFileStream;
-use rc_zip_sync::{ReadZip, ReadZipStreaming};
+use rc_zip_sync::ReadZipStreaming;
 use std::{
-    io::{Read, Seek, SeekFrom},
+    io::{self, Read, Seek, SeekFrom},
     path::Path,
 };
+use tokio_util::task::AbortOnDropHandle;
+
+const XZ_MAGIC: [u8; 6] = [0xfd, 0x37, 0x7a, 0x58, 0x5a, 0x00];
 
 pub struct OsImage {
     size: u64,
-    img: OsImageReader,
-}
-
-pub(crate) enum OsImageReader {
-    Xz(liblzma::read::XzDecoder<std::fs::File>),
-    Zip(rc_zip_sync::StreamingEntryReader<std::fs::File>),
-    XzPiped {
-        reader: liblzma::read::XzDecoder<ReaderFileStream>,
-        _background: tokio_util::task::AbortOnDropHandle<std::io::Result<()>>,
-    },
-    ZipPiped {
-        reader: rc_zip_sync::StreamingEntryReader<ReaderFileStream>,
-        _background: tokio_util::task::AbortOnDropHandle<std::io::Result<()>>,
-    },
-    Uncompressed(std::io::BufReader<std::fs::File>),
-    UncompressedPiped {
-        reader: std::io::BufReader<ReaderFileStream>,
-        _background: tokio_util::task::AbortOnDropHandle<std::io::Result<()>>,
-    },
+    img: OsImageCompression<OsImageSource>,
 }
 
 impl OsImage {
-    pub fn from_path(path: &Path) -> std::io::Result<Self> {
-        let mut file = std::fs::File::open(path)?;
+    pub fn from_path(path: &Path) -> io::Result<Self> {
+        let file = std::fs::File::open(path)?;
+        let mut img = OsImageCompression::new(OsImageSource::from(file))?;
 
-        let mut magic = [0u8; 6];
-        file.read_exact(&mut magic)?;
-
-        file.seek(std::io::SeekFrom::Start(0))?;
-
-        match magic {
-            [0xfd, 0x37, 0x7a, 0x58, 0x5a, 0x00] => {
-                let size = liblzma::uncompressed_size(&mut file)?;
-
-                file.seek(std::io::SeekFrom::Start(0))?;
-                let img = liblzma::read::XzDecoder::new_parallel(file);
-
-                Ok(Self {
-                    size,
-                    img: OsImageReader::Xz(img),
-                })
+        let size = match &mut img {
+            OsImageCompression::Xz(x) => {
+                let size = liblzma::uncompressed_size(x.get_mut())?;
+                x.get_mut().rewind()?;
+                size
             }
-            [0x50, 0x4b, 0x03, 0x04, _, _] => {
-                let temp = file.read_zip()?;
-                if temp.entries().count() != 1 {
-                    return Err(std::io::Error::other(
-                        "Zip image should only have single file",
-                    ));
-                }
+            OsImageCompression::Zip(x) => x.entry().uncompressed_size,
+            OsImageCompression::Uncompressed(x) => match x.get_ref() {
+                OsImageSource::File(file) => file.metadata()?.len(),
+                OsImageSource::FileStream { .. } => unreachable!(),
+            },
+        };
 
-                let img = file.stream_zip_entries_throwing_caution_to_the_wind()?;
-
-                Ok(Self {
-                    size: img.entry().uncompressed_size,
-                    img: OsImageReader::Zip(img),
-                })
-            }
-            _ => {
-                let size = file.metadata()?.len();
-
-                Ok(Self {
-                    size,
-                    img: OsImageReader::Uncompressed(std::io::BufReader::new(file)),
-                })
-            }
-        }
+        Ok(Self { size, img })
     }
 
     pub fn from_piped(
-        mut img: ReaderFileStream,
-        abort_handle: tokio::task::JoinHandle<std::io::Result<()>>,
+        img: ReaderFileStream,
+        abort_handle: tokio::task::JoinHandle<io::Result<()>>,
         size: u64,
-    ) -> std::io::Result<Self> {
-        let mut magic = [0u8; 6];
-        img.read_exact(&mut magic)?;
-        img.seek(SeekFrom::Start(0))?;
-
-        match magic {
-            [0xfd, 0x37, 0x7a, 0x58, 0x5a, 0x00] => Ok(Self {
-                size,
-                img: OsImageReader::XzPiped {
-                    reader: liblzma::read::XzDecoder::new_parallel(img),
-                    _background: tokio_util::task::AbortOnDropHandle::new(abort_handle),
-                },
-            }),
-            [0x50, 0x4b, 0x03, 0x04, _, _] => Ok(Self {
-                size,
-                img: OsImageReader::ZipPiped {
-                    reader: img.stream_zip_entries_throwing_caution_to_the_wind()?,
-                    _background: tokio_util::task::AbortOnDropHandle::new(abort_handle),
-                },
-            }),
-            _ => Ok(Self {
-                size,
-                img: OsImageReader::UncompressedPiped {
-                    reader: std::io::BufReader::new(img),
-                    _background: tokio_util::task::AbortOnDropHandle::new(abort_handle),
-                },
-            }),
-        }
+    ) -> io::Result<Self> {
+        Ok(Self {
+            size,
+            img: OsImageCompression::new(OsImageSource::FileStream {
+                reader: img,
+                _background: AbortOnDropHandle::new(abort_handle),
+            })?,
+        })
     }
 
     pub(crate) const fn size(&self) -> u64 {
@@ -116,15 +55,78 @@ impl OsImage {
     }
 }
 
-impl std::io::Read for OsImage {
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+impl Read for OsImage {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         match &mut self.img {
-            OsImageReader::Xz(x) => x.read(buf),
-            OsImageReader::Uncompressed(x) => x.read(buf),
-            OsImageReader::XzPiped { reader, .. } => reader.read(buf),
-            OsImageReader::UncompressedPiped { reader, .. } => reader.read(buf),
-            OsImageReader::ZipPiped { reader, .. } => reader.read(buf),
-            OsImageReader::Zip(x) => x.read(buf),
+            OsImageCompression::Xz(x) => x.read(buf),
+            OsImageCompression::Zip(x) => x.read(buf),
+            OsImageCompression::Uncompressed(x) => x.read(buf),
+        }
+    }
+}
+
+#[allow(clippy::large_enum_variant)]
+enum OsImageCompression<I: Read> {
+    Xz(liblzma::read::XzDecoder<I>),
+    Zip(rc_zip_sync::StreamingEntryReader<I>),
+    Uncompressed(io::BufReader<I>),
+}
+
+impl<I: Read + Seek> OsImageCompression<I> {
+    fn new(mut img: I) -> io::Result<Self> {
+        let mut magic = [0u8; 6];
+        img.read_exact(&mut magic)?;
+        img.rewind()?;
+
+        match magic {
+            XZ_MAGIC => Ok(Self::Xz(liblzma::read::XzDecoder::new_parallel(img))),
+            [0x50, 0x4b, 0x03, 0x04, _, _] => img
+                .stream_zip_entries_throwing_caution_to_the_wind()
+                .map(Self::Zip)
+                .map_err(Into::into),
+            _ => Ok(Self::Uncompressed(std::io::BufReader::new(img))),
+        }
+    }
+}
+
+impl<I: Read> Read for OsImageCompression<I> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match self {
+            OsImageCompression::Xz(x) => x.read(buf),
+            OsImageCompression::Zip(x) => x.read(buf),
+            OsImageCompression::Uncompressed(x) => x.read(buf),
+        }
+    }
+}
+
+enum OsImageSource {
+    File(std::fs::File),
+    FileStream {
+        reader: ReaderFileStream,
+        _background: AbortOnDropHandle<io::Result<()>>,
+    },
+}
+
+impl From<std::fs::File> for OsImageSource {
+    fn from(value: std::fs::File) -> Self {
+        Self::File(value)
+    }
+}
+
+impl Read for OsImageSource {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match self {
+            OsImageSource::File(x) => x.read(buf),
+            OsImageSource::FileStream { reader, .. } => reader.read(buf),
+        }
+    }
+}
+
+impl Seek for OsImageSource {
+    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+        match self {
+            OsImageSource::File(file) => file.seek(pos),
+            OsImageSource::FileStream { reader, .. } => reader.seek(pos),
         }
     }
 }

--- a/bb-helper/src/file_stream.rs
+++ b/bb-helper/src/file_stream.rs
@@ -187,6 +187,7 @@ mod tests {
         let (mut writer, mut reader) = file_stream().unwrap();
 
         writer.write_all(b"abcdef").await.unwrap();
+        writer.flush().await.unwrap();
 
         tokio::task::spawn_blocking(move || {
             reader.seek(SeekFrom::Start(2)).unwrap();
@@ -205,6 +206,7 @@ mod tests {
         let (mut writer, mut reader) = file_stream().unwrap();
 
         writer.write_all(b"abcdef").await.unwrap();
+        writer.flush().await.unwrap();
 
         tokio::task::spawn_blocking(move || {
             reader.seek(SeekFrom::Start(1)).unwrap();
@@ -236,6 +238,7 @@ mod tests {
         let (mut writer, mut reader) = file_stream().unwrap();
 
         writer.write_all(b"abcdef").await.unwrap();
+        writer.flush().await.unwrap();
         drop(writer);
 
         tokio::task::spawn_blocking(move || {
@@ -254,7 +257,9 @@ mod tests {
     #[tokio::test]
     async fn invalid_negative_seek_fails() {
         let (mut writer, mut reader) = file_stream().unwrap();
+
         writer.write_all(b"abc").await.unwrap();
+        writer.flush().await.unwrap();
 
         tokio::task::spawn_blocking(move || {
             let err = reader.seek(SeekFrom::Current(-10)).unwrap_err();


### PR DESCRIPTION
- Will make things when introducing new format support such as qcow2, which themselves might be inside xz.