### PR TITLE
bb-imager-cli: use classic confinement for snap

### DIFF
--- a/snapcraft.cli.yaml
+++ b/snapcraft.cli.yaml
@@ -19,7 +19,7 @@ description: |
   BeagleConnect Freedom, BeagleConnect Zepto, etc.
 
 grade: stable
-confinement: strict
+confinement: classic
 
 parts:
   bb-imager-cli:
@@ -32,30 +32,3 @@ parts:
       - enable-patchelf
     override-build: |
       make build-cli install-cli DESTDIR=${CRAFT_PART_INSTALL} PREFIX=/usr
-
-plugs:
-  # Required to read normal user files when running as root (when flashing SD Cards).
-  home:
-    read: all
-
-apps:
-  bb-imager-cli:
-    command: usr/bin/bb-imager-cli
-    completer: usr/share/bash-completion/completions/bb-imager-cli
-    plugs:
-      # Used for lsblk.
-      - hardware-observe
-      # Used for getting mount info when doing lsblk.
-      - mount-observe
-      # BCF and Zepto UART
-      - serial-port
-      # Zepto I2C
-      - i2c
-      # BCF MSP430
-      - hidraw
-      # Used to write SD Cards.
-      - block-devices
-      # Used to read the firmware/image to flash.
-      - home
-      # Used to toggle BSL in MSPM0.
-      - gpio-control


### PR DESCRIPTION
- Looking at discussion in GUI, CLI would be better off with classic confinement.