### PR TITLE
bb-imager-gui: Properly update flasher

### DIFF
--- a/bb-imager-gui/src/db/mod.rs
+++ b/bb-imager-gui/src/db/mod.rs
@@ -103,6 +103,7 @@ pub(crate) struct OsSublistListItem {
     pub(crate) id: i64,
     pub(crate) icon: Url,
     pub(crate) name: String,
+    pub(crate) flasher: bb_config::config::Flasher,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -616,7 +617,7 @@ impl Db {
     ) -> sqlx::Result<Vec<OsSublistListItem>> {
         sqlx::query_as(
             r#"
-            SELECT s.id, s.name, s.icon
+            SELECT s.id, s.name, s.icon, s.flasher
             FROM os_sublists s
             JOIN os_sublist_boards sb ON sb.sublist_id = s.id
             WHERE sb.board_id = $1

--- a/bb-imager-gui/src/helpers.rs
+++ b/bb-imager-gui/src/helpers.rs
@@ -824,7 +824,7 @@ pub(crate) enum OsImageId {
     Local(config::Flasher),
     // points to OsImage
     OsImage(i64),
-    OsSublist(i64),
+    OsSublist((i64, config::Flasher)),
 }
 
 #[derive(Debug, Clone)]
@@ -847,7 +847,7 @@ impl From<crate::db::OsImageListItem> for OsImageItem {
 impl From<crate::db::OsSublistListItem> for OsImageItem {
     fn from(value: crate::db::OsSublistListItem) -> Self {
         Self {
-            id: OsImageId::OsSublist(value.id),
+            id: OsImageId::OsSublist((value.id, value.flasher)),
             icon: Some(value.icon.into()),
             label: Cow::Owned(value.name),
         }

--- a/bb-imager-gui/src/message.rs
+++ b/bb-imager-gui/src/message.rs
@@ -174,8 +174,8 @@ pub(crate) fn update(state: &mut BBImager, message: BBImagerMessage) -> Task<BBI
                 helpers::OsImageId::OsSublist(id) => {
                     let board_id = inner.selected_board.id;
                     return Task::batch([
-                        inner.resolve_remote_sublists(board_id, Some(id)),
-                        inner.update_pos(Some(id)),
+                        inner.resolve_remote_sublists(board_id, Some(id.0)),
+                        inner.update_pos(Some(id.0), id.1),
                     ]);
                 }
             },

--- a/bb-imager-gui/src/state.rs
+++ b/bb-imager-gui/src/state.rs
@@ -195,8 +195,13 @@ impl ChooseOsState {
         self.refresh_image_list()
     }
 
-    pub fn update_pos(&mut self, pos: Option<i64>) -> Task<BBImagerMessage> {
+    pub fn update_pos(
+        &mut self,
+        pos: Option<i64>,
+        flasher: config::Flasher,
+    ) -> Task<BBImagerMessage> {
         self.pos = pos;
+        self.flasher = flasher;
         self.refresh_image_list()
     }
 }


### PR DESCRIPTION
- OsImage does not contain flasher. It is instead present in parent sublist. So we need to update flasher when navigating to subitem.