### PR TITLE
bb-imager-gui: Fix success text size

### DIFF
--- a/bb-imager-gui/src/ui/helpers.rs
+++ b/bb-imager-gui/src/ui/helpers.rs
@@ -369,12 +369,14 @@ impl<Message> canvas::Program<Message> for CircleBar {
                     .with_color(self.color),
             );
 
+            let frac = if self.label.len() > 4 { 3.0 } else { 2.0 };
+
             frame.fill_text(canvas::Text {
                 content: self.label.to_string(),
                 position: center,
                 align_x: iced::Center.into(),
                 align_y: iced::Center.into(),
-                size: (radius / 3.0).into(),
+                size: (radius / frac).into(),
                 color: theme.palette().text,
                 font: constants::FONT_BOLD,
                 ..Default::default()


### PR DESCRIPTION
- The change in size between 99 and 100% looks odd. But since Cancelled cannot fit inside the circle, we need to dynamically adjust size based on the number of characters.