### PR TITLE
bb-flasher-sd: Inline flash_internal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -645,6 +645,7 @@ dependencies = [
  "mbrman",
  "nix 0.31.3",
  "security-framework",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,6 +639,7 @@ dependencies = [
  "bb-drivelist",
  "fatfs",
  "fscommon",
+ "futures",
  "gpt",
  "libc",
  "mbrman",
@@ -7035,6 +7036,7 @@ checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "futures-util",
  "pin-project-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ members = [
         "bb-bmap-parser"
 ]
 
-[profile.release]
-lto = true
-codegen-units = 1
+# [profile.release]
+# lto = true
+# codegen-units = 1
 
 [workspace.package]
 version = "1.0.7"

--- a/bb-flasher-sd/Cargo.toml
+++ b/bb-flasher-sd/Cargo.toml
@@ -24,6 +24,9 @@ tokio-util = { version = "0.7", features = ["io-util", "compat"] }
 anyhow = "1.0"
 futures = "0.3"
 
+[dev-dependencies]
+tempfile = "3.27"
+
 [target.'cfg(target_os = "linux")'.dependencies]
 udisks2 = { version = "0.3", optional = true }
 libc = "0.2"

--- a/bb-flasher-sd/Cargo.toml
+++ b/bb-flasher-sd/Cargo.toml
@@ -20,8 +20,9 @@ mbrman = "0.6"
 gpt = "4.1"
 bb-bmap-parser = { version = "0.1", path = "../bb-bmap-parser" }
 tokio = { version = "1.52", default-features = false, features = ["rt-multi-thread", "fs", "io-util", "macros"] }
-tokio-util = { version = "0.7", features = ["io-util"] }
+tokio-util = { version = "0.7", features = ["io-util", "compat"] }
 anyhow = "1.0"
+futures = "0.3"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 udisks2 = { version = "0.3", optional = true }

--- a/bb-flasher-sd/Cargo.toml
+++ b/bb-flasher-sd/Cargo.toml
@@ -19,18 +19,18 @@ fscommon = "0.1"
 mbrman = "0.6"
 gpt = "4.1"
 bb-bmap-parser = { version = "0.1", path = "../bb-bmap-parser" }
-tokio = { version = "1.52", default-features = false, features = ["rt-multi-thread", "fs"] }
+tokio = { version = "1.52", default-features = false, features = ["rt-multi-thread", "fs", "io-util", "macros"] }
 tokio-util = { version = "0.7" }
 anyhow = "1.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 udisks2 = { version = "0.3", optional = true }
 libc = "0.2"
-tokio = { version = "1.52", default-features = false, features = ["rt-multi-thread", "process"] }
+tokio = { version = "1.52", default-features = false, features = ["rt-multi-thread", "process", "io-util", "macros"] }
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.62", features = ["Win32", "Win32_Storage", "Win32_Storage_FileSystem", "Win32_Security", "Win32_System", "Win32_System_IO", "Win32_System_Ioctl"] }
-tokio = { version = "1.50", default-features = false, features = ["rt-multi-thread", "process", "io-util"] }
+tokio = { version = "1.50", default-features = false, features = ["rt-multi-thread", "process", "io-util", "macros"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 security-framework = { version = "3.7", optional = true }

--- a/bb-flasher-sd/Cargo.toml
+++ b/bb-flasher-sd/Cargo.toml
@@ -20,7 +20,7 @@ mbrman = "0.6"
 gpt = "4.1"
 bb-bmap-parser = { version = "0.1", path = "../bb-bmap-parser" }
 tokio = { version = "1.52", default-features = false, features = ["rt-multi-thread", "fs", "io-util", "macros"] }
-tokio-util = { version = "0.7" }
+tokio-util = { version = "0.7", features = ["io-util"] }
 anyhow = "1.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/bb-flasher-sd/src/customization.rs
+++ b/bb-flasher-sd/src/customization.rs
@@ -111,6 +111,17 @@ pub struct Customization {
 }
 
 impl Customization {
+    pub(crate) fn customize_async(
+        &self,
+        dst: impl tokio::io::AsyncRead
+        + tokio::io::AsyncSeek
+        + tokio::io::AsyncWrite
+        + std::fmt::Debug
+        + Unpin,
+    ) -> Result<()> {
+        self.customize(tokio_util::io::SyncIoBridge::new(dst))
+    }
+
     pub(crate) fn customize(&self, dst: impl Write + Seek + Read + std::fmt::Debug) -> Result<()> {
         let partition = self.partition.open(dst)?;
         let root = partition.root_dir();

--- a/bb-flasher-sd/src/customization.rs
+++ b/bb-flasher-sd/src/customization.rs
@@ -82,6 +82,8 @@ impl PartitionTable {
             return Ok(PartitionTable::Mbr);
         }
 
+        tracing::debug!("{:?}", buf);
+
         Err(crate::Error::InvalidPartitionTable)
     }
 }
@@ -111,18 +113,11 @@ pub struct Customization {
 }
 
 impl Customization {
-    pub(crate) fn customize_async(
+    pub(crate) fn customize(
         &self,
-        dst: impl tokio::io::AsyncRead
-        + tokio::io::AsyncSeek
-        + tokio::io::AsyncWrite
-        + std::fmt::Debug
-        + Unpin,
+        mut dst: impl Write + Seek + Read + std::fmt::Debug,
     ) -> Result<()> {
-        self.customize(tokio_util::io::SyncIoBridge::new(dst))
-    }
-
-    pub(crate) fn customize(&self, dst: impl Write + Seek + Read + std::fmt::Debug) -> Result<()> {
+        dst.rewind()?;
         let partition = self.partition.open(dst)?;
         let root = partition.root_dir();
 
@@ -138,10 +133,12 @@ impl Customization {
                 ContentType::File(path) => {
                     let mut source = std::fs::File::open(path)?;
                     std::io::copy(&mut source, &mut f)?;
+                    f.flush()?;
                 }
                 ContentType::Data(items) => {
                     f.seek(SeekFrom::End(0))?;
                     f.write_all(items)?;
+                    f.flush()?;
                 }
             }
         }

--- a/bb-flasher-sd/src/flashing/mod.rs
+++ b/bb-flasher-sd/src/flashing/mod.rs
@@ -1,4 +1,4 @@
-use std::io::{Read, Seek, Write};
+use std::io::Read;
 use std::time::Instant;
 
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt, AsyncWrite, AsyncWriteExt};
@@ -7,7 +7,7 @@ use tokio_util::compat::FuturesAsyncReadCompatExt;
 
 use crate::Result;
 use crate::customization::Customization;
-use crate::helpers::{DirectIoBuffer, Eject, EjectAsync, chan_send, check_token, progress};
+use crate::helpers::{DirectIoBuffer, EjectAsync, chan_send, progress};
 
 #[cfg(test)]
 mod tests;
@@ -38,81 +38,11 @@ async fn reader_task_async(
     Ok(())
 }
 
-fn reader_task(
-    mut img: impl Read,
-    buf_rx: std::sync::mpsc::Receiver<Box<DirectIoBuffer<BUFFER_SIZE>>>,
-    buf_tx: std::sync::mpsc::SyncSender<(Box<DirectIoBuffer<BUFFER_SIZE>>, usize)>,
-    cancel: Option<tokio_util::sync::CancellationToken>,
-) -> Result<()> {
-    while let Ok(mut buf) = buf_rx.recv() {
-        let count = read_aligned(&mut img, buf.as_mut_slice())?;
-        if count == 0 {
-            break;
-        }
-
-        buf_tx
-            .send((buf, count))
-            .map_err(|_| crate::Error::WriterClosed)?;
-        check_token(cancel.as_ref())?;
-    }
-
-    Ok(())
-}
-
 /// While writing, a few assumptions should hold:
 /// - All writes should be in buffers multiple of block size (4K).
 /// - All writes should be aligned to block size (4K).
 ///
 /// Thus, we will be writing some data that is not strictly present in the bmap.
-fn writer_task_bmap(
-    bmap: bb_bmap_parser::Bmap,
-    mut sd: impl Write + Seek,
-    mut chan: Option<&mut mpsc::Sender<f32>>,
-    buf_rx: std::sync::mpsc::Receiver<(Box<DirectIoBuffer<BUFFER_SIZE>>, usize)>,
-    buf_tx: std::sync::mpsc::SyncSender<Box<DirectIoBuffer<BUFFER_SIZE>>>,
-    cancel: Option<tokio_util::sync::CancellationToken>,
-) -> Result<()> {
-    let mut pos = 0;
-    let (mut buf, mut count) = buf_rx.recv().unwrap();
-    let img_size = bmap.total_mapped_size();
-    let mut bytes_written = 0u64;
-
-    for b in bmap.block_map() {
-        let end_offset = b.offset() + b.length();
-
-        loop {
-            // Write any buffer that lies even partially in the bmap range.
-            if pos + (count as u64) > b.offset() && pos < end_offset {
-                sd.seek(std::io::SeekFrom::Start(pos))?;
-                sd.write_all(&buf.as_slice()[..count])?;
-                bytes_written += count as u64;
-            } else if pos >= end_offset {
-                break;
-            }
-
-            pos += count as u64;
-            // Clippy warning is simply wrong here
-            #[allow(clippy::option_map_or_none)]
-            chan_send(
-                chan.as_mut().map_or(None, |p| Some(p)),
-                progress(bytes_written, img_size),
-            );
-            check_token(cancel.as_ref())?;
-
-            match buf_rx.recv() {
-                Ok((x, y)) => {
-                    let _ = buf_tx.send(buf);
-                    buf = x;
-                    count = y;
-                }
-                Err(_) => break,
-            }
-        }
-    }
-
-    sd.flush().map_err(Into::into)
-}
-
 async fn writer_task_bmap_async<Sd>(
     bmap: bb_bmap_parser::Bmap,
     mut sd: Sd,
@@ -132,6 +62,12 @@ where
         let end_offset = b.offset() + b.length();
 
         loop {
+            tracing::debug!(
+                "pos: {}, bytes_written: {}, end_offset: {}",
+                pos,
+                bytes_written,
+                end_offset
+            );
             // Write any buffer that lies even partially in the bmap range.
             if pos + (count as u64) > b.offset() && pos < end_offset {
                 sd.seek(std::io::SeekFrom::Start(pos)).await?;
@@ -163,34 +99,6 @@ where
     sd.flush().await?;
 
     Ok(sd)
-}
-
-fn writer_task(
-    img_size: u64,
-    mut sd: impl Write + Seek,
-    mut chan: Option<&mut mpsc::Sender<f32>>,
-    buf_rx: std::sync::mpsc::Receiver<(Box<DirectIoBuffer<BUFFER_SIZE>>, usize)>,
-    buf_tx: std::sync::mpsc::SyncSender<Box<DirectIoBuffer<BUFFER_SIZE>>>,
-    cancel: Option<tokio_util::sync::CancellationToken>,
-) -> Result<()> {
-    let mut pos = 0u64;
-
-    while let Ok((buf, count)) = buf_rx.recv() {
-        sd.write_all(&buf.as_slice()[..count])?;
-
-        pos += count as u64;
-        // Clippy warning is simply wrong here
-        #[allow(clippy::option_map_or_none)]
-        chan_send(
-            chan.as_mut().map_or(None, |p| Some(p)),
-            progress(pos, img_size),
-        );
-
-        let _ = buf_tx.send(buf);
-        check_token(cancel.as_ref())?;
-    }
-
-    sd.flush().map_err(Into::into)
 }
 
 async fn writer_task_async<Sd>(
@@ -226,27 +134,6 @@ where
 
 /// A lot of reads from compressed files are not aligned. Since reading even from compressed files
 /// is significantly faster than writing to SD Card, better to do multiple reads.
-fn read_aligned(mut img: impl Read, buf: &mut [u8]) -> Result<usize> {
-    const ALIGNMENT: usize = 512;
-
-    let mut pos = 0;
-
-    while pos != buf.len() {
-        let count = img.read(&mut buf[pos..])?;
-        if count == 0 {
-            if pos % ALIGNMENT != 0 {
-                let end = pos - pos % ALIGNMENT + ALIGNMENT;
-                buf[pos..end].fill(0);
-                pos = end;
-            }
-            return Ok(pos);
-        }
-        pos += count;
-    }
-
-    Ok(pos)
-}
-
 async fn read_aligned_async(mut img: impl AsyncRead + Unpin, buf: &mut [u8]) -> Result<usize> {
     const ALIGNMENT: usize = 512;
 
@@ -266,39 +153,6 @@ async fn read_aligned_async(mut img: impl AsyncRead + Unpin, buf: &mut [u8]) -> 
     }
 
     Ok(pos)
-}
-
-fn write_sd(
-    img: impl Read + Send,
-    img_size: u64,
-    bmap: Option<bb_bmap_parser::Bmap>,
-    sd: impl Write + Seek,
-    chan: Option<&mut mpsc::Sender<f32>>,
-    cancel: Option<tokio_util::sync::CancellationToken>,
-) -> Result<()> {
-    const NUM_BUFFERS: usize = 4;
-
-    let (tx1, rx1) = std::sync::mpsc::sync_channel(NUM_BUFFERS);
-    let (tx2, rx2) = std::sync::mpsc::sync_channel(NUM_BUFFERS);
-    let global_start = Instant::now();
-
-    // Starting buffers
-    for _ in 0..NUM_BUFFERS {
-        tx1.send(Box::new(DirectIoBuffer::new())).unwrap();
-    }
-
-    std::thread::scope(|s| {
-        let cancle_clone = cancel.clone();
-        let handle = s.spawn(move || reader_task(img, rx1, tx2, cancle_clone));
-
-        match bmap {
-            Some(x) => writer_task_bmap(x, sd, chan, rx2, tx1, cancel),
-            None => writer_task(img_size, sd, chan, rx2, tx1, cancel),
-        }?;
-        tracing::info!("Total Time taken: {:?}", global_start.elapsed());
-
-        handle.join().unwrap()
-    })
 }
 
 async fn write_sd_async<Sd>(
@@ -436,61 +290,6 @@ pub async fn flash_async<R: AsyncRead + Send + Unpin + 'static>(
             flash_internal_async(img, bmap, sd, chan, customizations).await
         }
     }
-}
-
-async fn flash_internal<R: Read + Send + 'static>(
-    img: impl Future<Output = std::io::Result<(R, u64)>>,
-    bmap: Option<impl Future<Output = std::io::Result<Box<str>>>>,
-    sd: impl Read + Write + Seek + Eject + std::fmt::Debug + Send + 'static,
-    mut chan: Option<mpsc::Sender<f32>>,
-    customizations: Vec<Customization>,
-    cancel: Option<tokio_util::sync::CancellationToken>,
-) -> Result<()> {
-    tracing::info!("Resolving Image");
-    let bmap = match bmap {
-        Some(x) => {
-            Some(bb_bmap_parser::Bmap::from_xml(&x.await?).map_err(|_| crate::Error::InvalidBmap)?)
-        }
-        None => None,
-    };
-    let (img, img_size) = img.await?;
-
-    let cancel_child = cancel.as_ref().map(|x| x.child_token());
-    let res = tokio::task::spawn_blocking(move || {
-        chan_send(chan.as_mut(), 0.0);
-
-        let mut sd = crate::helpers::SdCardWrapper::new(sd);
-
-        tracing::info!("Writing to SD Card");
-        write_sd(
-            img,
-            img_size,
-            bmap,
-            &mut sd,
-            chan.as_mut(),
-            cancel_child.clone(),
-        )?;
-
-        check_token(cancel_child.as_ref())?;
-
-        tracing::info!("Applying customization");
-        for c in customizations {
-            let temp = crate::helpers::DeviceWrapper::new(&mut sd).unwrap();
-            c.customize(temp)?;
-        }
-
-        tracing::info!("Ejecting SD Card");
-        let _ = sd.eject();
-
-        Ok(())
-    })
-    .await
-    .unwrap();
-
-    // Cancel all tasks on drop
-    let _drop_guard = cancel.map(|x| x.drop_guard());
-
-    res
 }
 
 async fn flash_internal_async<R: AsyncRead + Send + Unpin + 'static>(

--- a/bb-flasher-sd/src/flashing/mod.rs
+++ b/bb-flasher-sd/src/flashing/mod.rs
@@ -1,6 +1,7 @@
 use std::io::{Read, Seek, Write};
 use std::time::Instant;
 
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt, AsyncWrite, AsyncWriteExt};
 use tokio::sync::mpsc;
 
 use crate::Result;
@@ -15,6 +16,26 @@ mod tests;
 const BUFFER_SIZE: usize = 1 * 1024 * 1024;
 #[cfg(debug_assertions)]
 const BUFFER_SIZE: usize = 8 * 1024;
+
+async fn reader_task_async(
+    mut img: impl AsyncRead + Unpin,
+    mut buf_rx: mpsc::Receiver<Box<DirectIoBuffer<BUFFER_SIZE>>>,
+    buf_tx: mpsc::Sender<(Box<DirectIoBuffer<BUFFER_SIZE>>, usize)>,
+) -> Result<()> {
+    while let Some(mut buf) = buf_rx.recv().await {
+        let count = read_aligned_async(&mut img, buf.as_mut_slice()).await?;
+        if count == 0 {
+            break;
+        }
+
+        buf_tx
+            .send((buf, count))
+            .await
+            .map_err(|_| crate::Error::WriterClosed)?;
+    }
+
+    Ok(())
+}
 
 fn reader_task(
     mut img: impl Read,
@@ -91,6 +112,58 @@ fn writer_task_bmap(
     sd.flush().map_err(Into::into)
 }
 
+async fn writer_task_bmap_async<Sd>(
+    bmap: bb_bmap_parser::Bmap,
+    mut sd: Sd,
+    mut chan: Option<mpsc::Sender<f32>>,
+    mut buf_rx: mpsc::Receiver<(Box<DirectIoBuffer<BUFFER_SIZE>>, usize)>,
+    buf_tx: mpsc::Sender<Box<DirectIoBuffer<BUFFER_SIZE>>>,
+) -> Result<Sd>
+where
+    Sd: AsyncWrite + AsyncSeek + Unpin,
+{
+    let mut pos = 0;
+    let (mut buf, mut count) = buf_rx.recv().await.unwrap();
+    let img_size = bmap.total_mapped_size();
+    let mut bytes_written = 0u64;
+
+    for b in bmap.block_map() {
+        let end_offset = b.offset() + b.length();
+
+        loop {
+            // Write any buffer that lies even partially in the bmap range.
+            if pos + (count as u64) > b.offset() && pos < end_offset {
+                sd.seek(std::io::SeekFrom::Start(pos)).await?;
+                sd.write_all(&buf.as_slice()[..count]).await?;
+                bytes_written += count as u64;
+            } else if pos >= end_offset {
+                break;
+            }
+
+            pos += count as u64;
+            // Clippy warning is simply wrong here
+            #[allow(clippy::option_map_or_none)]
+            chan_send(
+                chan.as_mut().map_or(None, |p| Some(p)),
+                progress(bytes_written, img_size),
+            );
+
+            match buf_rx.recv().await {
+                Some((x, y)) => {
+                    let _ = buf_tx.send(buf).await;
+                    buf = x;
+                    count = y;
+                }
+                None => break,
+            }
+        }
+    }
+
+    sd.flush().await?;
+
+    Ok(sd)
+}
+
 fn writer_task(
     img_size: u64,
     mut sd: impl Write + Seek,
@@ -119,6 +192,37 @@ fn writer_task(
     sd.flush().map_err(Into::into)
 }
 
+async fn writer_task_async<Sd>(
+    img_size: u64,
+    mut sd: Sd,
+    mut chan: Option<mpsc::Sender<f32>>,
+    mut buf_rx: mpsc::Receiver<(Box<DirectIoBuffer<BUFFER_SIZE>>, usize)>,
+    buf_tx: mpsc::Sender<Box<DirectIoBuffer<BUFFER_SIZE>>>,
+) -> Result<Sd>
+where
+    Sd: AsyncWrite + Unpin,
+{
+    let mut pos = 0u64;
+
+    while let Some((buf, count)) = buf_rx.recv().await {
+        sd.write_all(&buf.as_slice()[..count]).await?;
+
+        pos += count as u64;
+        // Clippy warning is simply wrong here
+        #[allow(clippy::option_map_or_none)]
+        chan_send(
+            chan.as_mut().map_or(None, |p| Some(p)),
+            progress(pos, img_size),
+        );
+
+        let _ = buf_tx.send(buf).await;
+    }
+
+    sd.flush().await?;
+
+    Ok(sd)
+}
+
 /// A lot of reads from compressed files are not aligned. Since reading even from compressed files
 /// is significantly faster than writing to SD Card, better to do multiple reads.
 fn read_aligned(mut img: impl Read, buf: &mut [u8]) -> Result<usize> {
@@ -128,6 +232,27 @@ fn read_aligned(mut img: impl Read, buf: &mut [u8]) -> Result<usize> {
 
     while pos != buf.len() {
         let count = img.read(&mut buf[pos..])?;
+        if count == 0 {
+            if pos % ALIGNMENT != 0 {
+                let end = pos - pos % ALIGNMENT + ALIGNMENT;
+                buf[pos..end].fill(0);
+                pos = end;
+            }
+            return Ok(pos);
+        }
+        pos += count;
+    }
+
+    Ok(pos)
+}
+
+async fn read_aligned_async(mut img: impl AsyncRead + Unpin, buf: &mut [u8]) -> Result<usize> {
+    const ALIGNMENT: usize = 512;
+
+    let mut pos = 0;
+
+    while pos != buf.len() {
+        let count = img.read(&mut buf[pos..]).await?;
         if count == 0 {
             if pos % ALIGNMENT != 0 {
                 let end = pos - pos % ALIGNMENT + ALIGNMENT;
@@ -173,6 +298,65 @@ fn write_sd(
 
         handle.join().unwrap()
     })
+}
+
+async fn write_sd_async<Sd>(
+    img: impl AsyncRead + Unpin + Send + 'static,
+    img_size: u64,
+    bmap: Option<bb_bmap_parser::Bmap>,
+    sd: Sd,
+    mut chan: Option<mpsc::Sender<f32>>,
+) -> Result<Sd>
+where
+    Sd: AsyncWrite + AsyncSeek + Unpin + Send + 'static,
+{
+    const NUM_BUFFERS: usize = 4;
+
+    let (tx1, rx1) = mpsc::channel(NUM_BUFFERS);
+    let (tx2, rx2) = mpsc::channel(NUM_BUFFERS);
+    let global_start = Instant::now();
+
+    // Starting buffers
+    for _ in 0..NUM_BUFFERS {
+        tx1.send(Box::new(DirectIoBuffer::new())).await.unwrap();
+    }
+
+    let mut reader = tokio::spawn(reader_task_async(img, rx1, tx2));
+    let mut writer = match bmap {
+        Some(x) => tokio::spawn(writer_task_bmap_async(x, sd, chan, rx2, tx1)),
+        None => tokio::spawn(writer_task_async(img_size, sd, chan, rx2, tx1)),
+    };
+
+    let res = tokio::select! {
+        r = &mut reader => {
+            match r.unwrap() {
+                Ok(()) => {
+                    writer.await.unwrap()
+                }
+                Err(e) => {
+                    writer.abort();
+                    Err(e)
+                }
+            }
+        }
+
+        r = &mut writer => {
+            match r.unwrap() {
+                Ok(sd) => {
+                    reader.await.unwrap()?;
+                    Ok(sd)
+                }
+                Err(e) => {
+                    reader.abort();
+                    Err(e)
+                }
+            }
+        }
+    };
+
+    tracing::info!("Total Time taken: {:?}", global_start.elapsed());
+
+    res
 }
 
 /// Flash OS image to SD card.

--- a/bb-flasher-sd/src/flashing/mod.rs
+++ b/bb-flasher-sd/src/flashing/mod.rs
@@ -224,20 +224,20 @@ pub async fn flash<R: Read + Send + 'static>(
                 .await?
                 .into_std()
                 .await;
-            flash_common(img, bmap, sd, chan, customizations, cancel).await
+            flash_internal(img, bmap, sd, chan, customizations, cancel).await
         }
         crate::Destination::SdCard(path) => {
             let sd = crate::pal::open(&path).await?;
-            flash_common(img, bmap, sd, chan, customizations, cancel).await
+            flash_internal(img, bmap, sd, chan, customizations, cancel).await
         }
     }
 }
 
-async fn flash_common<R: Read + Send + 'static>(
+async fn flash_internal<R: Read + Send + 'static>(
     img: impl Future<Output = std::io::Result<(R, u64)>>,
     bmap: Option<impl Future<Output = std::io::Result<Box<str>>>>,
     sd: impl Read + Write + Seek + Eject + std::fmt::Debug + Send + 'static,
-    chan: Option<mpsc::Sender<f32>>,
+    mut chan: Option<mpsc::Sender<f32>>,
     customizations: Vec<Customization>,
     cancel: Option<tokio_util::sync::CancellationToken>,
 ) -> Result<()> {
@@ -252,7 +252,32 @@ async fn flash_common<R: Read + Send + 'static>(
 
     let cancel_child = cancel.as_ref().map(|x| x.child_token());
     let res = tokio::task::spawn_blocking(move || {
-        flash_internal(img, img_size, bmap, sd, chan, customizations, cancel_child)
+        chan_send(chan.as_mut(), 0.0);
+
+        let mut sd = crate::helpers::SdCardWrapper::new(sd);
+
+        tracing::info!("Writing to SD Card");
+        write_sd(
+            img,
+            img_size,
+            bmap,
+            &mut sd,
+            chan.as_mut(),
+            cancel_child.clone(),
+        )?;
+
+        check_token(cancel_child.as_ref())?;
+
+        tracing::info!("Applying customization");
+        for c in customizations {
+            let temp = crate::helpers::DeviceWrapper::new(&mut sd).unwrap();
+            c.customize(temp)?;
+        }
+
+        tracing::info!("Ejecting SD Card");
+        let _ = sd.eject();
+
+        Ok(())
     })
     .await
     .unwrap();
@@ -261,34 +286,4 @@ async fn flash_common<R: Read + Send + 'static>(
     let _drop_guard = cancel.map(|x| x.drop_guard());
 
     res
-}
-
-fn flash_internal(
-    img: impl Read + Send,
-    img_size: u64,
-    bmap: Option<bb_bmap_parser::Bmap>,
-    sd: impl Read + Write + Seek + Eject + std::fmt::Debug,
-    mut chan: Option<mpsc::Sender<f32>>,
-    customizations: Vec<Customization>,
-    cancel: Option<tokio_util::sync::CancellationToken>,
-) -> Result<()> {
-    chan_send(chan.as_mut(), 0.0);
-
-    let mut sd = crate::helpers::SdCardWrapper::new(sd);
-
-    tracing::info!("Writing to SD Card");
-    write_sd(img, img_size, bmap, &mut sd, chan.as_mut(), cancel.clone())?;
-
-    check_token(cancel.as_ref())?;
-
-    tracing::info!("Applying customization");
-    for c in customizations {
-        let temp = crate::helpers::DeviceWrapper::new(&mut sd).unwrap();
-        c.customize(temp)?;
-    }
-
-    tracing::info!("Ejecting SD Card");
-    let _ = sd.eject();
-
-    Ok(())
 }

--- a/bb-flasher-sd/src/flashing/mod.rs
+++ b/bb-flasher-sd/src/flashing/mod.rs
@@ -7,7 +7,7 @@ use tokio_util::compat::FuturesAsyncReadCompatExt;
 
 use crate::Result;
 use crate::customization::Customization;
-use crate::helpers::{DirectIoBuffer, EjectAsync, chan_send, progress};
+use crate::helpers::{DirectIoBuffer, Eject, chan_send, progress};
 
 #[cfg(test)]
 mod tests;
@@ -18,13 +18,13 @@ const BUFFER_SIZE: usize = 1 * 1024 * 1024;
 #[cfg(debug_assertions)]
 const BUFFER_SIZE: usize = 8 * 1024;
 
-async fn reader_task_async(
+async fn reader_task(
     mut img: impl AsyncRead + Unpin,
     mut buf_rx: mpsc::Receiver<Box<DirectIoBuffer<BUFFER_SIZE>>>,
     buf_tx: mpsc::Sender<(Box<DirectIoBuffer<BUFFER_SIZE>>, usize)>,
 ) -> Result<()> {
     while let Some(mut buf) = buf_rx.recv().await {
-        let count = read_aligned_async(&mut img, buf.as_mut_slice()).await?;
+        let count = read_aligned(&mut img, buf.as_mut_slice()).await?;
         if count == 0 {
             break;
         }
@@ -43,7 +43,7 @@ async fn reader_task_async(
 /// - All writes should be aligned to block size (4K).
 ///
 /// Thus, we will be writing some data that is not strictly present in the bmap.
-async fn writer_task_bmap_async<Sd>(
+async fn writer_task_bmap<Sd>(
     bmap: bb_bmap_parser::Bmap,
     mut sd: Sd,
     mut chan: Option<mpsc::Sender<f32>>,
@@ -101,7 +101,7 @@ where
     Ok(sd)
 }
 
-async fn writer_task_async<Sd>(
+async fn writer_task<Sd>(
     img_size: u64,
     mut sd: Sd,
     mut chan: Option<mpsc::Sender<f32>>,
@@ -134,7 +134,7 @@ where
 
 /// A lot of reads from compressed files are not aligned. Since reading even from compressed files
 /// is significantly faster than writing to SD Card, better to do multiple reads.
-async fn read_aligned_async(mut img: impl AsyncRead + Unpin, buf: &mut [u8]) -> Result<usize> {
+async fn read_aligned(mut img: impl AsyncRead + Unpin, buf: &mut [u8]) -> Result<usize> {
     const ALIGNMENT: usize = 512;
 
     let mut pos = 0;
@@ -155,7 +155,7 @@ async fn read_aligned_async(mut img: impl AsyncRead + Unpin, buf: &mut [u8]) -> 
     Ok(pos)
 }
 
-async fn write_sd_async<Sd>(
+async fn write_sd<Sd>(
     img: impl AsyncRead + Unpin + Send + 'static,
     img_size: u64,
     bmap: Option<bb_bmap_parser::Bmap>,
@@ -176,10 +176,10 @@ where
         tx1.send(Box::new(DirectIoBuffer::new())).await.unwrap();
     }
 
-    let mut reader = tokio::spawn(reader_task_async(img, rx1, tx2));
+    let mut reader = tokio::spawn(reader_task(img, rx1, tx2));
     let mut writer = match bmap {
-        Some(x) => tokio::spawn(writer_task_bmap_async(x, sd, chan, rx2, tx1)),
-        None => tokio::spawn(writer_task_async(img_size, sd, chan, rx2, tx1)),
+        Some(x) => tokio::spawn(writer_task_bmap(x, sd, chan, rx2, tx1)),
+        None => tokio::spawn(writer_task(img_size, sd, chan, rx2, tx1)),
     };
 
     let res = tokio::select! {
@@ -283,19 +283,19 @@ pub async fn flash_async<R: AsyncRead + Send + Unpin + 'static>(
                 .truncate(true)
                 .open(path)
                 .await?;
-            flash_internal_async(img, bmap, sd, chan, customizations).await
+            flash_internal(img, bmap, sd, chan, customizations).await
         }
         crate::Destination::SdCard(path) => {
             let sd = crate::pal::open(&path).await?;
-            flash_internal_async(img, bmap, sd, chan, customizations).await
+            flash_internal(img, bmap, sd, chan, customizations).await
         }
     }
 }
 
-async fn flash_internal_async<R: AsyncRead + Send + Unpin + 'static>(
+async fn flash_internal<R: AsyncRead + Send + Unpin + 'static>(
     img: impl Future<Output = std::io::Result<(R, u64)>>,
     bmap: Option<impl Future<Output = std::io::Result<Box<str>>>>,
-    sd: impl AsyncRead + AsyncWrite + AsyncSeek + EjectAsync + std::fmt::Debug + Send + Unpin + 'static,
+    sd: impl AsyncRead + AsyncWrite + AsyncSeek + Eject + std::fmt::Debug + Send + Unpin + 'static,
     mut chan: Option<mpsc::Sender<f32>>,
     customizations: Vec<Customization>,
 ) -> Result<()> {
@@ -310,13 +310,13 @@ async fn flash_internal_async<R: AsyncRead + Send + Unpin + 'static>(
 
     chan_send(chan.as_mut(), 0.0);
 
-    let sd = crate::helpers::SdCardWrapperAsync::new(sd);
+    let sd = crate::helpers::SdCardWrapper::new(sd);
 
     tracing::info!("Writing to SD Card");
-    let sd = write_sd_async(img, img_size, bmap, sd, chan).await?;
+    let sd = write_sd(img, img_size, bmap, sd, chan).await?;
 
     tracing::info!("Applying customization");
-    let mut temp = crate::helpers::DeviceWrapperAsync::new(sd).await.unwrap();
+    let mut temp = crate::helpers::DeviceWrapper::new(sd).await.unwrap();
     let sd = tokio::task::spawn_blocking(move || {
         for c in customizations {
             c.customize_async(&mut temp)?;

--- a/bb-flasher-sd/src/flashing/mod.rs
+++ b/bb-flasher-sd/src/flashing/mod.rs
@@ -6,7 +6,7 @@ use tokio::sync::mpsc;
 
 use crate::Result;
 use crate::customization::Customization;
-use crate::helpers::{DirectIoBuffer, Eject, chan_send, check_token, progress};
+use crate::helpers::{DirectIoBuffer, Eject, EjectAsync, chan_send, check_token, progress};
 
 #[cfg(test)]
 mod tests;
@@ -417,6 +417,33 @@ pub async fn flash<R: Read + Send + 'static>(
     }
 }
 
+pub async fn flash_async<R: AsyncRead + Send + Unpin + 'static>(
+    img: impl Future<Output = std::io::Result<(R, u64)>>,
+    bmap: Option<impl Future<Output = std::io::Result<Box<str>>>>,
+    dst: crate::Destination,
+    chan: Option<mpsc::Sender<f32>>,
+    customizations: Vec<Customization>,
+) -> Result<()> {
+    tracing::info!("Opening Destination");
+
+    match dst {
+        crate::Destination::File(path) => {
+            let sd = tokio::fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .open(path)
+                .await?;
+            flash_internal_async(img, bmap, sd, chan, customizations).await
+        }
+        crate::Destination::SdCard(path) => {
+            let sd = crate::pal::open(&path).await?;
+            flash_internal_async(img, bmap, sd, chan, customizations).await
+        }
+    }
+}
+
 async fn flash_internal<R: Read + Send + 'static>(
     img: impl Future<Output = std::io::Result<(R, u64)>>,
     bmap: Option<impl Future<Output = std::io::Result<Box<str>>>>,
@@ -470,4 +497,41 @@ async fn flash_internal<R: Read + Send + 'static>(
     let _drop_guard = cancel.map(|x| x.drop_guard());
 
     res
+}
+
+async fn flash_internal_async<R: AsyncRead + Send + Unpin + 'static>(
+    img: impl Future<Output = std::io::Result<(R, u64)>>,
+    bmap: Option<impl Future<Output = std::io::Result<Box<str>>>>,
+    sd: impl AsyncRead + AsyncWrite + AsyncSeek + EjectAsync + std::fmt::Debug + Send + Unpin + 'static,
+    mut chan: Option<mpsc::Sender<f32>>,
+    customizations: Vec<Customization>,
+) -> Result<()> {
+    tracing::info!("Resolving Image");
+    let bmap = match bmap {
+        Some(x) => {
+            Some(bb_bmap_parser::Bmap::from_xml(&x.await?).map_err(|_| crate::Error::InvalidBmap)?)
+        }
+        None => None,
+    };
+    let (img, img_size) = img.await?;
+
+    chan_send(chan.as_mut(), 0.0);
+
+    let sd = crate::helpers::SdCardWrapperAsync::new(sd);
+
+    tracing::info!("Writing to SD Card");
+    let mut sd = write_sd_async(img, img_size, bmap, sd, chan).await?;
+
+    tracing::info!("Applying customization");
+    for c in customizations {
+        let temp = crate::helpers::DeviceWrapperAsync::new(&mut sd)
+            .await
+            .unwrap();
+        c.customize_async(temp)?;
+    }
+
+    tracing::info!("Ejecting SD Card");
+    let _ = sd.eject().await;
+
+    Ok(())
 }

--- a/bb-flasher-sd/src/flashing/mod.rs
+++ b/bb-flasher-sd/src/flashing/mod.rs
@@ -3,6 +3,7 @@ use std::time::Instant;
 
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt, AsyncWrite, AsyncWriteExt};
 use tokio::sync::mpsc;
+use tokio_util::compat::FuturesAsyncReadCompatExt;
 
 use crate::Result;
 use crate::customization::Customization;
@@ -305,7 +306,7 @@ async fn write_sd_async<Sd>(
     img_size: u64,
     bmap: Option<bb_bmap_parser::Bmap>,
     sd: Sd,
-    mut chan: Option<mpsc::Sender<f32>>,
+    chan: Option<mpsc::Sender<f32>>,
 ) -> Result<Sd>
 where
     Sd: AsyncWrite + AsyncSeek + Unpin + Send + 'static,
@@ -335,6 +336,7 @@ where
                 }
                 Err(e) => {
                     writer.abort();
+                    tracing::error!("Reader failed");
                     Err(e)
                 }
             }
@@ -348,6 +350,7 @@ where
                 }
                 Err(e) => {
                     reader.abort();
+                    tracing::error!("Writer failed");
                     Err(e)
                 }
             }
@@ -393,28 +396,19 @@ pub async fn flash<R: Read + Send + 'static>(
     dst: crate::Destination,
     chan: Option<mpsc::Sender<f32>>,
     customizations: Vec<Customization>,
-    cancel: Option<tokio_util::sync::CancellationToken>,
+    _cancel: Option<tokio_util::sync::CancellationToken>,
 ) -> Result<()> {
-    tracing::info!("Opening Destination");
-
-    match dst {
-        crate::Destination::File(path) => {
-            let sd = tokio::fs::OpenOptions::new()
-                .read(true)
-                .write(true)
-                .create(true)
-                .truncate(true)
-                .open(path)
-                .await?
-                .into_std()
-                .await;
-            flash_internal(img, bmap, sd, chan, customizations, cancel).await
-        }
-        crate::Destination::SdCard(path) => {
-            let sd = crate::pal::open(&path).await?;
-            flash_internal(img, bmap, sd, chan, customizations, cancel).await
-        }
-    }
+    flash_async(
+        async move {
+            img.await
+                .map(|(r, size)| (futures::io::AllowStdIo::new(r).compat(), size))
+        },
+        bmap,
+        dst,
+        chan,
+        customizations,
+    )
+    .await
 }
 
 pub async fn flash_async<R: AsyncRead + Send + Unpin + 'static>(

--- a/bb-flasher-sd/src/flashing/mod.rs
+++ b/bb-flasher-sd/src/flashing/mod.rs
@@ -287,6 +287,7 @@ pub async fn flash_async<R: AsyncRead + Send + Unpin + 'static>(
         }
         crate::Destination::SdCard(path) => {
             let sd = crate::pal::open(&path).await?;
+            let sd = crate::helpers::SdCardWrapper::new(sd);
             flash_internal(img, bmap, sd, chan, customizations).await
         }
     }
