### PR TITLE
Add boot partition update support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -644,6 +644,7 @@ dependencies = [
  "mbrman",
  "nix 0.31.3",
  "security-framework",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,6 +571,7 @@ dependencies = [
  "nix 0.31.3",
  "rc-zip-sync",
  "serde",
+ "tar",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -1994,6 +1995,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -6771,6 +6782,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tauri-winrt-notification"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8859,6 +8881,16 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.4",
+]
 
 [[package]]
 name = "xcursor"

--- a/bb-flasher-sd/Cargo.toml
+++ b/bb-flasher-sd/Cargo.toml
@@ -23,6 +23,10 @@ tokio = { version = "1.52", default-features = false, features = ["rt-multi-thre
 tokio-util = { version = "0.7" }
 anyhow = "1.0"
 
+[dev-dependencies]
+tokio = { version = "1.52", features = ["rt-multi-thread", "fs", "macros"] }
+tempfile = "3.27"
+
 [target.'cfg(target_os = "linux")'.dependencies]
 udisks2 = { version = "0.3", optional = true }
 libc = "0.2"

--- a/bb-flasher-sd/src/customization.rs
+++ b/bb-flasher-sd/src/customization.rs
@@ -9,7 +9,7 @@ pub enum ParitionType {
 }
 
 impl ParitionType {
-    fn open<T>(&self, dst: T) -> Result<FileSystem<BufStream<StreamSlice<T>>>>
+    pub(crate) fn open<T>(&self, dst: T) -> Result<FileSystem<BufStream<StreamSlice<T>>>>
     where
         T: Write + Seek + Read + std::fmt::Debug,
     {

--- a/bb-flasher-sd/src/helpers.rs
+++ b/bb-flasher-sd/src/helpers.rs
@@ -31,6 +31,12 @@ impl Eject for std::fs::File {
     }
 }
 
+impl Eject for &mut std::fs::File {
+    fn eject(self) -> io::Result<()> {
+        self.sync_all()
+    }
+}
+
 const BLOCK_SIZE: usize = 4096;
 
 #[derive(Debug)]

--- a/bb-flasher-sd/src/lib.rs
+++ b/bb-flasher-sd/src/lib.rs
@@ -52,6 +52,7 @@ pub(crate) mod customization;
 mod flashing;
 mod helpers;
 pub(crate) mod pal;
+pub mod update_boot;
 
 pub use customization::{Customization, ParitionType, ContentType};
 pub use flashing::flash;

--- a/bb-flasher-sd/src/update_boot.rs
+++ b/bb-flasher-sd/src/update_boot.rs
@@ -1,0 +1,214 @@
+use std::io::{Read, Seek, Write};
+
+use crate::{
+    Result,
+    helpers::{Eject, check_token},
+};
+
+pub enum FileType<'a> {
+    Dir,
+    File(Box<dyn Read + 'a>),
+}
+
+pub async fn update_boot<I>(
+    img: impl Future<Output = std::io::Result<I>>,
+    dst: crate::Destination,
+    cancel: Option<tokio_util::sync::CancellationToken>,
+) -> Result<()>
+where
+    I: Send + 'static,
+    for<'b> &'b mut I: IntoIterator<Item = (Box<str>, FileType<'b>)>,
+{
+    tracing::info!("Opening Destination");
+
+    match dst {
+        crate::Destination::File(path) => {
+            let sd = tokio::fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .open(path)
+                .await?
+                .into_std()
+                .await;
+            common(img, sd, cancel).await
+        }
+        crate::Destination::SdCard(path) => {
+            let sd = crate::pal::open(&path).await?;
+            common(img, sd, cancel).await
+        }
+    }
+}
+
+async fn common<I>(
+    img: impl Future<Output = std::io::Result<I>>,
+    sd: impl Read + Write + Seek + Eject + std::fmt::Debug + Send + 'static,
+    cancel: Option<tokio_util::sync::CancellationToken>,
+) -> Result<()>
+where
+    I: Send + 'static,
+    for<'b> &'b mut I: IntoIterator<Item = (Box<str>, FileType<'b>)>,
+{
+    let img = img.await?;
+
+    let cancel_child = cancel.as_ref().map(|x| x.child_token());
+    let res = tokio::task::spawn_blocking(move || internal(img, sd, cancel_child))
+        .await
+        .unwrap();
+
+    // Cancel all tasks on drop
+    let _drop_guard = cancel.map(|x| x.drop_guard());
+
+    res
+}
+
+fn internal<I>(
+    mut boot: I,
+    mut sd: impl Read + Write + Seek + Eject + std::fmt::Debug,
+    cancel: Option<tokio_util::sync::CancellationToken>,
+) -> Result<()>
+where
+    for<'b> &'b mut I: IntoIterator<Item = (Box<str>, FileType<'b>)>,
+{
+    check_token(cancel.as_ref())?;
+
+    tracing::info!("Updating bootfs");
+    {
+        let boot_part = crate::customization::ParitionType::Boot
+            .open(crate::helpers::DeviceWrapper::new(&mut sd)?)?;
+        let root = boot_part.root_dir();
+        for (path, c) in &mut boot {
+            match c {
+                FileType::Dir => {
+                    root.create_dir(&path)?;
+                }
+                FileType::File(mut reader) => {
+                    let mut dst = root.create_file(&path)?;
+                    dst.truncate()?;
+                    std::io::copy(&mut reader, &mut dst)?;
+                }
+            }
+        }
+    }
+    sd.flush()?;
+
+    tracing::info!("Ejecting SD Card");
+    let _ = sd.eject();
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use std::io::SeekFrom;
+
+    use fscommon::StreamSlice;
+    use mbrman::{CHS, MBR, MBRPartitionEntry};
+
+    use super::*;
+
+    const DISK_SIZE: u64 = 128 * 1024 * 1024; // 128 MiB
+    const SECTOR_SIZE: u32 = 512;
+    const FIRST_LBA: u32 = 2048;
+
+    #[derive(Debug, Clone)]
+    struct MockArchive(Vec<(Box<str>, Option<Vec<u8>>)>);
+
+    impl Default for MockArchive {
+        fn default() -> Self {
+            Self(vec![
+                ("config".into(), None),
+                ("config/cmdline.txt".into(), Some(b"console=ttyS0".to_vec())),
+            ])
+        }
+    }
+
+    impl<'a> IntoIterator for &'a mut MockArchive {
+        type Item = (Box<str>, FileType<'a>);
+        type IntoIter = Box<dyn Iterator<Item = Self::Item> + 'a>;
+
+        fn into_iter(self) -> Self::IntoIter {
+            Box::new(self.0.iter().map(|(p, f)| match f {
+                Some(x) => (p.clone(), FileType::File(Box::new(x.as_slice()))),
+                None => (p.clone(), FileType::Dir),
+            }))
+        }
+    }
+
+    fn mocksd() -> std::fs::File {
+        let mut img = tempfile::tempfile().unwrap();
+
+        img.set_len(DISK_SIZE).unwrap();
+
+        let mut mbr = MBR::new_from(&mut img, SECTOR_SIZE, [0x12, 0x34, 0x56, 0x78]).unwrap();
+
+        let total_sectors = (DISK_SIZE / SECTOR_SIZE as u64) as u32;
+        let num_sectors = total_sectors - FIRST_LBA;
+
+        mbr[1] = MBRPartitionEntry {
+            boot: 0x80,
+            first_chs: CHS::empty(),
+            sys: 0x0C, // FAT32 (LBA)
+            last_chs: CHS::empty(),
+            starting_lba: FIRST_LBA,
+            sectors: num_sectors,
+        };
+
+        mbr.write_into(&mut img).unwrap();
+
+        let partition_offset = FIRST_LBA as u64 * SECTOR_SIZE as u64;
+        let partition_size = num_sectors as u64 * SECTOR_SIZE as u64;
+
+        {
+            let mut partition = img.try_clone().unwrap();
+
+            partition.seek(SeekFrom::Start(partition_offset)).unwrap();
+
+            let mut partition =
+                StreamSlice::new(partition, partition_offset, partition_size).unwrap();
+
+            fatfs::format_volume(
+                &mut partition,
+                fatfs::FormatVolumeOptions::new()
+                    .fat_type(fatfs::FatType::Fat32)
+                    .volume_label(*b"BOOT       "),
+            )
+            .unwrap();
+        }
+
+        img.rewind().unwrap();
+
+        img
+    }
+
+    #[test]
+    fn basic() {
+        let mut iter = MockArchive::default();
+        let mut sd = mocksd();
+
+        internal(iter.clone(), &mut sd, None).unwrap();
+        sd.rewind().unwrap();
+
+        let boot_part = crate::customization::ParitionType::Boot.open(sd).unwrap();
+        let root = boot_part.root_dir();
+
+        for (path, f) in &mut iter {
+            match f {
+                FileType::Dir => {
+                    root.open_dir(&path).unwrap();
+                }
+                FileType::File(mut read) => {
+                    let mut dst = root.open_file(&path).unwrap();
+                    let mut expected = Vec::new();
+                    let mut actual = Vec::new();
+
+                    read.read_to_end(&mut expected).unwrap();
+                    dst.read_to_end(&mut actual).unwrap();
+
+                    assert_eq!(actual, expected);
+                }
+            }
+        }
+    }
+}

--- a/bb-flasher/Cargo.toml
+++ b/bb-flasher/Cargo.toml
@@ -27,6 +27,7 @@ rc-zip-sync = "4.4"
 bb-flasher-dfu = { path = "../bb-flasher-dfu", optional = true }
 anyhow = "1.0"
 bb-flasher-mspm0 = { path = "../bb-flasher-mspm0", optional = true }
+tar = "0.4"
 
 [dev-dependencies]
 tokio = { version = "1.52", default-features = false, features = ["rt-multi-thread", "sync", "net", "time", "macros"] }

--- a/bb-flasher/src/flasher/sd/mod.rs
+++ b/bb-flasher/src/flasher/sd/mod.rs
@@ -295,3 +295,61 @@ where
         .map_err(Into::into)
     }
 }
+
+/// Flasher of updaing BOOT partition on pre-flashed SD Card
+pub struct UpdateBootFlasher<I> {
+    img: I,
+    dst: bb_flasher_sd::Destination,
+    cancel: Option<tokio_util::sync::CancellationToken>,
+}
+
+impl<I, T> UpdateBootFlasher<I>
+where
+    I: Future<Output = std::io::Result<T>>,
+    T: Send + 'static,
+    for<'b> &'b mut T: IntoIterator<Item = (Box<str>, bb_flasher_sd::update_boot::FileType<'b>)>,
+{
+    pub fn new(img: I, dst: Target, cancel: Option<tokio_util::sync::CancellationToken>) -> Self {
+        Self {
+            img,
+            dst: bb_flasher_sd::Destination::SdCard(dst.0.path.into_boxed_path()),
+            cancel,
+        }
+    }
+}
+
+impl<I, T> BBFlasher for UpdateBootFlasher<I>
+where
+    I: Future<Output = std::io::Result<T>>,
+    T: Send + 'static,
+    for<'b> &'b mut T: IntoIterator<Item = (Box<str>, bb_flasher_sd::update_boot::FileType<'b>)>,
+{
+    async fn flash(self, chan: Option<mpsc::Sender<DownloadFlashingStatus>>) -> anyhow::Result<()> {
+        let dst = self.dst;
+
+        if let Some(chan) = chan {
+            let (_tx, mut rx) = tokio::sync::mpsc::channel(2);
+
+            let t = tokio::spawn(async move {
+                // Should run until tx is dropped, i.e. flasher task is done.
+                // If it is aborted, then cancel should be dropped, thereby signaling the flasher task to abort
+                while let Some(x) = rx.recv().await {
+                    let _ = chan.try_send(if x == 0.0 {
+                        DownloadFlashingStatus::Preparing
+                    } else {
+                        DownloadFlashingStatus::FlashingProgress(x)
+                    });
+                }
+            });
+
+            let resp = bb_flasher_sd::update_boot::update_boot(self.img, dst, self.cancel).await;
+
+            t.abort();
+
+            resp
+        } else {
+            bb_flasher_sd::update_boot::update_boot(self.img, dst, self.cancel).await
+        }
+        .map_err(Into::into)
+    }
+}

--- a/bb-flasher/src/img/mod.rs
+++ b/bb-flasher/src/img/mod.rs
@@ -13,6 +13,85 @@ mod test;
 
 const XZ_MAGIC: [u8; 6] = [0xfd, 0x37, 0x7a, 0x58, 0x5a, 0x00];
 
+pub struct OsArchive {
+    inner: OsArchiveCompression,
+}
+
+impl OsArchive {
+    pub fn from_path(path: &Path) -> io::Result<Self> {
+        let file = std::fs::File::open(path)?;
+        let img = OsArchiveCompression::new(OsImageSource::from(file))?;
+
+        Ok(Self { inner: img })
+    }
+}
+
+impl<'a> IntoIterator for &'a mut OsArchive {
+    type Item = (Box<str>, bb_flasher_sd::update_boot::FileType<'a>);
+    type IntoIter = Box<dyn Iterator<Item = Self::Item> + 'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        match &mut self.inner {
+            OsArchiveCompression::TarXz(archive) => {
+                Box::new(archive.entries().unwrap().flat_map(flat_map_with_log))
+            }
+            OsArchiveCompression::Tar(archive) => {
+                Box::new(archive.entries().unwrap().flat_map(flat_map_with_log))
+            }
+        }
+    }
+}
+
+fn flat_map_with_log<'a, R: Read>(
+    entry: io::Result<tar::Entry<'a, R>>,
+) -> Option<(Box<str>, bb_flasher_sd::update_boot::FileType<'a>)> {
+    match entry {
+        Ok(x) => Some(tar_entry_map(x)),
+        Err(e) => {
+            tracing::warn!("Dropping archive entry: {}", e);
+            None
+        }
+    }
+}
+
+fn tar_entry_map<'a, R: Read>(
+    entry: tar::Entry<'a, R>,
+) -> (Box<str>, bb_flasher_sd::update_boot::FileType<'a>) {
+    let p = entry
+        .path()
+        .unwrap()
+        .to_string_lossy()
+        .to_string()
+        .into_boxed_str();
+    let f = if entry.header().entry_type().is_dir() {
+        bb_flasher_sd::update_boot::FileType::Dir
+    } else {
+        bb_flasher_sd::update_boot::FileType::File(Box::new(entry))
+    };
+
+    (p, f)
+}
+
+enum OsArchiveCompression {
+    TarXz(tar::Archive<liblzma::read::XzDecoder<OsImageSource>>),
+    Tar(tar::Archive<io::BufReader<OsImageSource>>),
+}
+
+impl OsArchiveCompression {
+    fn new(mut img: OsImageSource) -> io::Result<Self> {
+        let mut magic = [0u8; 6];
+        img.read_exact(&mut magic)?;
+        img.rewind()?;
+
+        match magic {
+            XZ_MAGIC => Ok(Self::TarXz(tar::Archive::new(
+                liblzma::read::XzDecoder::new_parallel(img),
+            ))),
+            _ => Ok(Self::Tar(tar::Archive::new(io::BufReader::new(img)))),
+        }
+    }
+}
+
 pub struct OsImage {
     size: u64,
     img: OsImageCompression<OsImageSource>,

--- a/bb-flasher/src/lib.rs
+++ b/bb-flasher/src/lib.rs
@@ -47,6 +47,8 @@ pub use common::*;
 pub use flasher::*;
 pub use img::OsImage;
 
+use crate::img::OsArchive;
+
 /// An Os Image present in the local filesystem
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
@@ -74,6 +76,13 @@ impl LocalImage {
         let size = img.size();
 
         Ok((img, size))
+    }
+
+    pub async fn into_archive_future(self) -> std::io::Result<OsArchive> {
+        let p = self.0.clone();
+        tokio::task::spawn_blocking(move || OsArchive::from_path(&p))
+            .await
+            .unwrap()
     }
 }
 

--- a/bb-imager-cli/src/cli.rs
+++ b/bb-imager-cli/src/cli.rs
@@ -131,6 +131,14 @@ pub enum TargetCommands {
         /// provides. However, this will change in future. So best to explicitly set the flag.
         sysconfig: bool,
     },
+    /// Update boot partition with contents from archive
+    SdBootUpdate {
+        /// Local path to bootfs archive.
+        img: Box<Path>,
+
+        /// The destination device (e.g., `/dev/sdX` or specific device identifiers).
+        dst: PathBuf,
+    },
     /// Flash MSP430 on BeagleConnectFreedom.
     #[cfg(feature = "bcf_msp430")]
     Msp430 {

--- a/bb-imager-cli/src/main.rs
+++ b/bb-imager-cli/src/main.rs
@@ -123,6 +123,15 @@ async fn flash_internal(
     chan: Option<mpsc::Sender<DownloadFlashingStatus>>,
 ) -> anyhow::Result<()> {
     match target {
+        TargetCommands::SdBootUpdate { img, dst } => {
+            bb_flasher::sd::UpdateBootFlasher::new(
+                LocalImage::new(img).into_archive_future(),
+                dst.try_into().unwrap(),
+                None,
+            )
+            .flash(chan)
+            .await
+        }
         TargetCommands::Sd {
             dst,
             hostname,


### PR DESCRIPTION
- Basically, overwrite files on a fat32 destination.
- Does not actually create partition, so cannot be used for full flashing. But can be used for fixing/updating u-boot, and converting basic EFI based linux images to boot on beagle devices.
- Fixes #467 