### PR TITLE
.github: workflows: Fix armhf CLI snap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,6 @@ jobs:
         platform: [armhf, riscv64]
     name: Build CLI Snap - ${{matrix.platform}}
     runs-on: ubuntu-24.04
-    if: github.event_name != 'pull_request'
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -104,6 +103,8 @@ jobs:
         lfs: true
 
     - uses: docker/setup-qemu-action@v4
+
+    - run: cargo vendor --locked > .cargo/config.toml
 
     - run: ln -sf snapcraft.cli.yaml snapcraft.yaml
     - uses: canonical/snapcraft-multiarch-action@v1


### PR DESCRIPTION
- Seems to be a known bug in libgit2 inside qemu 32 bit.