### PR TITLE
bb-imager-gui: Add image support button

### DIFF
--- a/bb-config/src/config.rs
+++ b/bb-config/src/config.rs
@@ -178,6 +178,8 @@ pub struct OsImage {
     pub bmap: Option<Url>,
     /// Special Instructions for flashing board.
     pub info_text: Option<String>,
+    /// URL to support page for image. This is where issues should be reported.
+    pub support: Option<Url>,
 }
 
 /// Types of flashers Os Image(s) support

--- a/bb-imager-gui/migrations/20260316134019_init.sql
+++ b/bb-imager-gui/migrations/20260316134019_init.sql
@@ -70,6 +70,7 @@ CREATE TABLE os_images(
 	init_format TEXT NOT NULL,
 	bmap TEXT,
 	info_text TEXT,
+        support TEXT,
         remote_config_id INTEGER DEFAULT NULL,
 
 	FOREIGN KEY (parent_id) REFERENCES os_sublists(id) ON DELETE CASCADE,

--- a/bb-imager-gui/src/db/mod.rs
+++ b/bb-imager-gui/src/db/mod.rs
@@ -120,6 +120,7 @@ pub(crate) struct OsImage {
     pub(crate) init_format: bb_config::config::InitFormat,
     pub(crate) bmap: Option<Url>,
     pub(crate) info_text: Option<String>,
+    pub(crate) support: Option<Url>
 }
 
 impl FromRow<'_, SqliteRow> for OsImage {
@@ -139,6 +140,7 @@ impl FromRow<'_, SqliteRow> for OsImage {
             init_format: row.try_get("init_format")?,
             bmap: row.try_get("bmap")?,
             info_text: row.try_get("info_text")?,
+            support: row.try_get("support")?,
         })
     }
 }