@@ -310,24 +311,23 @@ async fn flash_internal<R: AsyncRead + Send + Unpin + 'static>(
 
     chan_send(chan.as_mut(), 0.0);
 
-    let sd = crate::helpers::SdCardWrapper::new(sd);
-
     tracing::info!("Writing to SD Card");
     let sd = write_sd(img, img_size, bmap, sd, chan).await?;
 
     tracing::info!("Applying customization");
-    let mut temp = crate::helpers::DeviceWrapper::new(sd).await.unwrap();
+    let sd = crate::helpers::DeviceWrapper::new(sd).await.unwrap();
+    let mut sd = tokio_util::io::SyncIoBridge::new(sd);
     let sd = tokio::task::spawn_blocking(move || {
         for c in customizations {
-            c.customize_async(&mut temp)?;
+            c.customize(&mut sd)?;
         }
-        Ok::<_, crate::Error>(temp)
+        Ok::<_, crate::Error>(sd)
     })
     .await
     .unwrap()?;
 
     tracing::info!("Ejecting SD Card");
-    let _ = sd.eject().await;
+    let _ = sd.into_inner().eject().await;
 
     Ok(())
 }

--- a/bb-flasher-sd/src/flashing/mod.rs
+++ b/bb-flasher-sd/src/flashing/mod.rs
@@ -313,15 +313,18 @@ async fn flash_internal_async<R: AsyncRead + Send + Unpin + 'static>(
     let sd = crate::helpers::SdCardWrapperAsync::new(sd);
 
     tracing::info!("Writing to SD Card");
