### PR TITLE
bb-config: remove non_exhaustive from Flasher

### DIFF
--- a/bb-config/src/config.rs
+++ b/bb-config/src/config.rs
@@ -182,7 +182,6 @@ pub struct OsImage {
 
 /// Types of flashers Os Image(s) support
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Deserialize, Serialize, sqlx::Type)]
-#[non_exhaustive]
 pub enum Flasher {
     #[default]
     /// Image needs to be written to SD Card


### PR DESCRIPTION
- Just made using _ mandatory in matches, which makes things difficult to track when adding new flasher.