@@ -451,10 +453,10 @@ impl Db {
     ) -> sqlx::Result<i64> {
         let id = sqlx::query(
             r#"
-            INSERT INTO os_images(name, parent_id, description, icon, url, 
-                image_download_size, image_download_sha256, extract_size, 
-                release_date, init_format, bmap, info_text, remote_config_id)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+            INSERT INTO os_images(name, parent_id, description, icon, url,
+                image_download_size, image_download_sha256, extract_size,
+                release_date, init_format, bmap, info_text, remote_config_id, support)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
             "#,
         )
         .bind(&img.name)
@@ -470,6 +472,7 @@ impl Db {
         .bind(img.bmap.as_ref().map(|x| x.as_str()))
         .bind(&img.info_text)
         .bind(remote_config_id)
+        .bind(img.support.as_ref().map(|x| x.as_str()))
         .execute(&mut *exec)
         .await?
         .last_insert_rowid();
@@ -573,7 +576,7 @@ impl Db {
             r#"
             SELECT id, name, description, icon, url, image_download_size,
                 image_download_sha256, extract_size, release_date, init_format,
-                bmap, info_text 
+                bmap, info_text, support
             FROM os_images WHERE id = $1"#,
         )
         .bind(id)

--- a/bb-imager-gui/src/db/tests.rs
+++ b/bb-imager-gui/src/db/tests.rs
@@ -404,6 +404,7 @@ async fn add_config_inserts_os_image_for_board() {
         init_format: bb_config::config::InitFormat::None,
         bmap: None,
         info_text: None,
+        support: None,
     };
 
     let config = Config {
@@ -483,6 +484,11 @@ async fn os_image_by_id_returns_correct_data() {
         init_format: bb_config::config::InitFormat::None,
         bmap: Some("https://example.com/os.bmap".try_into().unwrap()),
         info_text: Some("Test info".to_string()),
+        support: Some(
+            "https://github.com/beagleboard/bb-imager-rs"
+                .try_into()
+                .unwrap(),
+        ),
     };
 
     let config = Config {
@@ -582,6 +588,7 @@ async fn add_config_inserts_os_sublist_for_board() {
         init_format: bb_config::config::InitFormat::None,
         bmap: None,
         info_text: None,
+        support: None,
     };
 
     let sublist = bb_config::config::OsSubList {
@@ -670,6 +677,7 @@ async fn nested_os_sublists_propagate_board_support() {
         init_format: bb_config::config::InitFormat::None,
         bmap: None,
         info_text: None,
+        support: None,
     };
 
     let child_sublist = bb_config::config::OsSubList {
@@ -896,6 +904,7 @@ async fn remote_os_sublist_resolve_inserts_child_items_and_clears_url() {
         init_format: bb_config::config::InitFormat::None,
         bmap: None,
         info_text: None,
+        support: None,
     };
 
     db.os_remote_sublist_resolve(
@@ -1004,6 +1013,7 @@ async fn duplicate_remote_sublist_resolve_does_not_duplicate_os_items() {
         init_format: bb_config::config::InitFormat::None,
         bmap: None,
         info_text: None,
+        support: None,
     };
 
     // First resolve

--- a/bb-imager-gui/src/helpers.rs
+++ b/bb-imager-gui/src/helpers.rs
@@ -31,6 +31,7 @@ pub(crate) enum BoardImage {
         description: Option<String>,
         icon: BoardImageIcon,
         details: Vec<(&'static str, String)>,
+        support: Option<Url>,
     },
 }
 
@@ -52,6 +53,7 @@ impl BoardImage {
             description: None,
             icon: BoardImageIcon::Local,
             details,
+            support: None,
         }
     }
 
@@ -88,6 +90,7 @@ impl BoardImage {
             description: Some(image.description),
             icon: BoardImageIcon::Remote(image.icon.into()),
             details,
+            support: image.support.map(Into::into),
         }
     }
 
@@ -178,6 +181,13 @@ impl BoardImage {
             BoardImage::Image { init_format, .. } => {
                 *init_format = f;
             }
+        }
+    }
+
+    pub(crate) fn support(&self) -> Option<&Url> {
+        match self {
+            BoardImage::SdFormat { .. } => None,
+            BoardImage::Image { support, .. } => support.as_ref(),
         }
     }
 }

--- a/bb-imager-gui/src/ui/image_selection.rs
+++ b/bb-imager-gui/src/ui/image_selection.rs
@@ -212,6 +212,13 @@ fn os_view_pane<'a>(state: &'a crate::state::ChooseOsState) -> Element<'a, BBIma
                 col = col.push(detail_entry("Init Format", init_formats[0].to_string()))
             }
 
+            if let Some(x) = img.support() {
+                let row =
+                    widget::row![button("SUPPORT").on_press(BBImagerMessage::OpenUrl(x.clone()))]
+                        .spacing(16);
+                col = col.push(widget::center(row));
+            }
+
             widget::scrollable(col.spacing(16).padding(VIEW_COL_PADDING))
                 .id(state.common.scroll_id.clone())
                 .into()


### PR DESCRIPTION
- Useful specially when adding external images to imager.
- Suggested in #503 
- Eg:

```json
                {
                        "name": "Testing",
                        "description": "Debian 13 (Trixie) with the Xfce Desktop for BeagleY-AI based on TI AM67A (J722S) processor running linux 7.0}.",
                        "icon": "https://media.githubusercontent.com/media/beagleboard/bb-imager-rs/refs/heads/main/assets/os/debian.png",
                        "url": "https://files.beagle.cc/file/beagleboard-public-2021/images/beagley-ai-debian-13.5-xfce-v7.0-k3-arm64-2026-05-19-12gb.img.xz",
                        "bmap": "https://raw.githubusercontent.com/beagleboard/distros/refs/heads/main/bmap-temp/beagley-ai-debian-13.5-xfce-v7.0-k3-arm64-2026-05-19-12gb.bmap",
                        "extract_size": 12884901888,
                        "extract_sha256": "2c40f7c71a0f861a6d58b318d2b173a3925b31e044839ab1e0e1648c1c7e604c",
                        "image_download_size": 1225392868,
                        "image_download_sha256": "da171b63fccd927565ad5e1ffc4cb10a5dc322b4d0f6e62b69de8f2b8feae609",
                        "release_date": "2026-05-19",
                        "init_format": "sysconf",
                        "devices": [
                                "beagle-am67",
                                "recommended"
                        ],
                        "support": "https://github.com/beagleboard/bb-imager-rs/issues"
                }

```