### PR TITLE
bb-flasher-sd: Improve sync-async conversions

### DIFF
--- a/bb-flasher-sd/src/flashing/mod.rs
+++ b/bb-flasher-sd/src/flashing/mod.rs
@@ -7,7 +7,7 @@ use tokio_util::compat::FuturesAsyncReadCompatExt;
 
 use crate::Result;
 use crate::customization::Customization;
-use crate::helpers::{DirectIoBuffer, Eject, chan_send, progress};
+use crate::helpers::{DirectIoBuffer, Eject, IntoStdIo, chan_send, progress};
 
 #[cfg(test)]
 mod tests;
@@ -272,13 +272,17 @@ pub async fn flash_async<R: AsyncRead + Send + Unpin + 'static>(
     }
 }
 
-async fn flash_internal<R: AsyncRead + Send + Unpin + 'static>(
+async fn flash_internal<R, Sd>(
     img: impl Future<Output = std::io::Result<(R, u64)>>,
     bmap: Option<impl Future<Output = std::io::Result<Box<str>>>>,
-    sd: impl AsyncRead + AsyncWrite + AsyncSeek + Eject + std::fmt::Debug + Send + Unpin + 'static,
+    sd: Sd,
     mut chan: Option<mpsc::Sender<f32>>,
     customizations: Vec<Customization>,
-) -> Result<()> {
+) -> Result<()>
+where
+    R: AsyncRead + Send + Unpin + 'static,
+    Sd: AsyncRead + AsyncWrite + AsyncSeek + std::fmt::Debug + Send + Unpin + IntoStdIo + 'static,
+{
     tracing::info!("Resolving Image");
     let bmap = match bmap {
         Some(x) => {
@@ -294,7 +298,7 @@ async fn flash_internal<R: AsyncRead + Send + Unpin + 'static>(
     let sd = write_sd(img, img_size, bmap, sd, chan).await?;
 
     tracing::info!("Applying customization");
-    let sd = tokio_util::io::SyncIoBridge::new(sd);
+    let sd = sd.into_std_io().await?;
     let sd = tokio::task::spawn_blocking(move || {
         let mut sd = crate::helpers::DeviceWrapper::new(sd).unwrap();
         for c in customizations {
@@ -307,7 +311,7 @@ async fn flash_internal<R: AsyncRead + Send + Unpin + 'static>(
     .unwrap()?;
 
     tracing::info!("Ejecting SD Card");
-    let _ = sd.into_inner().eject().await;
+    let _ = sd.eject().await;
 
     Ok(())
 }

--- a/bb-flasher-sd/src/helpers.rs
+++ b/bb-flasher-sd/src/helpers.rs
@@ -1,9 +1,10 @@
-use std::io;
+use std::io::{self, Write};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use tokio::io::{AsyncSeek, AsyncSeekExt, AsyncWriteExt};
 use tokio::sync::mpsc;
+use tokio_util::io::SyncIoBridge;
 
 pub(crate) fn chan_send(chan: Option<&mut mpsc::Sender<f32>>, msg: f32) {
     if let Some(c) = chan {
@@ -19,8 +20,20 @@ pub(crate) trait Eject {
     fn eject(self) -> impl Future<Output = io::Result<()>>;
 }
 
+impl Eject for std::fs::File {
+    async fn eject(mut self) -> io::Result<()> {
+        tokio::task::spawn_blocking(move || {
+            self.flush()?;
+            self.sync_all()
+        })
+        .await
+        .unwrap()
+    }
+}
+
 impl Eject for tokio::fs::File {
-    async fn eject(self) -> io::Result<()> {
+    async fn eject(mut self) -> io::Result<()> {
+        self.flush().await?;
         self.sync_all().await
     }
 }
@@ -234,12 +247,20 @@ where
     }
 }
 
+impl<W> Eject for SyncIoBridge<W>
+where
+    W: Unpin + Eject,
+{
+    async fn eject(self) -> io::Result<()> {
+        self.into_inner().eject().await
+    }
+}
+
 impl<W> Eject for SdCardWrapper<W>
 where
     W: tokio::io::AsyncWrite + AsyncSeek + Unpin + Eject,
 {
     async fn eject(mut self) -> io::Result<()> {
-        // TODO: Make finish async
         self.finish().await?;
         self.inner.eject().await
     }
@@ -326,6 +347,33 @@ where
     fn poll_complete(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<u64>> {
         self.pos = std::task::ready!(Pin::new(&mut self.inner).poll_complete(cx))?;
         Poll::Ready(Ok(self.pos))
+    }
+}
+
+pub(crate) trait IntoStdIo {
+    type Output: io::Read + io::Write + io::Seek + std::fmt::Debug + Send + Eject;
+
+    fn into_std_io(self) -> impl Future<Output = io::Result<Self::Output>>;
+}
+
+impl IntoStdIo for tokio::fs::File {
+    type Output = std::fs::File;
+
+    async fn into_std_io(self) -> io::Result<Self::Output> {
+        Ok(self.into_std().await)
+    }
+}
+
+impl<T> IntoStdIo for SdCardWrapper<tokio_util::compat::Compat<futures::io::AllowStdIo<T>>>
+where
+    T: io::Read + io::Write + io::Seek + std::fmt::Debug + Send + Eject,
+{
+    type Output = tokio_util::io::SyncIoBridge<
+        SdCardWrapper<tokio_util::compat::Compat<futures::io::AllowStdIo<T>>>,
+    >;
+
+    async fn into_std_io(self) -> io::Result<Self::Output> {
+        Ok(tokio_util::io::SyncIoBridge::new(self))
     }
 }
 


### PR DESCRIPTION
- After some digging, it seems like using tokio::fs::File is not possible for O_DIRECT. So unless I decide to not use O_DIRECT, need to stick to futures::io::AllowStdIo.
- Since we need to go from async to sync for customization, it feels weird to have SyncIoBridge<AllowStdIo<T>>. So introduce helper traits that allow not having to do this.