-    let mut sd = write_sd_async(img, img_size, bmap, sd, chan).await?;
+    let sd = write_sd_async(img, img_size, bmap, sd, chan).await?;
 
     tracing::info!("Applying customization");
-    for c in customizations {
-        let temp = crate::helpers::DeviceWrapperAsync::new(&mut sd)
-            .await
-            .unwrap();
-        c.customize_async(temp)?;
-    }
+    let mut temp = crate::helpers::DeviceWrapperAsync::new(sd).await.unwrap();
+    let sd = tokio::task::spawn_blocking(move || {
+        for c in customizations {
+            c.customize_async(&mut temp)?;
+        }
+        Ok::<_, crate::Error>(temp)
+    })
+    .await
+    .unwrap()?;
 
     tracing::info!("Ejecting SD Card");
     let _ = sd.eject().await;

--- a/bb-flasher-sd/src/flashing/tests.rs
+++ b/bb-flasher-sd/src/flashing/tests.rs
@@ -1,6 +1,6 @@
-use crate::flashing::{BUFFER_SIZE, read_aligned_async};
+use crate::flashing::{BUFFER_SIZE, read_aligned};
 
-use super::write_sd_async;
+use super::write_sd;
 
 fn test_file(len: usize) -> std::io::Cursor<Box<[u8]>> {
     let data: Vec<u8> = (0..len)
@@ -17,7 +17,7 @@ async fn sd_write() {
     let dummy_file = test_file(FILE_LEN);
     let sd = std::io::Cursor::new(Vec::<u8>::new());
 
-    let sd = write_sd_async(dummy_file.clone(), FILE_LEN as u64, None, sd, None)
+    let sd = write_sd(dummy_file.clone(), FILE_LEN as u64, None, sd, None)
         .await
         .unwrap();
 
@@ -51,7 +51,7 @@ async fn sd_write_bmap() {
 
     let bmap = bmap.build().unwrap();
 
-    let sd = write_sd_async(
+    let sd = write_sd(
         dummy_file.clone(),
         FILE_LEN as u64,
         Some(bmap.clone()),
@@ -87,7 +87,7 @@ async fn aligned_read() {
     let mut pos = 0;
 
     loop {
-        let count = read_aligned_async(&mut dummy_file, &mut buf).await.unwrap();
+        let count = read_aligned(&mut dummy_file, &mut buf).await.unwrap();
         if count == 0 {
             break;
         }

--- a/bb-flasher-sd/src/flashing/tests.rs
+++ b/bb-flasher-sd/src/flashing/tests.rs
@@ -1,6 +1,6 @@
-use crate::flashing::{BUFFER_SIZE, read_aligned};
+use crate::flashing::{BUFFER_SIZE, read_aligned_async};
 
-use super::write_sd;
+use super::write_sd_async;
 
 fn test_file(len: usize) -> std::io::Cursor<Box<[u8]>> {
     let data: Vec<u8> = (0..len)
@@ -10,35 +10,29 @@ fn test_file(len: usize) -> std::io::Cursor<Box<[u8]>> {
     std::io::Cursor::new(data.into())
 }
 
-#[test]
-fn sd_write() {
+#[tokio::test]
+async fn sd_write() {
     const FILE_LEN: usize = 12 * 1024;
 
     let dummy_file = test_file(FILE_LEN);
-    let mut sd = std::io::Cursor::new(Vec::<u8>::new());
+    let sd = std::io::Cursor::new(Vec::<u8>::new());
 
-    write_sd(
-        dummy_file.clone(),
-        FILE_LEN as u64,
-        None,
-        &mut sd,
-        None,
-        None,
-    )
-    .unwrap();
+    let sd = write_sd_async(dummy_file.clone(), FILE_LEN as u64, None, sd, None)
+        .await
+        .unwrap();
 
     assert_eq!(sd.get_ref().as_slice(), dummy_file.get_ref().as_ref());
 }
 
-#[test]
-fn sd_write_bmap() {
+#[tokio::test]
+async fn sd_write_bmap() {
     const BLOCK_LEN: u64 = BUFFER_SIZE as u64;
     const FILE_LEN: usize = 32 * BUFFER_SIZE;
     const BLOCKS: u64 = (FILE_LEN as u64) / BLOCK_LEN;
     const MAPPED_BLOCKS: &[u64] = &[0, 2, BLOCKS - 1];
 
     let dummy_file = test_file(FILE_LEN);
-    let mut sd = std::io::Cursor::new(vec![0u8; FILE_LEN]);
+    let sd = std::io::Cursor::new(vec![0u8; FILE_LEN]);
 
     let mut bmap = bb_bmap_parser::Bmap::builder();
     bmap.image_size(FILE_LEN as u64)
@@ -57,14 +51,14 @@ fn sd_write_bmap() {
 
     let bmap = bmap.build().unwrap();
 
-    write_sd(
+    let sd = write_sd_async(
         dummy_file.clone(),
         FILE_LEN as u64,
         Some(bmap.clone()),
-        &mut sd,
-        None,
+        sd,
         None,
     )
+    .await
     .unwrap();
 
     for i in 0..(BLOCKS as usize) {
@@ -84,38 +78,22 @@ fn sd_write_bmap() {
     }
 }
 
-struct UnalignedReader(std::io::Cursor<Box<[u8]>>);
-
-impl UnalignedReader {
-    const fn as_slice(&self) -> &[u8] {
-        self.0.get_ref()
-    }
-}
-
-impl std::io::Read for UnalignedReader {
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        let count = std::cmp::min(self.0.get_ref().len() - self.0.position() as usize, 3);
-        let count = std::cmp::min(count, buf.len());
-        self.0.read(&mut buf[..count])
-    }
-}
-
-#[test]
-fn aligned_read() {
+#[tokio::test]
+async fn aligned_read() {
     const FILE_LEN: usize = 12 * 1024;
 
-    let mut dummy_file = UnalignedReader(test_file(FILE_LEN));
+    let mut dummy_file = test_file(FILE_LEN);
     let mut buf = [0u8; 1024];
     let mut pos = 0;
 
     loop {
-        let count = read_aligned(&mut dummy_file, &mut buf).unwrap();
+        let count = read_aligned_async(&mut dummy_file, &mut buf).await.unwrap();
         if count == 0 {
             break;
         }
 
         assert_eq!(count % 512, 0);
-        assert_eq!(buf[..count], dummy_file.as_slice()[pos..(pos + count)]);
+        assert_eq!(buf[..count], dummy_file.get_ref()[pos..(pos + count)]);
         pos += count;
     }
 

--- a/bb-flasher-sd/src/helpers.rs
+++ b/bb-flasher-sd/src/helpers.rs
@@ -1,7 +1,7 @@
 use std::{io, pin::Pin, task::Poll};
 
 use tokio::{
-    io::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt, AsyncWrite},
+    io::{AsyncRead, AsyncSeek, AsyncSeekExt, AsyncWrite, AsyncWriteExt},
     sync::mpsc,
 };
 
@@ -34,7 +34,15 @@ pub(crate) struct DeviceWrapper<F> {
     offset: u64,
     buf: Box<DirectIoBuffer<BLOCK_SIZE>>,
     cache_offset: u64,
-    pending_offset: Option<u64>,
+    state: DeviceWrapperState,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum DeviceWrapperState {
+    Idle,
+    Seeking,
+    Reading(usize),
+    Writing(usize),
 }
 
 impl<F> DeviceWrapper<F> {
@@ -52,6 +60,14 @@ impl<F> DeviceWrapper<F> {
     const fn cache_buf_hit_len(&self) -> usize {
         self.buf.len() - self.cache_buf_offset()
     }
+
+    fn reset_state(&mut self) {
+        self.set_state(DeviceWrapperState::Idle);
+    }
+
+    fn set_state(&mut self, state: DeviceWrapperState) {
+        self.state = state;
+    }
 }
 
 impl<F> DeviceWrapper<F>
@@ -66,7 +82,7 @@ where
             // Hack to make reading from 0 working
             cache_offset: 1,
             buf: Box::new(DirectIoBuffer::new()),
-            pending_offset: None,
+            state: DeviceWrapperState::Idle,
         })
     }
 }
@@ -75,14 +91,77 @@ impl<F> DeviceWrapper<F>
 where
     F: AsyncRead + AsyncSeek + Unpin,
 {
-    async fn fill_cache(&mut self) -> io::Result<()> {
-        if self.cache_offset != self.block_offset() {
-            self.cache_offset = self.block_offset();
-            self.f.seek(io::SeekFrom::Start(self.cache_offset)).await?;
-            self.f.read_exact(self.buf.as_mut_slice()).await?;
+    fn poll_seek(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+        pos: io::SeekFrom,
+    ) -> Poll<io::Result<()>> {
+        loop {
+            match self.state {
+                DeviceWrapperState::Idle => {
+                    // Ensure no pending seek
+                    let mut inner = Pin::new(&mut self.f);
+                    std::task::ready!(inner.as_mut().poll_complete(cx))?;
+
+                    if let Err(e) = Pin::new(&mut self.f).as_mut().start_seek(pos) {
+                        return Poll::Ready(Err(e));
+                    }
+
+                    self.set_state(DeviceWrapperState::Seeking);
+                }
+                DeviceWrapperState::Seeking => {
+                    let mut inner = Pin::new(&mut self.f);
+                    std::task::ready!(inner.as_mut().poll_complete(cx))?;
+
+                    self.reset_state();
+                    break;
+                }
+                _ => break,
+            }
         }
 
-        Ok(())
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_fill_cache(&mut self, cx: &mut std::task::Context<'_>) -> Poll<io::Result<()>> {
+        if self.cache_offset != self.block_offset() {
+            let new_cache_offset = self.block_offset();
+            std::task::ready!(self.poll_seek(cx, io::SeekFrom::Start(new_cache_offset)))?;
+
+            loop {
+                match self.state {
+                    DeviceWrapperState::Idle => {
+                        self.set_state(DeviceWrapperState::Reading(0));
+                    }
+                    DeviceWrapperState::Reading(pos) => {
+                        if pos == self.buf.len() {
+                            self.reset_state();
+                            self.cache_offset = self.block_offset();
+                            break;
+                        }
+
+                        let mut inner = Pin::new(&mut self.f);
+                        let mut buf = tokio::io::ReadBuf::new(&mut self.buf.as_mut_slice()[pos..]);
+
+                        let before = buf.filled().len();
+                        std::task::ready!(inner.as_mut().poll_read(cx, &mut buf))?;
+                        let after = buf.filled().len();
+                        // EOF
+                        if before == after {
+                            return Poll::Ready(Err(io::Error::new(
+                                io::ErrorKind::UnexpectedEof,
+                                "Encountered EOF",
+                            )));
+                        }
+
+                        self.state = DeviceWrapperState::Reading(pos + after);
+                    }
+                    _ => break,
+                }
+            }
+        }
+
+        Poll::Ready(Ok(()))
     }
 }
 
@@ -95,16 +174,7 @@ where
         cx: &mut std::task::Context<'_>,
         buf: &mut tokio::io::ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {
-        {
-            let fut = self.fill_cache();
-            tokio::pin!(fut);
-
-            match fut.poll(cx) {
-                Poll::Ready(Ok(())) => {}
-                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
-                Poll::Pending => return Poll::Pending,
-            }
-        }
+        std::task::ready!(self.poll_fill_cache(cx))?;
 
         let count = std::cmp::min(buf.remaining(), self.cache_buf_hit_len());
         let start = self.cache_buf_offset();
@@ -126,45 +196,39 @@ where
         cx: &mut std::task::Context<'_>,
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
-        {
-            let fut = self.fill_cache();
-            tokio::pin!(fut);
-            match fut.poll(cx) {
-                Poll::Ready(Ok(())) => {}
-                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
-                Poll::Pending => return Poll::Pending,
-            }
-        }
+        std::task::ready!(self.poll_fill_cache(cx))?;
 
         let count = std::cmp::min(buf.len(), self.cache_buf_hit_len());
         let start = self.cache_buf_offset();
 
         self.buf.as_mut_slice()[start..(start + count)].copy_from_slice(&buf[..count]);
 
-        {
-            let cache_offset = self.cache_offset;
-            let (f, write_buf) = {
-                let this = &mut *self;
-                (&mut this.f, this.buf.as_slice())
-            };
+        let cache_offset = self.cache_offset;
+        std::task::ready!(self.poll_seek(cx, io::SeekFrom::Start(cache_offset)))?;
 
-            let mut inner = Pin::new(f);
+        loop {
+            match self.state {
+                DeviceWrapperState::Idle => {
+                    self.set_state(DeviceWrapperState::Writing(0));
+                }
+                DeviceWrapperState::Writing(pos) => {
+                    let (f, write_buf) = {
+                        let this = &mut *self;
+                        (&mut this.f, this.buf.as_slice())
+                    };
 
-            match inner.as_mut().start_seek(io::SeekFrom::Start(cache_offset)) {
-                Ok(()) => {}
-                Err(e) => return Poll::Ready(Err(e)),
-            }
+                    if write_buf.len() == pos {
+                        // Since writing is finished, go back to idle.
+                        self.reset_state();
+                        break;
+                    }
 
-            match inner.as_mut().poll_complete(cx) {
-                Poll::Ready(Ok(_)) => {}
-                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
-                Poll::Pending => return Poll::Pending,
-            }
+                    let inner = Pin::new(f);
+                    let written = std::task::ready!(inner.poll_write(cx, &write_buf[pos..]))?;
 
-            match inner.poll_write(cx, write_buf) {
-                Poll::Ready(Ok(_)) => {}
-                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
-                Poll::Pending => return Poll::Pending,
+                    self.set_state(DeviceWrapperState::Writing(pos + written));
+                }
+                _ => break,
             }
         }
 
@@ -195,20 +259,18 @@ where
     fn start_seek(mut self: Pin<&mut Self>, position: io::SeekFrom) -> io::Result<()> {
         let new_offset = match position {
             io::SeekFrom::Start(i) => i,
-
             io::SeekFrom::Current(i) => self
                 .offset
                 .checked_add_signed(i)
                 .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "invalid seek"))?,
-
             io::SeekFrom::End(_) => {
                 Pin::new(&mut self.f).start_seek(position)?;
-                self.pending_offset = None;
+                self.set_state(DeviceWrapperState::Seeking);
                 return Ok(());
             }
         };
 
-        self.pending_offset = Some(new_offset);
+        self.offset = new_offset;
 
         Ok(())
     }
@@ -217,21 +279,12 @@ where
         mut self: Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> Poll<io::Result<u64>> {
-        if let Some(offset) = self.pending_offset.take() {
-            self.offset = offset;
-            return Poll::Ready(Ok(offset));
+        if self.state == DeviceWrapperState::Seeking {
+            self.offset = std::task::ready!(Pin::new(&mut self.f).poll_complete(cx))?;
+            self.reset_state();
         }
 
-        match Pin::new(&mut self.f).poll_complete(cx) {
-            Poll::Ready(Ok(pos)) => {
-                self.offset = pos;
-                Poll::Ready(Ok(pos))
-            }
-
-            Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
-
-            Poll::Pending => Poll::Pending,
-        }
+        Poll::Ready(Ok(self.offset))
     }
 }
 
@@ -288,9 +341,7 @@ where
     }
 
     pub(crate) async fn finish(&mut self) -> io::Result<()> {
-        use tokio::io::{AsyncSeekExt, AsyncWriteExt};
-
-        self.inner.seek(io::SeekFrom::Start(0)).await?;
+        self.inner.rewind().await?;
         self.inner.write_all(self.buf.as_slice()).await?;
         self.pos = u64::try_from(self.buf.len()).unwrap();
 
@@ -451,9 +502,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::io::SeekFrom;
+    use std::io::{SeekFrom, Write};
 
-    use tokio::io::AsyncWriteExt;
+    use tokio::io::AsyncReadExt;
 
     use super::*;
 
@@ -467,20 +518,30 @@ mod tests {
         std::io::Cursor::new(data.into())
     }
 
-    async fn test_file() -> super::DeviceWrapper<std::io::Cursor<Box<[u8]>>> {
+    async fn test_file() -> super::DeviceWrapper<tokio::fs::File> {
         let data: Vec<u8> = (0..FILE_LEN)
             .map(|x| x % 255)
             .map(|x| u8::try_from(x).unwrap())
             .collect();
-        super::DeviceWrapper::new(std::io::Cursor::new(data.into()))
-            .await
-            .unwrap()
+
+        let f = tempfile::tempfile().unwrap();
+        let mut f = tokio::fs::File::from_std(f);
+
+        f.write_all(&data).await.unwrap();
+        f.flush().await.unwrap();
+        f.rewind().await.unwrap();
+
+        super::DeviceWrapper::new(f).await.unwrap()
     }
 
     #[tokio::test]
     async fn dev_wrapper_read() {
         let mut temp = test_file().await;
         let mut buf = [0u8; 50];
+
+        temp.read_exact(&mut buf).await.unwrap();
+        let ans: Vec<u8> = (0..50).collect();
+        assert_eq!(buf.as_slice(), &ans);
 
         temp.seek(SeekFrom::Start(10)).await.unwrap();
         temp.read_exact(&mut buf).await.unwrap();
@@ -503,9 +564,11 @@ mod tests {
         let mut buf = [9u8; 50];
         temp.seek(SeekFrom::Start(10)).await.unwrap();
         temp.write_all(&buf).await.unwrap();
+        temp.flush().await.unwrap();
 
         temp.seek(SeekFrom::Start(4090)).await.unwrap();
         temp.write_all(&buf).await.unwrap();
+        temp.flush().await.unwrap();
 
         temp.seek(SeekFrom::Start(10)).await.unwrap();
         temp.read_exact(&mut buf).await.unwrap();

--- a/bb-flasher-sd/src/helpers.rs
+++ b/bb-flasher-sd/src/helpers.rs
@@ -1,7 +1,7 @@
 use std::{io, pin::Pin, task::Poll};
 
 use tokio::{
-    io::{AsyncReadExt, AsyncSeekExt},
+    io::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt, AsyncWrite},
     sync::mpsc,
 };
 
@@ -15,11 +15,11 @@ pub(crate) const fn progress(pos: u64, img_size: u64) -> f32 {
     pos as f32 / img_size as f32
 }
 
-pub(crate) trait EjectAsync {
+pub(crate) trait Eject {
     fn eject(self) -> impl Future<Output = io::Result<()>>;
 }
 
-impl EjectAsync for tokio::fs::File {
+impl Eject for tokio::fs::File {
     async fn eject(self) -> io::Result<()> {
         self.sync_all().await
     }
@@ -29,7 +29,7 @@ const BLOCK_SIZE: usize = 4096;
 
 #[derive(Debug)]
 /// Wrapper to perform aligned read/write operations.
-pub(crate) struct DeviceWrapperAsync<F> {
+pub(crate) struct DeviceWrapper<F> {
     f: F,
     offset: u64,
     buf: Box<DirectIoBuffer<BLOCK_SIZE>>,
@@ -37,7 +37,7 @@ pub(crate) struct DeviceWrapperAsync<F> {
     pending_offset: Option<u64>,
 }
 
-impl<F> DeviceWrapperAsync<F> {
+impl<F> DeviceWrapper<F> {
     /// Start offset of current block
     const fn block_offset(&self) -> u64 {
         self.offset - self.cache_buf_offset() as u64
@@ -54,13 +54,12 @@ impl<F> DeviceWrapperAsync<F> {
     }
 }
 
-impl<F> DeviceWrapperAsync<F>
+impl<F> DeviceWrapper<F>
 where
-    F: tokio::io::AsyncSeek + Unpin,
+    F: AsyncSeek + Unpin,
 {
     pub(crate) async fn new(mut f: F) -> io::Result<Self> {
         f.rewind().await?;
-
         Ok(Self {
             f,
             offset: 0,
@@ -72,16 +71,14 @@ where
     }
 }
 
-impl<F> DeviceWrapperAsync<F>
+impl<F> DeviceWrapper<F>
 where
-    F: tokio::io::AsyncRead + tokio::io::AsyncSeek + Unpin,
+    F: AsyncRead + AsyncSeek + Unpin,
 {
     async fn fill_cache(&mut self) -> io::Result<()> {
         if self.cache_offset != self.block_offset() {
             self.cache_offset = self.block_offset();
-
             self.f.seek(io::SeekFrom::Start(self.cache_offset)).await?;
-
             self.f.read_exact(self.buf.as_mut_slice()).await?;
         }
 
@@ -89,9 +86,9 @@ where
     }
 }
 
-impl<F> tokio::io::AsyncRead for DeviceWrapperAsync<F>
+impl<F> AsyncRead for DeviceWrapper<F>
 where
-    F: tokio::io::AsyncRead + tokio::io::AsyncSeek + Unpin,
+    F: AsyncRead + AsyncSeek + Unpin,
 {
     fn poll_read(
         mut self: Pin<&mut Self>,
@@ -100,7 +97,6 @@ where
     ) -> Poll<io::Result<()>> {
         {
             let fut = self.fill_cache();
-
             tokio::pin!(fut);
 
             match fut.poll(cx) {
@@ -111,7 +107,6 @@ where
         }
 
         let count = std::cmp::min(buf.remaining(), self.cache_buf_hit_len());
-
         let start = self.cache_buf_offset();
 
         buf.put_slice(&self.buf.as_slice()[start..(start + count)]);
@@ -122,9 +117,9 @@ where
     }
 }
 
-impl<F> tokio::io::AsyncWrite for DeviceWrapperAsync<F>
+impl<F> AsyncWrite for DeviceWrapper<F>
 where
-    F: tokio::io::AsyncWrite + tokio::io::AsyncRead + tokio::io::AsyncSeek + Unpin,
+    F: AsyncWrite + AsyncRead + AsyncSeek + Unpin,
 {
     fn poll_write(
         mut self: Pin<&mut Self>,
@@ -193,9 +188,9 @@ where
     }
 }
 
-impl<F> tokio::io::AsyncSeek for DeviceWrapperAsync<F>
+impl<F> AsyncSeek for DeviceWrapper<F>
 where
-    F: tokio::io::AsyncSeek + Unpin,
+    F: AsyncSeek + Unpin,
 {
     fn start_seek(mut self: Pin<&mut Self>, position: io::SeekFrom) -> io::Result<()> {
         let new_offset = match position {
@@ -240,9 +235,9 @@ where
     }
 }
 
-impl<W> EjectAsync for DeviceWrapperAsync<W>
+impl<W> Eject for DeviceWrapper<W>
 where
-    W: tokio::io::AsyncRead + tokio::io::AsyncWrite + tokio::io::AsyncSeek + Unpin + EjectAsync,
+    W: AsyncRead + AsyncWrite + AsyncSeek + Unpin + Eject,
 {
     async fn eject(self) -> io::Result<()> {
         self.f.eject().await
@@ -274,15 +269,15 @@ impl<const N: usize> DirectIoBuffer<N> {
 /// A wrapper to support writing the first block at the end. This is required on Windows to make
 /// things work reliably.
 #[derive(Debug)]
-pub(crate) struct SdCardWrapperAsync<W> {
+pub(crate) struct SdCardWrapper<W> {
     inner: W,
     buf: Box<DirectIoBuffer<BLOCK_SIZE>>,
     pos: u64,
 }
 
-impl<W> SdCardWrapperAsync<W>
+impl<W> SdCardWrapper<W>
 where
-    W: tokio::io::AsyncRead + tokio::io::AsyncWrite + tokio::io::AsyncSeek + Unpin,
+    W: AsyncRead + AsyncWrite + AsyncSeek + Unpin,
 {
     pub(crate) fn new(inner: W) -> Self {
         Self {
@@ -303,9 +298,9 @@ where
     }
 }
 
-impl<W> EjectAsync for SdCardWrapperAsync<W>
+impl<W> Eject for SdCardWrapper<W>
 where
-    W: tokio::io::AsyncRead + tokio::io::AsyncWrite + tokio::io::AsyncSeek + Unpin + EjectAsync,
+    W: AsyncRead + AsyncWrite + AsyncSeek + Unpin + Eject,
 {
     async fn eject(mut self) -> io::Result<()> {
         self.finish().await?;
@@ -313,9 +308,9 @@ where
     }
 }
 
-impl<W> tokio::io::AsyncRead for SdCardWrapperAsync<W>
+impl<W> AsyncRead for SdCardWrapper<W>
 where
-    W: tokio::io::AsyncRead + tokio::io::AsyncSeek + Unpin,
+    W: AsyncRead + AsyncSeek + Unpin,
 {
     fn poll_read(
         mut self: Pin<&mut Self>,
@@ -367,9 +362,9 @@ where
     }
 }
 
-impl<W> tokio::io::AsyncWrite for SdCardWrapperAsync<W>
+impl<W> AsyncWrite for SdCardWrapper<W>
 where
-    W: tokio::io::AsyncWrite + tokio::io::AsyncSeek + Unpin,
+    W: AsyncWrite + AsyncSeek + Unpin,
 {
     fn poll_write(
         mut self: Pin<&mut Self>,
@@ -432,9 +427,9 @@ where
     }
 }
 
-impl<W> tokio::io::AsyncSeek for SdCardWrapperAsync<W>
+impl<W> AsyncSeek for SdCardWrapper<W>
 where
-    W: tokio::io::AsyncSeek + Unpin,
+    W: AsyncSeek + Unpin,
 {
     fn start_seek(mut self: Pin<&mut Self>, position: io::SeekFrom) -> io::Result<()> {
         Pin::new(&mut self.inner).start_seek(position)
@@ -472,12 +467,12 @@ mod tests {
         std::io::Cursor::new(data.into())
     }
 
-    async fn test_file() -> super::DeviceWrapperAsync<std::io::Cursor<Box<[u8]>>> {
+    async fn test_file() -> super::DeviceWrapper<std::io::Cursor<Box<[u8]>>> {
         let data: Vec<u8> = (0..FILE_LEN)
             .map(|x| x % 255)
             .map(|x| u8::try_from(x).unwrap())
             .collect();
-        super::DeviceWrapperAsync::new(std::io::Cursor::new(data.into()))
+        super::DeviceWrapper::new(std::io::Cursor::new(data.into()))
             .await
             .unwrap()
     }
@@ -527,7 +522,7 @@ mod tests {
     async fn sd_card_wrapper() {
         let mut test_data = test_data();
         let mut temp_buf = vec![0; FILE_LEN].into_boxed_slice();
-        let mut sd = SdCardWrapperAsync::new(std::io::Cursor::new(temp_buf.clone()));
+        let mut sd = SdCardWrapper::new(std::io::Cursor::new(temp_buf.clone()));
 
         tokio::io::copy(&mut test_data, &mut sd).await.unwrap();
 

--- a/bb-flasher-sd/src/helpers.rs
+++ b/bb-flasher-sd/src/helpers.rs
@@ -1,6 +1,9 @@
-use std::io;
+use std::{io, pin::Pin, task::Poll};
 
-use tokio::sync::mpsc;
+use tokio::{
+    io::{AsyncReadExt, AsyncSeekExt},
+    sync::mpsc,
+};
 
 use crate::Result;
 
@@ -147,6 +150,219 @@ where
     }
 }
 
+#[derive(Debug)]
+/// Wrapper to perform aligned read/write operations.
+pub(crate) struct DeviceWrapperAsync<F> {
+    f: F,
+    offset: u64,
+    buf: Box<DirectIoBuffer<BLOCK_SIZE>>,
+    cache_offset: u64,
+    pending_offset: Option<u64>,
+}
+
+impl<F> DeviceWrapperAsync<F> {
+    /// Start offset of current block
+    const fn block_offset(&self) -> u64 {
+        self.offset - self.cache_buf_offset() as u64
+    }
+
+    /// Offset inside cache to start reading/writing
+    const fn cache_buf_offset(&self) -> usize {
+        (self.offset % BLOCK_SIZE as u64) as usize
+    }
+
+    /// Number of bytes from `Self::cache_buf_offset` that can be used
+    const fn cache_buf_hit_len(&self) -> usize {
+        self.buf.len() - self.cache_buf_offset()
+    }
+}
+
+impl<F> DeviceWrapperAsync<F>
+where
+    F: tokio::io::AsyncSeek + Unpin,
+{
+    pub(crate) async fn new(mut f: F) -> io::Result<Self> {
+        f.rewind().await?;
+
+        Ok(Self {
+            f,
+            offset: 0,
+            // Hack to make reading from 0 working
+            cache_offset: 1,
+            buf: Box::new(DirectIoBuffer::new()),
+            pending_offset: None,
+        })
+    }
+}
+
+impl<F> DeviceWrapperAsync<F>
+where
+    F: tokio::io::AsyncRead + tokio::io::AsyncSeek + Unpin,
+{
+    async fn fill_cache(&mut self) -> io::Result<()> {
+        if self.cache_offset != self.block_offset() {
+            self.cache_offset = self.block_offset();
+
+            self.f.seek(io::SeekFrom::Start(self.cache_offset)).await?;
+
+            self.f.read_exact(self.buf.as_mut_slice()).await?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<F> tokio::io::AsyncRead for DeviceWrapperAsync<F>
+where
+    F: tokio::io::AsyncRead + tokio::io::AsyncSeek + Unpin,
+{
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        {
+            let fut = self.fill_cache();
+
+            tokio::pin!(fut);
+
+            match fut.poll(cx) {
+                Poll::Ready(Ok(())) => {}
+                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+
+        let count = std::cmp::min(buf.remaining(), self.cache_buf_hit_len());
+
+        let start = self.cache_buf_offset();
+
+        buf.put_slice(&self.buf.as_slice()[start..(start + count)]);
+
+        self.offset += count as u64;
+
+        Poll::Ready(Ok(()))
+    }
+}
+
+impl<F> tokio::io::AsyncWrite for DeviceWrapperAsync<F>
+where
+    F: tokio::io::AsyncWrite + tokio::io::AsyncRead + tokio::io::AsyncSeek + Unpin,
+{
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        {
+            let fut = self.fill_cache();
+            tokio::pin!(fut);
+            match fut.poll(cx) {
+                Poll::Ready(Ok(())) => {}
+                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+
+        let count = std::cmp::min(buf.len(), self.cache_buf_hit_len());
+        let start = self.cache_buf_offset();
+
+        self.buf.as_mut_slice()[start..(start + count)].copy_from_slice(&buf[..count]);
+
+        {
+            let cache_offset = self.cache_offset;
+            let (f, write_buf) = {
+                let this = &mut *self;
+                (&mut this.f, this.buf.as_slice())
+            };
+
+            let mut inner = Pin::new(f);
+
+            match inner.as_mut().start_seek(io::SeekFrom::Start(cache_offset)) {
+                Ok(()) => {}
+                Err(e) => return Poll::Ready(Err(e)),
+            }
+
+            match inner.as_mut().poll_complete(cx) {
+                Poll::Ready(Ok(_)) => {}
+                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                Poll::Pending => return Poll::Pending,
+            }
+
+            match inner.poll_write(cx, write_buf) {
+                Poll::Ready(Ok(_)) => {}
+                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+
+        self.offset += count as u64;
+
+        Poll::Ready(Ok(count))
+    }
+
+    fn poll_flush(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.f).poll_flush(cx)
+    }
+
+    fn poll_shutdown(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.f).poll_shutdown(cx)
+    }
+}
+
+impl<F> tokio::io::AsyncSeek for DeviceWrapperAsync<F>
+where
+    F: tokio::io::AsyncSeek + Unpin,
+{
+    fn start_seek(mut self: Pin<&mut Self>, position: io::SeekFrom) -> io::Result<()> {
+        let new_offset = match position {
+            io::SeekFrom::Start(i) => i,
+
+            io::SeekFrom::Current(i) => self
+                .offset
+                .checked_add_signed(i)
+                .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "invalid seek"))?,
+
+            io::SeekFrom::End(_) => {
+                Pin::new(&mut self.f).start_seek(position)?;
+                self.pending_offset = None;
+                return Ok(());
+            }
+        };
+
+        self.pending_offset = Some(new_offset);
+
+        Ok(())
+    }
+
+    fn poll_complete(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<io::Result<u64>> {
+        if let Some(offset) = self.pending_offset.take() {
+            self.offset = offset;
+            return Poll::Ready(Ok(offset));
+        }
+
+        match Pin::new(&mut self.f).poll_complete(cx) {
+            Poll::Ready(Ok(pos)) => {
+                self.offset = pos;
+                Poll::Ready(Ok(pos))
+            }
+
+            Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
+
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
 #[repr(align(4096))]
 #[derive(Debug)]
 pub(crate) struct DirectIoBuffer<const N: usize>([u8; N]);
@@ -267,13 +483,198 @@ where
     }
 }
 
+/// A wrapper to support writing the first block at the end. This is required on Windows to make
+/// things work reliably.
+#[derive(Debug)]
+pub(crate) struct SdCardWrapperAsync<W> {
+    inner: W,
+    buf: Box<DirectIoBuffer<BLOCK_SIZE>>,
+    pos: u64,
+}
+
+impl<W> SdCardWrapperAsync<W>
+where
+    W: tokio::io::AsyncRead + tokio::io::AsyncWrite + tokio::io::AsyncSeek + Unpin,
+{
+    pub(crate) fn new(inner: W) -> Self {
+        Self {
+            inner,
+            buf: Box::new(DirectIoBuffer::new()),
+            pos: 0,
+        }
+    }
+
+    pub(crate) async fn finish(&mut self) -> io::Result<()> {
+        use tokio::io::{AsyncSeekExt, AsyncWriteExt};
+
+        self.inner.seek(io::SeekFrom::Start(0)).await?;
+        self.inner.write_all(self.buf.as_slice()).await?;
+        self.pos = u64::try_from(self.buf.len()).unwrap();
+
+        Ok(())
+    }
+}
+
+impl<W> Eject for SdCardWrapperAsync<W>
+where
+    W: tokio::io::AsyncRead + tokio::io::AsyncWrite + tokio::io::AsyncSeek + Unpin + Eject,
+{
+    fn eject(mut self) -> io::Result<()> {
+        tokio::runtime::Handle::current().block_on(async {
+            self.finish().await?;
+            self.inner.eject()
+        })
+    }
+}
+
+impl<W> tokio::io::AsyncRead for SdCardWrapperAsync<W>
+where
+    W: tokio::io::AsyncRead + tokio::io::AsyncSeek + Unpin,
+{
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let pos = usize::try_from(self.pos).unwrap();
+
+        if pos < self.buf.len() {
+            let remaining = buf.remaining();
+            let count = std::cmp::min(self.buf.len() - pos, remaining);
+
+            let mut inner = Pin::new(&mut self.inner);
+
+            match inner.as_mut().poll_complete(cx) {
+                Poll::Ready(Ok(_)) => {}
+                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                Poll::Pending => return Poll::Pending,
+            }
+
+            if let Err(e) = inner
+                .as_mut()
+                .start_seek(io::SeekFrom::Current(i64::try_from(count).unwrap()))
+            {
+                return Poll::Ready(Err(e));
+            }
+            match inner.poll_complete(cx) {
+                Poll::Ready(Ok(_)) => {}
+                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                Poll::Pending => return Poll::Pending,
+            }
+
+            buf.put_slice(&self.buf.as_slice()[pos..(pos + count)]);
+            self.pos += u64::try_from(count).unwrap();
+
+            Poll::Ready(Ok(()))
+        } else {
+            let before = buf.filled().len();
+
+            match Pin::new(&mut self.inner).poll_read(cx, buf) {
+                Poll::Ready(Ok(())) => {
+                    let read = buf.filled().len() - before;
+                    self.pos += u64::try_from(read).unwrap();
+                    Poll::Ready(Ok(()))
+                }
+                other => other,
+            }
+        }
+    }
+}
+
+impl<W> tokio::io::AsyncWrite for SdCardWrapperAsync<W>
+where
+    W: tokio::io::AsyncWrite + tokio::io::AsyncSeek + Unpin,
+{
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        let pos = usize::try_from(self.pos).unwrap();
+
+        if pos < self.buf.len() {
+            let count = std::cmp::min(self.buf.len() - pos, buf.len());
+
+            let mut inner = Pin::new(&mut self.inner);
+
+            match inner.as_mut().poll_complete(cx) {
+                Poll::Ready(Ok(_)) => {}
+                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                Poll::Pending => return Poll::Pending,
+            }
+
+            if let Err(e) = inner
+                .as_mut()
+                .start_seek(io::SeekFrom::Current(i64::try_from(count).unwrap()))
+            {
+                return Poll::Ready(Err(e));
+            }
+            match inner.poll_complete(cx) {
+                Poll::Ready(Ok(_)) => {}
+                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                Poll::Pending => return Poll::Pending,
+            }
+
+            self.buf.as_mut_slice()[pos..(pos + count)].copy_from_slice(&buf[..count]);
+
+            self.pos += u64::try_from(count).unwrap();
+
+            Poll::Ready(Ok(count))
+        } else {
+            match Pin::new(&mut self.inner).poll_write(cx, buf) {
+                Poll::Ready(Ok(count)) => {
+                    self.pos += u64::try_from(count).unwrap();
+                    Poll::Ready(Ok(count))
+                }
+                other => other,
+            }
+        }
+    }
+
+    fn poll_flush(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
+}
+
+impl<W> tokio::io::AsyncSeek for SdCardWrapperAsync<W>
+where
+    W: tokio::io::AsyncSeek + Unpin,
+{
+    fn start_seek(mut self: Pin<&mut Self>, position: io::SeekFrom) -> io::Result<()> {
+        Pin::new(&mut self.inner).start_seek(position)
+    }
+
+    fn poll_complete(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<io::Result<u64>> {
+        match Pin::new(&mut self.inner).poll_complete(cx) {
+            Poll::Ready(Ok(pos)) => {
+                self.pos = pos;
+                Poll::Ready(Ok(pos))
+            }
+            other => other,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use std::io::{Read, Seek, SeekFrom, Write};
+    use std::io::SeekFrom;
 
-    use crate::helpers::BLOCK_SIZE;
+    use tokio::io::AsyncWriteExt;
 
-    use super::SdCardWrapper;
+    use super::*;
 
     const FILE_LEN: usize = 12 * 1024;
 
@@ -285,62 +686,64 @@ mod tests {
         std::io::Cursor::new(data.into())
     }
 
-    fn test_file() -> super::DeviceWrapper<std::io::Cursor<Box<[u8]>>> {
+    async fn test_file() -> super::DeviceWrapperAsync<std::io::Cursor<Box<[u8]>>> {
         let data: Vec<u8> = (0..FILE_LEN)
             .map(|x| x % 255)
             .map(|x| u8::try_from(x).unwrap())
             .collect();
-        super::DeviceWrapper::new(std::io::Cursor::new(data.into())).unwrap()
+        super::DeviceWrapperAsync::new(std::io::Cursor::new(data.into()))
+            .await
+            .unwrap()
     }
 
-    #[test]
-    fn dev_wrapper_read() {
-        let mut temp = test_file();
+    #[tokio::test]
+    async fn dev_wrapper_read() {
+        let mut temp = test_file().await;
         let mut buf = [0u8; 50];
 
-        temp.seek(SeekFrom::Start(10)).unwrap();
-        temp.read_exact(&mut buf).unwrap();
+        temp.seek(SeekFrom::Start(10)).await.unwrap();
+        temp.read_exact(&mut buf).await.unwrap();
 
         let ans: Vec<u8> = (10..60).collect();
         assert_eq!(buf.as_slice(), &ans);
 
-        temp.seek(SeekFrom::Start(4095)).unwrap();
-        temp.read_exact(&mut buf).unwrap();
+        temp.seek(SeekFrom::Start(4095)).await.unwrap();
+        temp.read_exact(&mut buf).await.unwrap();
 
         let ans: Vec<u8> = (4095..4145).map(|x| (x % 255) as u8).collect();
         assert_eq!(buf.as_slice(), &ans);
     }
 
-    #[test]
-    fn dev_wrapper_write() {
-        let mut temp = test_file();
+    #[tokio::test]
+    async fn dev_wrapper_write() {
+        let mut temp = test_file().await;
         let ans = [9u8; 50];
 
         let mut buf = [9u8; 50];
-        temp.seek(SeekFrom::Start(10)).unwrap();
-        temp.write_all(&buf).unwrap();
+        temp.seek(SeekFrom::Start(10)).await.unwrap();
+        temp.write_all(&buf).await.unwrap();
 
-        temp.seek(SeekFrom::Start(4090)).unwrap();
-        temp.write_all(&buf).unwrap();
+        temp.seek(SeekFrom::Start(4090)).await.unwrap();
+        temp.write_all(&buf).await.unwrap();
 
-        temp.seek(SeekFrom::Start(10)).unwrap();
-        temp.read_exact(&mut buf).unwrap();
+        temp.seek(SeekFrom::Start(10)).await.unwrap();
+        temp.read_exact(&mut buf).await.unwrap();
 
         assert_eq!(ans, buf);
 
-        temp.seek(SeekFrom::Start(4090)).unwrap();
-        temp.read_exact(&mut buf).unwrap();
+        temp.seek(SeekFrom::Start(4090)).await.unwrap();
+        temp.read_exact(&mut buf).await.unwrap();
 
         assert_eq!(ans, buf);
     }
 
-    #[test]
-    fn sd_card_wrapper() {
+    #[tokio::test]
+    async fn sd_card_wrapper() {
         let mut test_data = test_data();
         let mut temp_buf = vec![0; FILE_LEN].into_boxed_slice();
-        let mut sd = SdCardWrapper::new(std::io::Cursor::new(temp_buf.clone()));
+        let mut sd = SdCardWrapperAsync::new(std::io::Cursor::new(temp_buf.clone()));
 
-        std::io::copy(&mut test_data, &mut sd).unwrap();
+        tokio::io::copy(&mut test_data, &mut sd).await.unwrap();
 
         assert_eq!(
             test_data.get_ref()[BLOCK_SIZE..],
@@ -352,11 +755,11 @@ mod tests {
         );
         assert!(sd.inner.get_ref()[..BLOCK_SIZE].iter().all(|x| *x == 0));
 
-        sd.seek(std::io::SeekFrom::Start(0)).unwrap();
-        sd.read_exact(&mut temp_buf).unwrap();
+        sd.rewind().await.unwrap();
+        sd.read_exact(&mut temp_buf).await.unwrap();
         assert_eq!(temp_buf, test_data.get_ref().clone());
 
-        sd.finish().unwrap();
+        sd.finish().await.unwrap();
         assert_eq!(test_data.get_ref(), sd.inner.get_ref());
     }
 }

--- a/bb-flasher-sd/src/helpers.rs
+++ b/bb-flasher-sd/src/helpers.rs
@@ -5,8 +5,6 @@ use tokio::{
     sync::mpsc,
 };
 
-use crate::Result;
-
 pub(crate) fn chan_send(chan: Option<&mut mpsc::Sender<f32>>, msg: f32) {
     if let Some(c) = chan {
         let _ = c.try_send(msg);
@@ -15,23 +13,6 @@ pub(crate) fn chan_send(chan: Option<&mut mpsc::Sender<f32>>, msg: f32) {
 
 pub(crate) const fn progress(pos: u64, img_size: u64) -> f32 {
     pos as f32 / img_size as f32
-}
-
-pub(crate) fn check_token(cancel: Option<&tokio_util::sync::CancellationToken>) -> Result<()> {
-    match cancel {
-        Some(x) if x.is_cancelled() => Err(crate::Error::Aborted),
-        _ => Ok(()),
-    }
-}
-
-pub(crate) trait Eject {
-    fn eject(self) -> io::Result<()>;
-}
-
-impl Eject for std::fs::File {
-    fn eject(self) -> io::Result<()> {
-        self.sync_all()
-    }
 }
 
 pub(crate) trait EjectAsync {
@@ -45,120 +26,6 @@ impl EjectAsync for tokio::fs::File {
 }
 
 const BLOCK_SIZE: usize = 4096;
-
-#[derive(Debug)]
-/// Wrapper to perform aligned read/write operations.
-pub(crate) struct DeviceWrapper<F> {
-    f: F,
-    offset: u64,
-    buf: Box<DirectIoBuffer<BLOCK_SIZE>>,
-    cache_offset: u64,
-}
-
-impl<F> DeviceWrapper<F> {
-    /// Start offset of current block
-    const fn block_offset(&self) -> u64 {
-        self.offset - self.cache_buf_offset() as u64
-    }
-
-    /// Offset inside cache to start reading/writing
-    const fn cache_buf_offset(&self) -> usize {
-        (self.offset % BLOCK_SIZE as u64) as usize
-    }
-
-    /// Number of bytes from `Self::cache_buf_offset` that can be used
-    const fn cache_buf_hit_len(&self) -> usize {
-        self.buf.len() - self.cache_buf_offset()
-    }
-}
-
-impl<F> DeviceWrapper<F>
-where
-    F: io::Seek,
-{
-    pub(crate) fn new(mut f: F) -> io::Result<Self> {
-        f.rewind()?;
-        Ok(Self {
-            f,
-            offset: 0,
-            // Hack to make reading from 0 working
-            cache_offset: 1,
-            buf: Box::new(DirectIoBuffer::new()),
-        })
-    }
-}
-
-impl<F> DeviceWrapper<F>
-where
-    F: io::Read + io::Seek,
-{
-    fn fill_cache(&mut self) -> io::Result<()> {
-        if self.cache_offset != self.block_offset() {
-            self.cache_offset = self.block_offset();
-            self.f.seek(io::SeekFrom::Start(self.cache_offset))?;
-            self.f.read_exact(self.buf.as_mut_slice())
-        } else {
-            Ok(())
-        }
-    }
-}
-
-impl<F> io::Read for DeviceWrapper<F>
-where
-    F: io::Read + io::Seek,
-{
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.fill_cache()?;
-        let count = std::cmp::min(buf.len(), self.cache_buf_hit_len());
-
-        buf[..count].copy_from_slice(
-            &self.buf.as_slice()[self.cache_buf_offset()..(self.cache_buf_offset() + count)],
-        );
-
-        self.offset += count as u64;
-
-        Ok(count)
-    }
-}
-
-impl<F> io::Write for DeviceWrapper<F>
-where
-    F: io::Write + io::Read + io::Seek,
-{
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.fill_cache()?;
-        let count = std::cmp::min(buf.len(), self.cache_buf_hit_len());
-        let start = self.cache_buf_offset();
-
-        self.buf.as_mut_slice()[start..(start + count)].copy_from_slice(&buf[..count]);
-
-        self.f.seek(io::SeekFrom::Start(self.cache_offset))?;
-        self.f.write(self.buf.as_slice())?;
-
-        self.offset += count as u64;
-
-        Ok(count)
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        self.f.flush()
-    }
-}
-
-impl<F> io::Seek for DeviceWrapper<F>
-where
-    F: io::Seek,
-{
-    fn seek(&mut self, pos: io::SeekFrom) -> io::Result<u64> {
-        match pos {
-            io::SeekFrom::Start(i) => self.offset = i,
-            io::SeekFrom::Current(i) => self.offset = self.offset.checked_add_signed(i).unwrap(),
-            io::SeekFrom::End(_) => self.offset = self.f.seek(pos)?,
-        }
-
-        Ok(self.offset)
-    }
-}
 
 #[derive(Debug)]
 /// Wrapper to perform aligned read/write operations.
@@ -392,104 +259,6 @@ impl<const N: usize> DirectIoBuffer<N> {
 
     const fn len(&self) -> usize {
         self.0.len()
-    }
-}
-
-/// A wrapper to support writing the first block at the end. This is required on Windows to make
-/// things work reliably.
-#[derive(Debug)]
-pub(crate) struct SdCardWrapper<W> {
-    inner: W,
-    buf: Box<DirectIoBuffer<BLOCK_SIZE>>,
-    pos: u64,
-}
-
-impl<W> SdCardWrapper<W>
-where
-    W: io::Read + io::Write + io::Seek,
-{
-    pub(crate) fn new(inner: W) -> Self {
-        Self {
-            inner,
-            buf: Box::new(DirectIoBuffer::new()),
-            pos: 0,
-        }
-    }
-
-    fn finish(&mut self) -> io::Result<()> {
-        self.inner.seek(io::SeekFrom::Start(0))?;
-        self.inner.write_all(self.buf.as_slice())?;
-        self.pos = u64::try_from(self.buf.len()).unwrap();
-
-        Ok(())
-    }
-}
-
-impl<W> Eject for SdCardWrapper<W>
-where
-    W: io::Read + io::Write + io::Seek + Eject,
-{
-    fn eject(mut self) -> io::Result<()> {
-        self.finish()?;
-        self.inner.eject()
-    }
-}
-
-impl<W> io::Read for SdCardWrapper<W>
-where
-    W: io::Read + io::Seek,
-{
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        let pos = usize::try_from(self.pos).unwrap();
-
-        let count = if pos < self.buf.len() {
-            let count = std::cmp::min(self.buf.len() - pos, buf.len());
-            self.inner
-                .seek(io::SeekFrom::Current(i64::try_from(count).unwrap()))?;
-            buf[..count].copy_from_slice(&self.buf.as_slice()[pos..(pos + count)]);
-            count
-        } else {
-            self.inner.read(buf)?
-        };
-
-        self.pos += u64::try_from(count).unwrap();
-        Ok(count)
-    }
-}
-
-impl<W> io::Write for SdCardWrapper<W>
-where
-    W: io::Write + io::Seek,
-{
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        let pos = usize::try_from(self.pos).unwrap();
-
-        let count = if pos < self.buf.len() {
-            let count = std::cmp::min(self.buf.len() - pos, buf.len());
-            self.inner
-                .seek(io::SeekFrom::Current(i64::try_from(count).unwrap()))?;
-            self.buf.as_mut_slice()[pos..(pos + count)].copy_from_slice(&buf[..count]);
-            count
-        } else {
-            self.inner.write(buf)?
-        };
-
-        self.pos += u64::try_from(count).unwrap();
-        Ok(count)
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        self.inner.flush()
-    }
-}
-
-impl<W> io::Seek for SdCardWrapper<W>
-where
-    W: io::Seek,
-{
-    fn seek(&mut self, pos: io::SeekFrom) -> io::Result<u64> {
-        self.pos = self.inner.seek(pos)?;
-        Ok(self.pos)
     }
 }
 

--- a/bb-flasher-sd/src/helpers.rs
+++ b/bb-flasher-sd/src/helpers.rs
@@ -240,6 +240,15 @@ where
     }
 }
 
+impl<W> EjectAsync for DeviceWrapperAsync<W>
+where
+    W: tokio::io::AsyncRead + tokio::io::AsyncWrite + tokio::io::AsyncSeek + Unpin + EjectAsync,
+{
+    async fn eject(self) -> io::Result<()> {
+        self.f.eject().await
+    }
+}
+
 #[repr(align(4096))]
 #[derive(Debug)]
 pub(crate) struct DirectIoBuffer<const N: usize>([u8; N]);

--- a/bb-flasher-sd/src/helpers.rs
+++ b/bb-flasher-sd/src/helpers.rs
@@ -34,6 +34,16 @@ impl Eject for std::fs::File {
     }
 }
 
+pub(crate) trait EjectAsync {
+    fn eject(self) -> impl Future<Output = io::Result<()>>;
+}
+
+impl EjectAsync for tokio::fs::File {
+    async fn eject(self) -> io::Result<()> {
+        self.sync_all().await
+    }
+}
+
 const BLOCK_SIZE: usize = 4096;
 
 #[derive(Debug)]
@@ -515,15 +525,13 @@ where
     }
 }
 
-impl<W> Eject for SdCardWrapperAsync<W>
+impl<W> EjectAsync for SdCardWrapperAsync<W>
 where
-    W: tokio::io::AsyncRead + tokio::io::AsyncWrite + tokio::io::AsyncSeek + Unpin + Eject,
+    W: tokio::io::AsyncRead + tokio::io::AsyncWrite + tokio::io::AsyncSeek + Unpin + EjectAsync,
 {
-    fn eject(mut self) -> io::Result<()> {
-        tokio::runtime::Handle::current().block_on(async {
-            self.finish().await?;
-            self.inner.eject()
-        })
+    async fn eject(mut self) -> io::Result<()> {
+        self.finish().await?;
+        self.inner.eject().await
     }
 }
 

--- a/bb-flasher-sd/src/pal/linux.rs
+++ b/bb-flasher-sd/src/pal/linux.rs
@@ -1,4 +1,4 @@
-use crate::helpers::EjectAsync;
+use crate::helpers::Eject;
 use crate::{Error, Result};
 
 use std::{
@@ -139,7 +139,7 @@ pub(crate) struct LinuxDrive {
 }
 
 #[cfg(feature = "udev")]
-impl EjectAsync for LinuxDrive {
+impl Eject for LinuxDrive {
     async fn eject(self) -> io::Result<()> {
         async fn inner(dst: PathBuf) -> io::Result<()> {
             let dbus_client = udisks2::Client::new().await.map_err(io::Error::other)?;
@@ -191,7 +191,7 @@ impl EjectAsync for LinuxDrive {
 }
 
 #[cfg(not(feature = "udev"))]
-impl EjectAsync for LinuxDrive {
+impl Eject for LinuxDrive {
     async fn eject(self) -> std::io::Result<()> {
         let _ = self.file.sync_all().await;
         let drive = self.drive.clone();

--- a/bb-flasher-sd/src/pal/linux.rs
+++ b/bb-flasher-sd/src/pal/linux.rs
@@ -1,8 +1,11 @@
-use crate::{Error, Result, helpers::Eject};
+use crate::helpers::EjectAsync;
+use crate::{Error, Result};
 
 use std::{
     io,
     path::{Path, PathBuf},
+    pin::Pin,
+    task::{Context, Poll},
 };
 
 #[cfg(feature = "udev")]
@@ -83,7 +86,7 @@ pub(crate) async fn open(dst: &Path) -> Result<LinuxDrive> {
             .open_device("rw", HashMap::from([("flags", libc::O_DIRECT.into())]))
             .await?;
         let file =
-            unsafe { std::fs::File::from_raw_fd(std::os::fd::OwnedFd::from(fd).into_raw_fd()) };
+            unsafe { tokio::fs::File::from_raw_fd(std::os::fd::OwnedFd::from(fd).into_raw_fd()) };
 
         Ok(LinuxDrive {
             file,
@@ -104,9 +107,7 @@ pub(crate) async fn open(dst: &Path) -> Result<LinuxDrive> {
         .create(false)
         .custom_flags(libc::O_DIRECT)
         .open(dst)
-        .await?
-        .into_std()
-        .await;
+        .await?;
 
     Ok(LinuxDrive {
         file,
@@ -133,13 +134,13 @@ pub(crate) async fn format(dst: &Path) -> Result<()> {
 
 #[derive(Debug)]
 pub(crate) struct LinuxDrive {
-    file: std::fs::File,
+    file: tokio::fs::File,
     drive: PathBuf,
 }
 
 #[cfg(feature = "udev")]
-impl Eject for LinuxDrive {
-    fn eject(self) -> io::Result<()> {
+impl EjectAsync for LinuxDrive {
+    async fn eject(self) -> io::Result<()> {
         async fn inner(dst: PathBuf) -> io::Result<()> {
             let dbus_client = udisks2::Client::new().await.map_err(io::Error::other)?;
 
@@ -180,28 +181,26 @@ impl Eject for LinuxDrive {
             Ok(())
         }
 
-        let _ = self.file.sync_all();
+        let _ = self.file.sync_all().await?;
         let dst = self.drive.clone();
 
         std::mem::drop(self);
 
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_io()
-            .build()
-            .unwrap();
-        rt.block_on(async move { inner(dst).await })
-            .map_err(io::Error::other)
+        inner(dst).await.map_err(io::Error::other)
     }
 }
 
 #[cfg(not(feature = "udev"))]
-impl Eject for LinuxDrive {
-    fn eject(self) -> std::io::Result<()> {
-        let _ = self.file.sync_all();
+impl EjectAsync for LinuxDrive {
+    async fn eject(self) -> std::io::Result<()> {
+        let _ = self.file.sync_all().await;
         let drive = self.drive.clone();
         std::mem::drop(self);
 
-        let output = std::process::Command::new("eject").arg(drive).output()?;
+        let output = tokio::process::Command::new("eject")
+            .arg(drive)
+            .output()
+            .await?;
 
         if output.status.success() {
             Ok(())
@@ -212,25 +211,40 @@ impl Eject for LinuxDrive {
         }
     }
 }
-
-impl io::Read for LinuxDrive {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.file.read(buf)
+impl tokio::io::AsyncRead for LinuxDrive {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.file).poll_read(cx, buf)
     }
 }
 
-impl io::Seek for LinuxDrive {
-    fn seek(&mut self, pos: io::SeekFrom) -> io::Result<u64> {
-        self.file.seek(pos)
+impl tokio::io::AsyncSeek for LinuxDrive {
+    fn start_seek(mut self: Pin<&mut Self>, position: io::SeekFrom) -> io::Result<()> {
+        Pin::new(&mut self.file).start_seek(position)
+    }
+
+    fn poll_complete(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<u64>> {
+        Pin::new(&mut self.file).poll_complete(cx)
     }
 }
 
-impl io::Write for LinuxDrive {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.file.write(buf)
+impl tokio::io::AsyncWrite for LinuxDrive {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.file).poll_write(cx, buf)
     }
 
-    fn flush(&mut self) -> io::Result<()> {
-        self.file.flush()
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.file).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.file).poll_shutdown(cx)
     }
 }


### PR DESCRIPTION
- Planning to remove sync internals. This change will allow gradual migration (first reader task then writer).
- Mainly for preparation for bootfs support.