### PR TITLE
bb-flasher: Remove tokio dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,6 +686,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
  "url",

--- a/bb-flasher/Cargo.toml
+++ b/bb-flasher/Cargo.toml
@@ -15,7 +15,6 @@ liblzma = { version = "0.4", features = ["parallel"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 yaml_serde = { version = "0.10", optional = true }
 thiserror = { version = "2.0" }
-tokio = { version = "1.52", default-features = false, features = ["rt-multi-thread", "sync", "net", "time"] }
 tracing = "0.1"
 bb-flasher-pb2-mspm0 = { path = "../bb-flasher-pb2-mspm0", optional = true }
 bb-flasher-bcf = { path = "../bb-flasher-bcf", optional = true }

--- a/bb-flasher/src/img/mod.rs
+++ b/bb-flasher/src/img/mod.rs
@@ -36,13 +36,13 @@ impl OsArchive {
 
     pub fn from_piped(
         img: ReaderFileStream,
-        abort_handle: tokio::task::JoinHandle<io::Result<()>>,
+        _background: AbortOnDropHandle<io::Result<()>>,
         size: u64,
         chan: Option<mpsc::SyncSender<f32>>,
     ) -> io::Result<Self> {
         let img = OsImageSource::FileStream {
             reader: img,
-            _background: AbortOnDropHandle::new(abort_handle),
+            _background,
         };
         Self::new(img, chan, size)
     }
@@ -138,14 +138,14 @@ impl OsImage {
 
     pub fn from_piped(
         img: ReaderFileStream,
-        abort_handle: tokio::task::JoinHandle<io::Result<()>>,
+        _background: AbortOnDropHandle<io::Result<()>>,
         size: u64,
     ) -> io::Result<Self> {
         Ok(Self {
             size,
             img: OsImageCompression::new(OsImageSource::FileStream {
                 reader: img,
-                _background: AbortOnDropHandle::new(abort_handle),
+                _background,
             })?,
         })
     }

--- a/bb-flasher/src/img/test.rs
+++ b/bb-flasher/src/img/test.rs
@@ -209,7 +209,8 @@ async fn file_stream_uncompressed_image_reads_contents() {
 
     tokio::task::spawn_blocking(move || {
         let abort = tokio::spawn(async { Ok(()) });
-        let mut img = OsImage::from_piped(reader, abort, data.len() as u64).unwrap();
+        let mut img =
+            OsImage::from_piped(reader, AbortOnDropHandle::new(abort), data.len() as u64).unwrap();
 
         assert_eq!(img.size(), data.len() as u64);
 
@@ -251,7 +252,9 @@ async fn file_stream_xz_image_reports_uncompressed_size_and_reads_contents() {
 
     tokio::task::spawn_blocking(move || {
         let abort = tokio::spawn(async { Ok(()) });
-        let mut img = OsImage::from_piped(reader, abort, original.len() as u64).unwrap();
+        let mut img =
+            OsImage::from_piped(reader, AbortOnDropHandle::new(abort), original.len() as u64)
+                .unwrap();
 
         assert_eq!(img.size(), original.len() as u64);
 
@@ -297,7 +300,9 @@ async fn file_stream_zip_image_reads_first_entry_contents() {
 
     tokio::task::spawn_blocking(move || {
         let abort = tokio::spawn(async { Ok(()) });
-        let mut img = OsImage::from_piped(reader, abort, original.len() as u64).unwrap();
+        let mut img =
+            OsImage::from_piped(reader, AbortOnDropHandle::new(abort), original.len() as u64)
+                .unwrap();
 
         assert_eq!(img.size(), original.len() as u64);
 

--- a/bb-imager-gui/Cargo.toml
+++ b/bb-imager-gui/Cargo.toml
@@ -33,6 +33,7 @@ anyhow = "1.0"
 sqlx = { version = "0.9", features = ["runtime-tokio", "chrono"] }
 tempfile = "3.26"
 const-hex = { version = "1.19", features = ["serde"] }
+tokio-util = { version = "0.7", features = ["rt"] }
 
 [build-dependencies]
 embed-resource = "3.0"

--- a/bb-imager-gui/src/helpers.rs
+++ b/bb-imager-gui/src/helpers.rs
@@ -7,6 +7,7 @@ use bb_config::config;
 use bb_flasher::{BBFlasherTarget, DownloadFlashingStatus};
 use iced::widget;
 use std::sync::mpsc;
+use tokio_util::task::AbortOnDropHandle;
 use url::Url;
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -303,7 +304,7 @@ impl RemoteImage {
                 Ok(())
             });
 
-            bb_flasher::OsArchive::from_piped(rx, t, self.extract_size, tx)
+            bb_flasher::OsArchive::from_piped(rx, AbortOnDropHandle::new(t), self.extract_size, tx)
         }
     }
 
@@ -341,7 +342,8 @@ impl RemoteImage {
                 Ok(())
             });
 
-            let img = bb_flasher::OsImage::from_piped(rx, t, self.extract_size)?;
+            let img =
+                bb_flasher::OsImage::from_piped(rx, AbortOnDropHandle::new(t), self.extract_size)?;
             Ok((img, self.extract_size))
         }
     }


### PR DESCRIPTION
- Still depends on tokio-util. Will make it optional in future.