### PR TITLE
bb-flasher-sd: Make eject sync

### DIFF
--- a/bb-flasher-sd/src/bootfs_update.rs
+++ b/bb-flasher-sd/src/bootfs_update.rs
@@ -58,9 +58,7 @@ where
     internal((&mut img).into_iter(), &mut sd, cancel)?;
 
     tracing::info!("Ejecting SD Card");
-    tokio::runtime::Handle::current().block_on(async move {
-        let _ = sd.eject().await;
-    });
+    let _ = sd.eject();
 
     Ok(())
 }

--- a/bb-flasher-sd/src/flashing/mod.rs
+++ b/bb-flasher-sd/src/flashing/mod.rs
@@ -281,7 +281,7 @@ where
     }
 
     tracing::info!("Ejecting SD Card");
-    let _ = sd.eject().await;
+    let _ = sd.eject();
 
     Ok(())
 }

--- a/bb-flasher-sd/src/helpers.rs
+++ b/bb-flasher-sd/src/helpers.rs
@@ -1,6 +1,5 @@
 use std::io::{self, Write};
 
-use tokio::io::AsyncWriteExt;
 use tokio::sync::mpsc;
 use tokio_util::io::SyncIoBridge;
 
@@ -15,36 +14,13 @@ pub(crate) const fn progress(pos: u64, img_size: u64) -> f32 {
 }
 
 pub(crate) trait Eject {
-    fn eject(self) -> impl Future<Output = io::Result<()>>;
+    fn eject(self) -> io::Result<()>;
 }
 
 impl Eject for std::fs::File {
-    async fn eject(mut self) -> io::Result<()> {
-        tokio::task::spawn_blocking(move || {
-            self.flush()?;
-            self.sync_all()
-        })
-        .await
-        .unwrap()
-    }
-}
-
-impl Eject for tokio::fs::File {
-    async fn eject(mut self) -> io::Result<()> {
-        self.flush().await?;
-        self.sync_all().await
-    }
-}
-
-impl<T: Eject> Eject for futures::io::AllowStdIo<T> {
-    async fn eject(self) -> io::Result<()> {
-        self.into_inner().eject().await
-    }
-}
-
-impl<T: Eject> Eject for tokio_util::compat::Compat<T> {
-    async fn eject(self) -> io::Result<()> {
-        self.into_inner().eject().await
+    fn eject(mut self) -> io::Result<()> {
+        self.flush()?;
+        self.sync_all()
     }
 }
 
@@ -284,9 +260,9 @@ impl<W> Eject for SdCardWrapper<W>
 where
     W: io::Write + io::Seek + Eject,
 {
-    async fn eject(mut self) -> io::Result<()> {
+    fn eject(mut self) -> io::Result<()> {
         self.finish()?;
-        self.inner.eject().await
+        self.inner.eject()
     }
 }
 
@@ -294,8 +270,8 @@ impl<W> Eject for SyncIoBridge<W>
 where
     W: Unpin + Eject,
 {
-    async fn eject(self) -> io::Result<()> {
-        self.into_inner().eject().await
+    fn eject(self) -> io::Result<()> {
+        self.into_inner().eject()
     }
 }
 

--- a/bb-flasher-sd/src/pal/linux.rs
+++ b/bb-flasher-sd/src/pal/linux.rs
@@ -139,7 +139,7 @@ pub(crate) struct LinuxDrive {
 
 #[cfg(feature = "udev")]
 impl Eject for LinuxDrive {
-    async fn eject(self) -> io::Result<()> {
+    fn eject(self) -> io::Result<()> {
         async fn inner(dst: PathBuf) -> io::Result<()> {
             let dbus_client = udisks2::Client::new().await.map_err(io::Error::other)?;
 
@@ -180,32 +180,28 @@ impl Eject for LinuxDrive {
             Ok(())
         }
 
-        let f = tokio::fs::File::from_std(self.file);
-
-        f.sync_all().await?;
+        let _ = self.file.sync_all();
         let dst = self.drive.clone();
 
-        std::mem::drop(f);
+        std::mem::drop(self);
 
-        inner(dst).await.map_err(io::Error::other)
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_io()
+            .build()
+            .unwrap();
+        rt.block_on(async move { inner(dst).await })
+            .map_err(io::Error::other)
     }
 }
 
 #[cfg(not(feature = "udev"))]
 impl Eject for LinuxDrive {
-    async fn eject(self) -> std::io::Result<()> {
-        let f = tokio::fs::File::from_std(self.file);
-
-        f.sync_all().await?;
+    fn eject(self) -> std::io::Result<()> {
+        let _ = self.file.sync_all();
         let drive = self.drive.clone();
+        std::mem::drop(self);
 
-        std::mem::drop(f);
-
-        let output = tokio::process::Command::new("eject")
-            .arg(drive)
-            .output()
-            .await?;
-
+        let output = std::process::Command::new("eject").arg(drive).output()?;
         if output.status.success() {
             Ok(())
         } else {

--- a/bb-flasher-sd/src/pal/macos.rs
+++ b/bb-flasher-sd/src/pal/macos.rs
@@ -42,21 +42,18 @@ impl std::fmt::Debug for MacOSFile {
     }
 }
 
-async fn unmount_disk(path: &str) -> std::io::Result<()> {
-    tokio::process::Command::new("diskutil")
+fn unmount_disk(path: &str) -> std::io::Result<()> {
+    std::process::Command::new("diskutil")
         .args(["unmountDisk", path])
         .output()
-        .await
         .map(|_| ())
 }
 
 impl crate::helpers::Eject for MacOSFile {
-    async fn eject(self) -> std::io::Result<()> {
-        let f = tokio::fs::File::from_std(self.inner);
-        f.sync_all().await?;
-        std::mem::drop(f);
+    fn eject(self) -> std::io::Result<()> {
+        self.inner.sync_all()?;
+        let _ = unmount_disk(&self.path.to_string_lossy());
 
-        let _ = unmount_disk(&self.path.to_string_lossy()).await;
         Ok(())
     }
 }
@@ -72,7 +69,7 @@ pub(crate) async fn format(dst: &Path) -> Result<()> {
 #[cfg(not(feature = "macos_authopen"))]
 pub(crate) async fn open(dst: &Path) -> Result<MacOSFile> {
     let dst_str = dst.to_string_lossy();
-    let _ = unmount_disk(&dst_str).await;
+    let _ = unmount_disk(&dst_str);
 
     let f = tokio::fs::OpenOptions::new()
         .read(true)
@@ -175,7 +172,7 @@ pub(crate) async fn open(dst: &Path) -> Result<MacOSFile> {
     }
 
     let p = dst.to_owned();
-    let _ = unmount_disk(dst.to_str().unwrap()).await;
+    let _ = unmount_disk(dst.to_str().unwrap());
     // TODO: Make this into a real async function
     let f = tokio::task::spawn_blocking(move || inner(p))
         .await

--- a/bb-flasher-sd/src/pal/windows.rs
+++ b/bb-flasher-sd/src/pal/windows.rs
@@ -212,13 +212,9 @@ impl Seek for WinDrive {
 
 /// TODO: Implement real eject
 impl crate::helpers::Eject for WinDrive {
-    async fn eject(self) -> io::Result<()> {
-        tokio::task::spawn_blocking(move || {
-            self.drive.sync_all()?;
-            Ok(())
-        })
-        .await
-        .unwrap()
+    fn eject(self) -> io::Result<()> {
+        self.drive.sync_all()?;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
- Broader push to be async free everywhere except gui.
- Hopefully, by the end, I can remove static lifetime requirement from Read. Requred to use qcow without too much trouble.