### PR TITLE
bb-flasher: Make image future normal method

### DIFF
--- a/bb-flasher/src/lib.rs
+++ b/bb-flasher/src/lib.rs
@@ -65,22 +65,15 @@ impl LocalImage {
     pub fn file_name(&self) -> &std::ffi::OsStr {
         self.0.file_name().unwrap()
     }
-}
 
-impl IntoFuture for LocalImage {
-    type Output = std::io::Result<(OsImage, u64)>;
-    type IntoFuture = std::pin::Pin<Box<dyn Future<Output = Self::Output> + Send>>;
+    pub async fn into_image_future(self) -> std::io::Result<(OsImage, u64)> {
+        let p = self.0.clone();
+        let img = tokio::task::spawn_blocking(move || OsImage::from_path(&p))
+            .await
+            .unwrap()?;
+        let size = img.size();
 
-    fn into_future(self) -> Self::IntoFuture {
-        Box::pin(async move {
-            let p = self.0.clone();
-            let img = tokio::task::spawn_blocking(move || OsImage::from_path(&p))
-                .await
-                .unwrap()?;
-            let size = img.size();
-
-            Ok((img, size))
-        })
+        Ok((img, size))
     }
 }
 

--- a/bb-imager-cli/src/main.rs
+++ b/bb-imager-cli/src/main.rs
@@ -166,7 +166,7 @@ async fn flash_internal(
             }
 
             bb_flasher::sd::Flasher::new(
-                LocalImage::new(img).into_future(),
+                LocalImage::new(img).into_image_future(),
                 bmap.map(LocalStringFile::new).map(IntoFuture::into_future),
                 dst.try_into().unwrap(),
                 customization,
@@ -182,7 +182,7 @@ async fn flash_internal(
             no_verify,
         } => {
             bb_flasher::bcf::cc1352p7::Flasher::new(
-                LocalImage::new(img).into_future(),
+                LocalImage::new(img).into_image_future(),
                 dst.into(),
                 !no_verify,
                 None,
@@ -192,15 +192,21 @@ async fn flash_internal(
         }
         #[cfg(feature = "bcf_msp430")]
         TargetCommands::Msp430 { img, dst } => {
-            bb_flasher::bcf::msp430::Flasher::new(LocalImage::new(img).into_future(), dst.into())
-                .flash(chan)
-                .await
+            bb_flasher::bcf::msp430::Flasher::new(
+                LocalImage::new(img).into_image_future(),
+                dst.into(),
+            )
+            .flash(chan)
+            .await
         }
         #[cfg(feature = "pb2_mspm0")]
         TargetCommands::Pb2Mspm0 { no_eeprom, img } => {
-            bb_flasher::pb2::mspm0::Flasher::new(LocalImage::new(img).into_future(), !no_eeprom)
-                .flash(chan)
-                .await
+            bb_flasher::pb2::mspm0::Flasher::new(
+                LocalImage::new(img).into_image_future(),
+                !no_eeprom,
+            )
+            .flash(chan)
+            .await
         }
         #[cfg(feature = "dfu")]
         TargetCommands::Dfu { identifier, imgs } => {
@@ -213,7 +219,7 @@ async fn flash_internal(
                 .map(|x| {
                     (
                         x[0].to_string(),
-                        LocalImage::new(PathBuf::from(&x[1]).into()).into_future(),
+                        LocalImage::new(PathBuf::from(&x[1]).into()).into_image_future(),
                     )
                 })
                 .collect();
@@ -233,7 +239,7 @@ async fn flash_internal(
             no_verify,
         } => {
             bb_flasher::mspm0::Flasher::no_prep(
-                LocalImage::new(img).into_future(),
+                LocalImage::new(img).into_image_future(),
                 dst.into(),
                 !no_verify,
                 None,
@@ -254,7 +260,7 @@ async fn flash_internal(
         } => match (reset_gpio, bsl_gpio) {
             (Some(reset), Some(bsl)) => {
                 bb_flasher::mspm0::Flasher::gpio_by_name(
-                    LocalImage::new(img).into_future(),
+                    LocalImage::new(img).into_image_future(),
                     dst.into(),
                     !no_verify,
                     None,
@@ -266,7 +272,7 @@ async fn flash_internal(
             }
             (None, None) => {
                 bb_flasher::mspm0::Flasher::no_prep(
-                    LocalImage::new(img).into_future(),
+                    LocalImage::new(img).into_image_future(),
                     dst.into(),
                     !no_verify,
                     None,

--- a/bb-imager-gui/src/helpers.rs
+++ b/bb-imager-gui/src/helpers.rs
@@ -381,7 +381,7 @@ impl IntoFuture for SelectedImage {
 
     fn into_future(self) -> Self::IntoFuture {
         match self {
-            SelectedImage::LocalImage(x) => x.into_future(),
+            SelectedImage::LocalImage(x) => Box::pin(x.into_image_future()),
             SelectedImage::RemoteImage(x) => x.into_future(),
         }
     }


### PR DESCRIPTION
- Can use the same base type for representing archive.
- Derived from #478 