### PR TITLE
Makefile: Improve vendor deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -318,8 +318,10 @@ package-armv7-unknown-linux-gnueabihf: package-checks
 
 cargo-vendor.tar.zst: Cargo.lock
 	$(info Create tarball of all deps)
-	$(CARGO_PATH) vendor ${_RUST_ARGS_BASE}
-	tar --zstd -cvf cargo-vendor.tar.zst vendor
+	mkdir -p dist/vendor/.cargo
+	$(CARGO_PATH) vendor ${_RUST_ARGS_BASE} dist/vendor/vendor > dist/vendor/.cargo/config.toml
+	pushd dist/vendor && tar --zstd -cvf cargo-vendor.tar.zst .cargo vendor
+	mv dist/vendor/cargo-vendor.tar.zst ./
 
 ## housekeeping: vendor-deps: Create tarball of dependencies
 .PHONY: vendor-deps


### PR DESCRIPTION
Add generated `.cargo/config.toml`. Required in cases when using git dependencies.