### PR TITLE
bb-flasher-sd: Partial async migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,6 +639,7 @@ dependencies = [
  "bb-drivelist",
  "fatfs",
  "fscommon",
+ "futures",
  "gpt",
  "libc",
  "mbrman",
@@ -7035,6 +7036,7 @@ checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "futures-util",
  "pin-project-lite",

--- a/bb-flasher-sd/Cargo.toml
+++ b/bb-flasher-sd/Cargo.toml
@@ -19,9 +19,13 @@ fscommon = "0.1"
 mbrman = "0.6"
 gpt = "4.1"
 bb-bmap-parser = { version = "0.1", path = "../bb-bmap-parser" }
-tokio = { version = "1.52", default-features = false, features = ["rt-multi-thread", "fs"] }
-tokio-util = { version = "0.7" }
+tokio = { version = "1.52", default-features = false, features = ["rt-multi-thread", "fs", "io-util"] }
+tokio-util = { version = "0.7", features = ["io-util", "compat", "rt"] }
 anyhow = "1.0"
+futures = "0.3"
+
+[dev-dependencies]
+tokio = { version = "1.52", default-features = false, features = ["rt-multi-thread", "fs", "io-util", "macros"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 udisks2 = { version = "0.3", optional = true }

--- a/bb-flasher-sd/src/flashing/mod.rs
+++ b/bb-flasher-sd/src/flashing/mod.rs
@@ -1,11 +1,13 @@
-use std::io::{Read, Seek, Write};
+use std::io::Read;
 use std::time::Instant;
 
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt, AsyncWrite, AsyncWriteExt};
 use tokio::sync::mpsc;
+use tokio_util::compat::FuturesAsyncReadCompatExt;
 
 use crate::Result;
 use crate::customization::Customization;
-use crate::helpers::{DirectIoBuffer, Eject, chan_send, check_token, progress};
+use crate::helpers::{DirectIoBuffer, Eject, chan_send, progress};
 
 #[cfg(test)]
 mod tests;
@@ -16,22 +18,21 @@ const BUFFER_SIZE: usize = 1 * 1024 * 1024;
 #[cfg(debug_assertions)]
 const BUFFER_SIZE: usize = 8 * 1024;
 
-fn reader_task(
-    mut img: impl Read,
-    buf_rx: std::sync::mpsc::Receiver<Box<DirectIoBuffer<BUFFER_SIZE>>>,
-    buf_tx: std::sync::mpsc::SyncSender<(Box<DirectIoBuffer<BUFFER_SIZE>>, usize)>,
-    cancel: Option<tokio_util::sync::CancellationToken>,
+async fn reader_task(
+    mut img: impl AsyncRead + Unpin,
+    mut buf_rx: mpsc::Receiver<Box<DirectIoBuffer<BUFFER_SIZE>>>,
+    buf_tx: mpsc::Sender<(Box<DirectIoBuffer<BUFFER_SIZE>>, usize)>,
 ) -> Result<()> {
-    while let Ok(mut buf) = buf_rx.recv() {
-        let count = read_aligned(&mut img, buf.as_mut_slice())?;
+    while let Some(mut buf) = buf_rx.recv().await {
+        let count = read_aligned(&mut img, buf.as_mut_slice()).await?;
         if count == 0 {
             break;
         }
 
         buf_tx
             .send((buf, count))
+            .await
             .map_err(|_| crate::Error::WriterClosed)?;
-        check_token(cancel.as_ref())?;
     }
 
     Ok(())
@@ -42,16 +43,18 @@ fn reader_task(
 /// - All writes should be aligned to block size (4K).
 ///
 /// Thus, we will be writing some data that is not strictly present in the bmap.
-fn writer_task_bmap(
+async fn writer_task_bmap<Sd>(
     bmap: bb_bmap_parser::Bmap,
-    mut sd: impl Write + Seek,
-    mut chan: Option<&mut mpsc::Sender<f32>>,
-    buf_rx: std::sync::mpsc::Receiver<(Box<DirectIoBuffer<BUFFER_SIZE>>, usize)>,
-    buf_tx: std::sync::mpsc::SyncSender<Box<DirectIoBuffer<BUFFER_SIZE>>>,
-    cancel: Option<tokio_util::sync::CancellationToken>,
-) -> Result<()> {
+    mut sd: Sd,
+    mut chan: Option<mpsc::Sender<f32>>,
+    mut buf_rx: mpsc::Receiver<(Box<DirectIoBuffer<BUFFER_SIZE>>, usize)>,
+    buf_tx: mpsc::Sender<Box<DirectIoBuffer<BUFFER_SIZE>>>,
+) -> Result<Sd>
+where
+    Sd: AsyncWrite + AsyncSeek + Unpin,
+{
     let mut pos = 0;
-    let (mut buf, mut count) = buf_rx.recv().unwrap();
+    let (mut buf, mut count) = buf_rx.recv().await.unwrap();
     let img_size = bmap.total_mapped_size();
     let mut bytes_written = 0u64;
 
@@ -59,75 +62,70 @@ fn writer_task_bmap(
         let end_offset = b.offset() + b.length();
 
         loop {
+            tracing::debug!("pos: {pos}, bytes_written: {bytes_written}, end_offset: {end_offset}");
             // Write any buffer that lies even partially in the bmap range.
             if pos + (count as u64) > b.offset() && pos < end_offset {
-                sd.seek(std::io::SeekFrom::Start(pos))?;
-                sd.write_all(&buf.as_slice()[..count])?;
+                sd.seek(std::io::SeekFrom::Start(pos)).await?;
+                sd.write_all(&buf.as_slice()[..count]).await?;
                 bytes_written += count as u64;
             } else if pos >= end_offset {
                 break;
             }
 
             pos += count as u64;
-            // Clippy warning is simply wrong here
-            #[allow(clippy::option_map_or_none)]
-            chan_send(
-                chan.as_mut().map_or(None, |p| Some(p)),
-                progress(bytes_written, img_size),
-            );
-            check_token(cancel.as_ref())?;
+            chan_send(chan.as_mut(), progress(bytes_written, img_size));
 
-            match buf_rx.recv() {
-                Ok((x, y)) => {
-                    let _ = buf_tx.send(buf);
+            match buf_rx.recv().await {
+                Some((x, y)) => {
+                    let _ = buf_tx.send(buf).await;
                     buf = x;
                     count = y;
                 }
-                Err(_) => break,
+                None => break,
             }
         }
     }
 
-    sd.flush().map_err(Into::into)
+    sd.flush().await?;
+
+    Ok(sd)
 }
 
-fn writer_task(
+async fn writer_task<Sd>(
     img_size: u64,
-    mut sd: impl Write + Seek,
-    mut chan: Option<&mut mpsc::Sender<f32>>,
-    buf_rx: std::sync::mpsc::Receiver<(Box<DirectIoBuffer<BUFFER_SIZE>>, usize)>,
-    buf_tx: std::sync::mpsc::SyncSender<Box<DirectIoBuffer<BUFFER_SIZE>>>,
-    cancel: Option<tokio_util::sync::CancellationToken>,
-) -> Result<()> {
+    mut sd: Sd,
+    mut chan: Option<mpsc::Sender<f32>>,
+    mut buf_rx: mpsc::Receiver<(Box<DirectIoBuffer<BUFFER_SIZE>>, usize)>,
+    buf_tx: mpsc::Sender<Box<DirectIoBuffer<BUFFER_SIZE>>>,
+) -> Result<Sd>
+where
+    Sd: AsyncWrite + Unpin,
+{
     let mut pos = 0u64;
 
-    while let Ok((buf, count)) = buf_rx.recv() {
-        sd.write_all(&buf.as_slice()[..count])?;
+    while let Some((buf, count)) = buf_rx.recv().await {
+        sd.write_all(&buf.as_slice()[..count]).await?;
 
         pos += count as u64;
-        // Clippy warning is simply wrong here
-        #[allow(clippy::option_map_or_none)]
-        chan_send(
-            chan.as_mut().map_or(None, |p| Some(p)),
-            progress(pos, img_size),
-        );
+        chan_send(chan.as_mut(), progress(pos, img_size));
 
-        let _ = buf_tx.send(buf);
-        check_token(cancel.as_ref())?;
+        let _ = buf_tx.send(buf).await;
     }
 
-    sd.flush().map_err(Into::into)
+    sd.flush().await?;
+
+    Ok(sd)
 }
 
 /// A lot of reads from compressed files are not aligned. Since reading even from compressed files
 /// is significantly faster than writing to SD Card, better to do multiple reads.
-fn read_aligned(mut img: impl Read, buf: &mut [u8]) -> Result<usize> {
+async fn read_aligned(mut img: impl AsyncRead + Unpin, buf: &mut [u8]) -> Result<usize> {
     const ALIGNMENT: usize = 512;
 
     let mut pos = 0;
 
     while pos != buf.len() {
-        let count = img.read(&mut buf[pos..])?;
+        let count = img.read(&mut buf[pos..]).await?;
         if count == 0 {
             if pos % ALIGNMENT != 0 {
                 let end = pos - pos % ALIGNMENT + ALIGNMENT;
@@ -142,37 +140,51 @@ fn read_aligned(mut img: impl Read, buf: &mut [u8]) -> Result<usize> {
     Ok(pos)
 }
 
-fn write_sd(
-    img: impl Read + Send,
+async fn write_sd<Sd>(
+    img: impl AsyncRead + Unpin + Send + 'static,
     img_size: u64,
     bmap: Option<bb_bmap_parser::Bmap>,
-    sd: impl Write + Seek,
-    chan: Option<&mut mpsc::Sender<f32>>,
-    cancel: Option<tokio_util::sync::CancellationToken>,
-) -> Result<()> {
+    sd: Sd,
+    chan: Option<mpsc::Sender<f32>>,
+) -> Result<Sd>
+where
+    Sd: AsyncWrite + AsyncSeek + Unpin + Send + 'static,
+{
     const NUM_BUFFERS: usize = 4;
 
-    let (tx1, rx1) = std::sync::mpsc::sync_channel(NUM_BUFFERS);
-    let (tx2, rx2) = std::sync::mpsc::sync_channel(NUM_BUFFERS);
+    let (tx1, rx1) = mpsc::channel(NUM_BUFFERS);
+    let (tx2, rx2) = mpsc::channel(NUM_BUFFERS);
     let global_start = Instant::now();
 
     // Starting buffers
     for _ in 0..NUM_BUFFERS {
-        tx1.send(Box::new(DirectIoBuffer::new())).unwrap();
+        tx1.send(Box::new(DirectIoBuffer::new())).await.unwrap();
     }
 
-    std::thread::scope(|s| {
-        let cancle_clone = cancel.clone();
-        let handle = s.spawn(move || reader_task(img, rx1, tx2, cancle_clone));
+    let reader = tokio::spawn(reader_task(img, rx1, tx2));
+    let mut reader = tokio_util::task::AbortOnDropHandle::new(reader);
 
-        match bmap {
-            Some(x) => writer_task_bmap(x, sd, chan, rx2, tx1, cancel),
-            None => writer_task(img_size, sd, chan, rx2, tx1, cancel),
-        }?;
-        tracing::info!("Total Time taken: {:?}", global_start.elapsed());
+    let writer = match bmap {
+        Some(x) => tokio::spawn(writer_task_bmap(x, sd, chan, rx2, tx1)),
+        None => tokio::spawn(writer_task(img_size, sd, chan, rx2, tx1)),
+    };
+    let mut writer = tokio_util::task::AbortOnDropHandle::new(writer);
 
-        handle.join().unwrap()
-    })
+    let res = tokio::select! {
+        r = &mut reader => {
+            r.unwrap()?;
+            writer.await.unwrap()
+        }
+        r = &mut writer => {
+            let sd = r.unwrap()?;
+            reader.await.unwrap()?;
+            Ok(sd)
+        }
+    };
+
+    tracing::info!("Total Time taken: {:?}", global_start.elapsed());
+
+    res
 }
 
 /// Flash OS image to SD card.
@@ -211,6 +223,33 @@ pub async fn flash<R: Read + Send + 'static>(
     customizations: Vec<Customization>,
     cancel: Option<tokio_util::sync::CancellationToken>,
 ) -> Result<()> {
+    let fut1 = flash_async(
+        async move {
+            img.await
+                .map(|(r, size)| (futures::io::AllowStdIo::new(r).compat(), size))
+        },
+        bmap,
+        dst,
+        chan,
+        customizations,
+    );
+
+    match cancel {
+        Some(x) => tokio::select! {
+            _ = x.cancelled() => Err(crate::Error::Aborted),
+            res = fut1 => res
+        },
+        None => fut1.await,
+    }
+}
+
+pub async fn flash_async<R: AsyncRead + Send + Unpin + 'static>(
+    img: impl Future<Output = std::io::Result<(R, u64)>>,
+    bmap: Option<impl Future<Output = std::io::Result<Box<str>>>>,
+    dst: crate::Destination,
+    chan: Option<mpsc::Sender<f32>>,
+    customizations: Vec<Customization>,
+) -> Result<()> {
     tracing::info!("Opening Destination");
 
     match dst {
@@ -221,25 +260,24 @@ pub async fn flash<R: Read + Send + 'static>(
                 .create(true)
                 .truncate(true)
                 .open(path)
-                .await?
-                .into_std()
-                .await;
-            flash_common(img, bmap, sd, chan, customizations, cancel).await
+                .await?;
+            flash_internal(img, bmap, sd, chan, customizations).await
         }
         crate::Destination::SdCard(path) => {
             let sd = crate::pal::open(&path).await?;
-            flash_common(img, bmap, sd, chan, customizations, cancel).await
+            let sd = crate::helpers::SdCardWrapper::new(sd);
+            let sd = futures::io::AllowStdIo::new(sd).compat();
+            flash_internal(img, bmap, sd, chan, customizations).await
         }
     }
 }
 
-async fn flash_common<R: Read + Send + 'static>(
+async fn flash_internal<R: AsyncRead + Send + Unpin + 'static>(
     img: impl Future<Output = std::io::Result<(R, u64)>>,
     bmap: Option<impl Future<Output = std::io::Result<Box<str>>>>,
-    sd: impl Read + Write + Seek + Eject + std::fmt::Debug + Send + 'static,
-    chan: Option<mpsc::Sender<f32>>,
+    sd: impl AsyncRead + AsyncWrite + AsyncSeek + Eject + std::fmt::Debug + Send + Unpin + 'static,
+    mut chan: Option<mpsc::Sender<f32>>,
     customizations: Vec<Customization>,
-    cancel: Option<tokio_util::sync::CancellationToken>,
 ) -> Result<()> {
     tracing::info!("Resolving Image");
     let bmap = match bmap {
@@ -250,45 +288,25 @@ async fn flash_common<R: Read + Send + 'static>(
     };
     let (img, img_size) = img.await?;
 
-    let cancel_child = cancel.as_ref().map(|x| x.child_token());
-    let res = tokio::task::spawn_blocking(move || {
-        flash_internal(img, img_size, bmap, sd, chan, customizations, cancel_child)
-    })
-    .await
-    .unwrap();
-
-    // Cancel all tasks on drop
-    let _drop_guard = cancel.map(|x| x.drop_guard());
-
-    res
-}
-
-fn flash_internal(
-    img: impl Read + Send,
-    img_size: u64,
-    bmap: Option<bb_bmap_parser::Bmap>,
-    sd: impl Read + Write + Seek + Eject + std::fmt::Debug,
-    mut chan: Option<mpsc::Sender<f32>>,
-    customizations: Vec<Customization>,
-    cancel: Option<tokio_util::sync::CancellationToken>,
-) -> Result<()> {
     chan_send(chan.as_mut(), 0.0);
 
-    let mut sd = crate::helpers::SdCardWrapper::new(sd);
-
     tracing::info!("Writing to SD Card");
-    write_sd(img, img_size, bmap, &mut sd, chan.as_mut(), cancel.clone())?;
-
-    check_token(cancel.as_ref())?;
+    let sd = write_sd(img, img_size, bmap, sd, chan).await?;
 
     tracing::info!("Applying customization");
-    for c in customizations {
-        let temp = crate::helpers::DeviceWrapper::new(&mut sd).unwrap();
-        c.customize(temp)?;
-    }
+    let sd = tokio_util::io::SyncIoBridge::new(sd);
+    tokio::task::spawn_blocking(move || {
+        let mut sd = crate::helpers::DeviceWrapper::new(sd).unwrap();
+        for c in customizations {
+            c.customize(&mut sd)?;
+        }
 
-    tracing::info!("Ejecting SD Card");
-    let _ = sd.eject();
+        tracing::info!("Ejecting SD Card");
+        let _ = sd.into_inner().into_inner().eject();
 
-    Ok(())
+        Ok(())
+    })
+    .await
+    .unwrap()
 }
+

--- a/bb-flasher-sd/src/flashing/tests.rs
+++ b/bb-flasher-sd/src/flashing/tests.rs
@@ -10,35 +10,29 @@ fn test_file(len: usize) -> std::io::Cursor<Box<[u8]>> {
     std::io::Cursor::new(data.into())
 }
 
-#[test]
-fn sd_write() {
+#[tokio::test]
+async fn sd_write() {
     const FILE_LEN: usize = 12 * 1024;
 
     let dummy_file = test_file(FILE_LEN);
-    let mut sd = std::io::Cursor::new(Vec::<u8>::new());
+    let sd = std::io::Cursor::new(Vec::<u8>::new());
 
-    write_sd(
-        dummy_file.clone(),
-        FILE_LEN as u64,
-        None,
-        &mut sd,
-        None,
-        None,
-    )
-    .unwrap();
+    let sd = write_sd(dummy_file.clone(), FILE_LEN as u64, None, sd, None)
+        .await
+        .unwrap();
 
     assert_eq!(sd.get_ref().as_slice(), dummy_file.get_ref().as_ref());
 }
 
-#[test]
-fn sd_write_bmap() {
+#[tokio::test]
+async fn sd_write_bmap() {
     const BLOCK_LEN: u64 = BUFFER_SIZE as u64;
     const FILE_LEN: usize = 32 * BUFFER_SIZE;
     const BLOCKS: u64 = (FILE_LEN as u64) / BLOCK_LEN;
     const MAPPED_BLOCKS: &[u64] = &[0, 2, BLOCKS - 1];
 
     let dummy_file = test_file(FILE_LEN);
-    let mut sd = std::io::Cursor::new(vec![0u8; FILE_LEN]);
+    let sd = std::io::Cursor::new(vec![0u8; FILE_LEN]);
 
     let mut bmap = bb_bmap_parser::Bmap::builder();
     bmap.image_size(FILE_LEN as u64)
@@ -57,14 +51,14 @@ fn sd_write_bmap() {
 
     let bmap = bmap.build().unwrap();
 
-    write_sd(
+    let sd = write_sd(
         dummy_file.clone(),
         FILE_LEN as u64,
         Some(bmap.clone()),
-        &mut sd,
-        None,
+        sd,
         None,
     )
+    .await
     .unwrap();
 
     for i in 0..(BLOCKS as usize) {
@@ -84,40 +78,25 @@ fn sd_write_bmap() {
     }
 }
 
-struct UnalignedReader(std::io::Cursor<Box<[u8]>>);
-
-impl UnalignedReader {
-    const fn as_slice(&self) -> &[u8] {
-        self.0.get_ref()
-    }
-}
-
-impl std::io::Read for UnalignedReader {
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        let count = std::cmp::min(self.0.get_ref().len() - self.0.position() as usize, 3);
-        let count = std::cmp::min(count, buf.len());
-        self.0.read(&mut buf[..count])
-    }
-}
-
-#[test]
-fn aligned_read() {
+#[tokio::test]
+async fn aligned_read() {
     const FILE_LEN: usize = 12 * 1024;
 
-    let mut dummy_file = UnalignedReader(test_file(FILE_LEN));
+    let mut dummy_file = test_file(FILE_LEN);
     let mut buf = [0u8; 1024];
     let mut pos = 0;
 
     loop {
-        let count = read_aligned(&mut dummy_file, &mut buf).unwrap();
+        let count = read_aligned(&mut dummy_file, &mut buf).await.unwrap();
         if count == 0 {
             break;
         }
 
         assert_eq!(count % 512, 0);
-        assert_eq!(buf[..count], dummy_file.as_slice()[pos..(pos + count)]);
+        assert_eq!(buf[..count], dummy_file.get_ref()[pos..(pos + count)]);
         pos += count;
     }
 
     assert_eq!(pos, FILE_LEN);
 }
+

--- a/bb-flasher-sd/src/helpers.rs
+++ b/bb-flasher-sd/src/helpers.rs
@@ -2,8 +2,6 @@ use std::io;
 
 use tokio::sync::mpsc;
 
-use crate::Result;
-
 pub(crate) fn chan_send(chan: Option<&mut mpsc::Sender<f32>>, msg: f32) {
     if let Some(c) = chan {
         let _ = c.try_send(msg);
@@ -14,13 +12,6 @@ pub(crate) const fn progress(pos: u64, img_size: u64) -> f32 {
     pos as f32 / img_size as f32
 }
 
-pub(crate) fn check_token(cancel: Option<&tokio_util::sync::CancellationToken>) -> Result<()> {
-    match cancel {
-        Some(x) if x.is_cancelled() => Err(crate::Error::Aborted),
-        _ => Ok(()),
-    }
-}
-
 pub(crate) trait Eject {
     fn eject(self) -> io::Result<()>;
 }
@@ -28,6 +19,24 @@ pub(crate) trait Eject {
 impl Eject for std::fs::File {
     fn eject(self) -> io::Result<()> {
         self.sync_all()
+    }
+}
+
+impl Eject for tokio::fs::File {
+    fn eject(self) -> io::Result<()> {
+        tokio::runtime::Handle::current().block_on(async move { self.sync_all().await })
+    }
+}
+
+impl<T: Eject> Eject for futures::io::AllowStdIo<T> {
+    fn eject(self) -> io::Result<()> {
+        self.into_inner().eject()
+    }
+}
+
+impl<T: Eject> Eject for tokio_util::compat::Compat<T> {
+    fn eject(self) -> io::Result<()> {
+        self.into_inner().eject()
     }
 }
 
@@ -56,6 +65,10 @@ impl<F> DeviceWrapper<F> {
     /// Number of bytes from `Self::cache_buf_offset` that can be used
     const fn cache_buf_hit_len(&self) -> usize {
         self.buf.len() - self.cache_buf_offset()
+    }
+
+    pub(crate) fn into_inner(self) -> F {
+        self.f
     }
 }
 

--- a/bb-imager-gui/src/message.rs
+++ b/bb-imager-gui/src/message.rs
@@ -438,7 +438,8 @@ pub(crate) fn update(state: &mut BBImager, message: BBImagerMessage) -> Task<BBI
                 OverlayData::Flashing(flashing_state) => flashing_state.progress_update(x),
                 _ => panic!("Unexpected message"),
             },
-            _ => panic!("Unexpected message"),
+            // Debug build can be slow.
+            _ => {}
         },
         BBImagerMessage::FlashStart | BBImagerMessage::Retry => {
             return state.start_flashing();


### PR DESCRIPTION
- Internally still mostly sync, but using the AllowStdIO bridge.
- No change in public API yet.
- No performance regression observed.
- Fast tracking from #482 