### PR TITLE
bb-imager-gui: Add bootfs update support

### DIFF
--- a/bb-config/src/config.rs
+++ b/bb-config/src/config.rs
@@ -186,6 +186,8 @@ pub enum Flasher {
     #[default]
     /// Image needs to be written to SD Card
     SdCard,
+    /// Archive for updated bootfs
+    SdCardBootfs,
     /// BeagleConnect Freedom CC1352P7 Firmware
     BeagleConnectFreedom,
     /// BeagleConnect Freedom Msp430 Firmware

--- a/bb-flasher/src/flasher/sd/mod.rs
+++ b/bb-flasher/src/flasher/sd/mod.rs
@@ -314,16 +314,20 @@ impl<F> UpdateBootFlasher<F>
 where
     F: FnOnce() -> std::io::Result<crate::img::OsArchive>,
 {
-    const fn new(img: F, dst: bb_flasher_sd::Destination, cancel: Option<Arc<AtomicBool>>) -> Self {
-        Self { img, dst, cancel }
+    pub fn new(img: F, dst: Target, cancel: Option<Arc<AtomicBool>>) -> Self {
+        Self {
+            img,
+            dst: bb_flasher_sd::Destination::SdCard(dst.0.path.into_boxed_path()),
+            cancel,
+        }
     }
 
     pub fn with_file_dest(img: F, dst: PathBuf, cancel: Option<Arc<AtomicBool>>) -> Self {
-        Self::new(
+        Self {
             img,
-            bb_flasher_sd::Destination::File(dst.into_boxed_path()),
+            dst: bb_flasher_sd::Destination::File(dst.into_boxed_path()),
             cancel,
-        )
+        }
     }
 
     pub fn flash(self) -> anyhow::Result<()> {

--- a/bb-flasher/src/img/mod.rs
+++ b/bb-flasher/src/img/mod.rs
@@ -20,15 +20,31 @@ pub struct OsArchive {
 }
 
 impl OsArchive {
+    fn new(img: OsImageSource, chan: Option<mpsc::SyncSender<f32>>, size: u64) -> io::Result<Self> {
+        let img = ReaderWithProgress::new(img, size, chan);
+        let img = OsArchiveCompression::new(img)?;
+        Ok(Self { inner: img })
+    }
+
     pub fn from_path(path: &Path, chan: Option<mpsc::SyncSender<f32>>) -> io::Result<Self> {
         let file = std::fs::File::open(path)?;
         let len = file.metadata()?.len();
 
         let img = OsImageSource::from(file);
-        let img = ReaderWithProgress::new(img, len, chan);
-        let img = OsArchiveCompression::new(img)?;
+        Self::new(img, chan, len)
+    }
 
-        Ok(Self { inner: img })
+    pub fn from_piped(
+        img: ReaderFileStream,
+        abort_handle: tokio::task::JoinHandle<io::Result<()>>,
+        size: u64,
+        chan: Option<mpsc::SyncSender<f32>>,
+    ) -> io::Result<Self> {
+        let img = OsImageSource::FileStream {
+            reader: img,
+            _background: AbortOnDropHandle::new(abort_handle),
+        };
+        Self::new(img, chan, size)
     }
 }
 

--- a/bb-flasher/src/lib.rs
+++ b/bb-flasher/src/lib.rs
@@ -45,9 +45,7 @@ use std::path::Path;
 
 pub use common::*;
 pub use flasher::*;
-pub use img::OsImage;
-
-use crate::img::OsArchive;
+pub use img::{OsImage, OsArchive};
 
 /// An Os Image present in the local filesystem
 #[derive(Debug, Clone)]

--- a/bb-imager-gui/src/helpers.rs
+++ b/bb-imager-gui/src/helpers.rs
@@ -255,6 +255,47 @@ impl RemoteImage {
     fn file_name(&self) -> &str {
         self.url.path_segments().unwrap().next_back().unwrap()
     }
+
+    fn into_archive_fn(
+        self,
+        tx: Option<std::sync::mpsc::SyncSender<f32>>,
+    ) -> impl FnOnce() -> std::io::Result<bb_flasher::OsArchive> {
+        move || {
+            let rt = tokio::runtime::Builder::new_multi_thread().build().unwrap();
+
+            let downloader = self.downloader.clone();
+            let cache =
+                rt.block_on(
+                    async move { downloader.check_cache_from_sha(self.extract_sha256).await },
+                );
+
+            if let Some(path) = cache {
+                tracing::info!("Found the remote image in cache");
+                return bb_flasher::OsArchive::from_path(&path, tx);
+            }
+
+            tracing::info!("Remote image not found in cache. Downloading");
+            let (tx_stream, rx) = bb_helper::file_stream::file_stream()?;
+            let downloader = self.downloader.clone();
+            let url = self.url.clone();
+            let sha = self.extract_sha256;
+
+            let t: tokio::task::JoinHandle<std::io::Result<()>> = rt.spawn(async move {
+                downloader
+                    .download_to_stream(*url, sha, tx_stream)
+                    .await
+                    .map_err(|e| {
+                        let msg = format!("Error while downloading Os Image: {e}");
+                        tracing::error!("{}", &msg);
+                        std::io::Error::other(msg)
+                    })?;
+                tracing::info!("Image download finished");
+                Ok(())
+            });
+
+            bb_flasher::OsArchive::from_piped(rx, t, self.extract_size, tx)
+        }
+    }
 }
 
 impl IntoFuture for RemoteImage {
@@ -339,6 +380,16 @@ impl SelectedImage {
             Self::RemoteImage(x) => x.file_name().to_string(),
         }
     }
+
+    fn into_archive_fn(
+        self,
+        tx: Option<std::sync::mpsc::SyncSender<f32>>,
+    ) -> Box<dyn FnOnce() -> std::io::Result<bb_flasher::OsArchive>> {
+        match self {
+            SelectedImage::LocalImage(x) => Box::new(x.into_archive_fn(tx)),
+            SelectedImage::RemoteImage(x) => Box::new(x.into_archive_fn(tx)),
+        }
+    }
 }
 
 impl IntoFuture for SelectedImage {
@@ -387,7 +438,13 @@ pub(crate) async fn flash(
                 .flash(Some(chan))
                 .await
         }
-        (BoardImage::Image { img, bmap, .. }, customization, Destination::LocalFile(f)) => {
+        (
+            BoardImage::Image {
+                img, bmap, flasher, ..
+            },
+            customization,
+            Destination::LocalFile(f),
+        ) if flasher == config::Flasher::SdCard => {
             bb_flasher::sd::Flasher::with_file_dest(
                 img.into_future(),
                 bmap.map(IntoFuture::into_future),
@@ -398,7 +455,13 @@ pub(crate) async fn flash(
             .flash(Some(chan))
             .await
         }
-        (BoardImage::Image { img, bmap, .. }, customization, Destination::SdCard(t)) => {
+        (
+            BoardImage::Image {
+                img, bmap, flasher, ..
+            },
+            customization,
+            Destination::SdCard(t),
+        ) if flasher == config::Flasher::SdCard => {
             bb_flasher::sd::Flasher::new(
                 img.into_future(),
                 bmap.map(IntoFuture::into_future),
@@ -408,6 +471,42 @@ pub(crate) async fn flash(
             )
             .flash(Some(chan))
             .await
+        }
+        (BoardImage::Image { img, flasher, .. }, _, Destination::SdCard(t))
+            if flasher == config::Flasher::SdCardBootfs =>
+        {
+            let (tx, rx) = std::sync::mpsc::sync_channel(4);
+            tokio::task::spawn_blocking(move || {
+                while let Ok(msg) = rx.recv() {
+                    let _ = chan.blocking_send(DownloadFlashingStatus::FlashingProgress(msg));
+                }
+            });
+            tokio::task::spawn_blocking(move || {
+                bb_flasher::sd::UpdateBootFlasher::new(img.into_archive_fn(Some(tx)), t, None)
+                    .flash()
+            })
+            .await
+            .unwrap()
+        }
+        (BoardImage::Image { img, flasher, .. }, _, Destination::LocalFile(t))
+            if flasher == config::Flasher::SdCardBootfs =>
+        {
+            let (tx, rx) = std::sync::mpsc::sync_channel(4);
+            tokio::task::spawn_blocking(move || {
+                while let Ok(msg) = rx.recv() {
+                    let _ = chan.blocking_send(DownloadFlashingStatus::FlashingProgress(msg));
+                }
+            });
+            tokio::task::spawn_blocking(move || {
+                bb_flasher::sd::UpdateBootFlasher::with_file_dest(
+                    img.into_archive_fn(Some(tx)),
+                    t,
+                    None,
+                )
+                .flash()
+            })
+            .await
+            .unwrap()
         }
         #[cfg(feature = "bcf_cc1352p7")]
         (
@@ -509,11 +608,13 @@ impl Destination {
 
 pub(crate) async fn destinations(flasher: config::Flasher, filter: bool) -> Vec<Destination> {
     match flasher {
-        config::Flasher::SdCard => bb_flasher::sd::Target::destinations(filter)
-            .await
-            .into_iter()
-            .map(Destination::SdCard)
-            .collect(),
+        config::Flasher::SdCard | config::Flasher::SdCardBootfs => {
+            bb_flasher::sd::Target::destinations(filter)
+                .await
+                .into_iter()
+                .map(Destination::SdCard)
+                .collect()
+        }
         #[cfg(feature = "bcf_cc1352p7")]
         config::Flasher::BeagleConnectFreedom => {
             bb_flasher::bcf::cc1352p7::Target::destinations(filter)
@@ -540,7 +641,9 @@ pub(crate) async fn destinations(flasher: config::Flasher, filter: bool) -> Vec<
 
 pub(crate) fn file_filter(flasher: config::Flasher) -> &'static [&'static str] {
     match flasher {
-        config::Flasher::SdCard => bb_flasher::sd::Target::FILE_TYPES,
+        config::Flasher::SdCard | config::Flasher::SdCardBootfs => {
+            bb_flasher::sd::Target::FILE_TYPES
+        }
         #[cfg(feature = "bcf_cc1352p7")]
         config::Flasher::BeagleConnectFreedom => bb_flasher::bcf::cc1352p7::Target::FILE_TYPES,
         #[cfg(feature = "bcf_msp430")]
@@ -553,7 +656,7 @@ pub(crate) fn file_filter(flasher: config::Flasher) -> &'static [&'static str] {
 
 pub(crate) const fn flasher_supported(flasher: config::Flasher) -> bool {
     match flasher {
-        config::Flasher::SdCard => true,
+        config::Flasher::SdCard | config::Flasher::SdCardBootfs => true,
         #[cfg(feature = "bcf_cc1352p7")]
         config::Flasher::BeagleConnectFreedom => true,
         #[cfg(feature = "bcf_msp430")]
@@ -599,7 +702,7 @@ impl FlashingCustomization {
                         .unwrap_or_default(),
                 )
             }
-            config::Flasher::SdCard => Self::NoneSd,
+            config::Flasher::SdCard | config::Flasher::SdCardBootfs => Self::NoneSd,
             config::Flasher::BeagleConnectFreedom => {
                 Self::Bcf(app_config.bcf_customization.clone().unwrap_or_default())
             }
@@ -793,7 +896,9 @@ pub(crate) fn no_customization(
         {
             None
         }
-        config::Flasher::SdCard => Some(FlashingCustomization::NoneSd),
+        config::Flasher::SdCard | config::Flasher::SdCardBootfs => {
+            Some(FlashingCustomization::NoneSd)
+        }
         config::Flasher::Msp430Usb => Some(FlashingCustomization::Msp430),
         _ => None,
     }


### PR DESCRIPTION
- Tested with the following os_list.json:

```
"os_list": [
        {
                "name": "Bootfs Update",
                "description": "Bootfs update",
                "icon": "https://media.githubusercontent.com/media/beagleboard/bb-imager-rs/refs/heads/main/assets/os/debian.png",
                "flasher": "SdCardBootfs",
                "subitems": [
                        {
                                "name": "PocketBeagle 2 Bootfs Update",
                                "description": "PocketBeagle 2 Bootfs update",
                                "icon": "https://media.githubusercontent.com/media/beagleboard/bb-imager-rs/refs/heads/main/assets/os/debian.png",
                                "url": "https://sourceforge.net/projects/lzmautils/files/xz-5.8.3.tar.xz/download",
                                "extract_size": 12390400,
                                "extract_sha256": "11f678259564554db052553fcf69af244ec41c6026fad961c7f5b82e895df643",
                                "image_download_size": 1548064,
                                "image_download_sha256": "fff1ffcf2b0da84d308a14de513a1aa23d4e9aa3464d17e64b9714bfdd0bbfb6",
                                "release_date": "2026-05-19",
                                "devices": [
                                  "pocketbeagle2-am62"
                                ]
                        }
                ]
        }
]
```

- Fixes #467 
- cc @RobertCNelson @jadonk 