### PR TITLE
bb-helper: Remove tokio dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,7 +639,6 @@ name = "bb-helper"
 version = "1.0.12"
 dependencies = [
  "tempfile",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,6 +515,7 @@ version = "0.2.0"
 dependencies = [
  "bb-helper",
  "const-hex",
+ "futures-util",
  "reqwest",
  "serde",
  "sha2 0.10.9",

--- a/bb-downloader/Cargo.toml
+++ b/bb-downloader/Cargo.toml
@@ -15,7 +15,7 @@ reqwest = { version = "0.13", default-features = false, features = ["stream", "h
 sha2 = "0.10"
 tracing = "0.1"
 serde = { version = "1.0", optional = true }
-tokio = { version = "1.52", default-features = false, features = ["fs"] }
+tokio = { version = "1.52", default-features = false, features = ["fs", "rt-multi-thread"] }
 const-hex = "1.19"
 tempfile = "3.27"
 bb-helper = { path = "../bb-helper", features = ["file_stream"] }

--- a/bb-downloader/Cargo.toml
+++ b/bb-downloader/Cargo.toml
@@ -15,11 +15,12 @@ reqwest = { version = "0.13", default-features = false, features = ["stream", "h
 sha2 = "0.10"
 tracing = "0.1"
 serde = { version = "1.0", optional = true }
-tokio = { version = "1.52", default-features = false, features = ["fs", "rt-multi-thread"] }
+tokio = { version = "1.52", default-features = false, features = ["rt"] }
 const-hex = "1.19"
 tempfile = "3.27"
 bb-helper = { path = "../bb-helper", features = ["file_stream"] }
 tokio-stream = "0.1.18"
+futures-util = { version = "0.3", features = ["io"] }
 
 [features]
 default = ["rustls"]

--- a/bb-downloader/src/lib.rs
+++ b/bb-downloader/src/lib.rs
@@ -38,15 +38,14 @@
 //! }
 //! ```
 
+use futures_util::AsyncWriteExt;
 #[cfg(feature = "json")]
 use serde::de::DeserializeOwned;
 use sha2::{Digest as _, Sha256};
 use std::{
-    io::{self, Read, Write},
+    io::{self, Read},
     path::{Path, PathBuf},
-    time::Duration,
 };
-use tokio::io::{AsyncSeekExt, AsyncWriteExt};
 use tokio_stream::StreamExt;
 
 pub use reqwest::IntoUrl;
@@ -77,6 +76,24 @@ pub struct Downloader {
 }
 
 impl Downloader {
+    #[cfg(not(target_arch = "wasm32"))]
+    fn new_client() -> reqwest::Client {
+        reqwest::Client::builder()
+            .user_agent(env!("CARGO_PKG_NAME"))
+            .connect_timeout(std::time::Duration::from_secs(10))
+            .read_timeout(std::time::Duration::from_secs(15))
+            .build()
+            .expect("Unsupported OS")
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    fn new_client() -> reqwest::Client {
+        reqwest::Client::builder()
+            .user_agent(env!("CARGO_PKG_NAME"))
+            .build()
+            .expect("Unsupported OS")
+    }
+
     /// Create a new downloader that uses a directory for storing cached files.
     pub fn new<P: Into<PathBuf>>(cache_dir: P) -> io::Result<Self> {
         let cache_dir = cache_dir.into();
@@ -92,12 +109,7 @@ impl Downloader {
             ));
         }
 
-        let client = reqwest::Client::builder()
-            .user_agent(env!("CARGO_PKG_NAME"))
-            .connect_timeout(Duration::from_secs(10))
-            .read_timeout(Duration::from_secs(15))
-            .build()
-            .expect("Unsupported OS");
+        let client = Self::new_client();
 
         Ok(Self { client, cache_dir })
     }
@@ -183,10 +195,10 @@ impl Downloader {
 
         let file_path = self.path_from_url(&url);
 
-        let mut file = AsyncTempFile::new()?;
+        let mut file = tempfile::tempfile()?;
         {
-            let mut file = tokio::io::BufWriter::new(&mut file.0);
-
+            let file = std::io::BufWriter::new(&mut file);
+            let mut file = futures_util::io::AllowStdIo::new(file);
             let response = self
                 .client
                 .get(url)
@@ -196,15 +208,25 @@ impl Downloader {
             let mut response_stream = response.bytes_stream();
 
             while let Some(x) = response_stream.next().await {
-                let mut data = x.map_err(io::Error::other)?;
-                file.write_all_buf(&mut data).await?;
+                let data = x.map_err(io::Error::other)?;
+                file.write_all(&data).await?;
             }
 
             file.flush().await?
         }
 
-        file.persist(&file_path).await?;
-        Ok(file_path)
+        tokio::task::spawn_blocking(move || {
+            let mut file = std::io::BufReader::new(file);
+            let mut f = std::fs::File::create(&file_path)?;
+
+            std::io::Seek::rewind(&mut file)?;
+            std::io::copy(&mut file, &mut f)?;
+            std::io::Write::flush(&mut f)?;
+
+            Ok(file_path)
+        })
+        .await
+        .unwrap()
     }
 
     /// Downloads the file and streams the content to pipe. This allows not having to wait for the
@@ -227,7 +249,8 @@ impl Downloader {
         let file_path = self.path_from_sha(sha256);
 
         {
-            let mut file = std::io::BufWriter::new(&mut writer);
+            let file = std::io::BufWriter::new(&mut writer);
+            let mut file = futures_util::io::AllowStdIo::new(file);
 
             let response = self
                 .client
@@ -243,7 +266,7 @@ impl Downloader {
             while let Some(x) = response_stream.next().await {
                 let data = x.map_err(io::Error::other)?;
                 hasher.update(&data);
-                tokio::task::block_in_place(|| file.write_all(&data))?;
+                file.write_all(&data).await?;
             }
 
             let hash: [u8; 32] = hasher
@@ -263,7 +286,7 @@ impl Downloader {
                     "Invalid SHA256",
                 ));
             }
-            tokio::task::block_in_place(|| file.flush())?;
+            file.flush().await?;
         }
 
         tracing::info!("Saving donwloaded file to disk");
@@ -311,31 +334,4 @@ fn sha256_from_path(p: &Path) -> io::Result<[u8; 32]> {
         .expect("SHA-256 is 32 bytes");
 
     Ok(hash)
-}
-
-struct AsyncTempFile(tokio::fs::File);
-
-impl AsyncTempFile {
-    fn new() -> io::Result<Self> {
-        let f = tempfile::tempfile()?;
-        Ok(Self(tokio::fs::File::from_std(f)))
-    }
-
-    async fn persist(&mut self, path: &Path) -> io::Result<()> {
-        let mut f = tokio::fs::File::create(path).await?;
-        self.0.seek(io::SeekFrom::Start(0)).await?;
-
-        tokio::io::copy(&mut self.0, &mut f).await?;
-
-        // Causes errors if not present
-        f.flush().await?;
-
-        Ok(())
-    }
-}
-
-impl From<std::fs::File> for AsyncTempFile {
-    fn from(value: std::fs::File) -> Self {
-        Self(tokio::fs::File::from_std(value))
-    }
 }

--- a/bb-downloader/src/lib.rs
+++ b/bb-downloader/src/lib.rs
@@ -42,7 +42,7 @@
 use serde::de::DeserializeOwned;
 use sha2::{Digest as _, Sha256};
 use std::{
-    io::{self, Read},
+    io::{self, Read, Write},
     path::{Path, PathBuf},
     time::Duration,
 };
@@ -227,7 +227,7 @@ impl Downloader {
         let file_path = self.path_from_sha(sha256);
 
         {
-            let mut file = tokio::io::BufWriter::new(&mut writer);
+            let mut file = std::io::BufWriter::new(&mut writer);
 
             let response = self
                 .client
@@ -241,9 +241,9 @@ impl Downloader {
             let mut hasher = Sha256::new();
 
             while let Some(x) = response_stream.next().await {
-                let mut data = x.map_err(io::Error::other)?;
+                let data = x.map_err(io::Error::other)?;
                 hasher.update(&data);
-                file.write_all_buf(&mut data).await?;
+                tokio::task::block_in_place(|| file.write_all(&data))?;
             }
 
             let hash: [u8; 32] = hasher
@@ -263,11 +263,13 @@ impl Downloader {
                     "Invalid SHA256",
                 ));
             }
-            file.flush().await?;
+            tokio::task::block_in_place(|| file.flush())?;
         }
 
         tracing::info!("Saving donwloaded file to disk");
-        writer.persist(&file_path).await
+        tokio::task::spawn_blocking(move || writer.persist(&file_path))
+            .await
+            .unwrap()
     }
 
     fn path_from_url(&self, url: &reqwest::Url) -> PathBuf {

--- a/bb-flasher/src/img/test.rs
+++ b/bb-flasher/src/img/test.rs
@@ -2,8 +2,6 @@ use super::*;
 
 use std::io::{Cursor, Read, Write};
 use tempfile::NamedTempFile;
-#[cfg(feature = "piped_image")]
-use tokio::io::AsyncWriteExt;
 use zip::write::SimpleFileOptions;
 
 #[test]
@@ -205,24 +203,20 @@ async fn file_stream_uncompressed_image_reads_contents() {
 
     let (mut writer, reader) = bb_helper::file_stream::file_stream().unwrap();
 
-    writer.write_all(data).await.unwrap();
-    writer.flush().await.unwrap();
+    writer.write_all(data).unwrap();
+    writer.flush().unwrap();
     drop(writer);
 
-    tokio::task::spawn_blocking(move || {
-        let abort = tokio::spawn(async { Ok(()) });
-        let mut img =
-            OsImage::from_piped(reader, AbortOnDropHandle::new(abort), data.len() as u64).unwrap();
+    let abort = tokio::spawn(async { Ok(()) });
+    let mut img =
+        OsImage::from_piped(reader, AbortOnDropHandle::new(abort), data.len() as u64).unwrap();
 
-        assert_eq!(img.size(), data.len() as u64);
+    assert_eq!(img.size(), data.len() as u64);
 
-        let mut out = Vec::new();
-        img.read_to_end(&mut out).unwrap();
+    let mut out = Vec::new();
+    img.read_to_end(&mut out).unwrap();
 
-        assert_eq!(out, data);
-    })
-    .await
-    .unwrap()
+    assert_eq!(out, data);
 }
 
 #[tokio::test]
@@ -249,25 +243,20 @@ async fn file_stream_xz_image_reports_uncompressed_size_and_reads_contents() {
 
     let (mut writer, reader) = bb_helper::file_stream::file_stream().unwrap();
 
-    writer.write_all(&compressed).await.unwrap();
-    writer.flush().await.unwrap();
+    writer.write_all(&compressed).unwrap();
+    writer.flush().unwrap();
     drop(writer);
 
-    tokio::task::spawn_blocking(move || {
-        let abort = tokio::spawn(async { Ok(()) });
-        let mut img =
-            OsImage::from_piped(reader, AbortOnDropHandle::new(abort), original.len() as u64)
-                .unwrap();
+    let abort = tokio::spawn(async { Ok(()) });
+    let mut img =
+        OsImage::from_piped(reader, AbortOnDropHandle::new(abort), original.len() as u64).unwrap();
 
-        assert_eq!(img.size(), original.len() as u64);
+    assert_eq!(img.size(), original.len() as u64);
 
-        let mut out = Vec::new();
-        img.read_to_end(&mut out).unwrap();
+    let mut out = Vec::new();
+    img.read_to_end(&mut out).unwrap();
 
-        assert_eq!(out, original);
-    })
-    .await
-    .unwrap()
+    assert_eq!(out, original);
 }
 
 #[tokio::test]
@@ -298,23 +287,18 @@ async fn file_stream_zip_image_reads_first_entry_contents() {
 
     let (mut writer, reader) = bb_helper::file_stream::file_stream().unwrap();
 
-    writer.write_all(zip_data.get_ref()).await.unwrap();
-    writer.flush().await.unwrap();
+    writer.write_all(zip_data.get_ref()).unwrap();
+    writer.flush().unwrap();
     drop(writer);
 
-    tokio::task::spawn_blocking(move || {
-        let abort = tokio::spawn(async { Ok(()) });
-        let mut img =
-            OsImage::from_piped(reader, AbortOnDropHandle::new(abort), original.len() as u64)
-                .unwrap();
+    let abort = tokio::spawn(async { Ok(()) });
+    let mut img =
+        OsImage::from_piped(reader, AbortOnDropHandle::new(abort), original.len() as u64).unwrap();
 
-        assert_eq!(img.size(), original.len() as u64);
+    assert_eq!(img.size(), original.len() as u64);
 
-        let mut out = Vec::new();
-        img.read_to_end(&mut out).unwrap();
+    let mut out = Vec::new();
+    img.read_to_end(&mut out).unwrap();
 
-        assert_eq!(out, original);
-    })
-    .await
-    .unwrap()
+    assert_eq!(out, original);
 }

--- a/bb-helper/Cargo.toml
+++ b/bb-helper/Cargo.toml
@@ -8,12 +8,8 @@ license.workspace = true
 
 [dependencies]
 tempfile = "3.27"
-tokio = { version = "1.52", default-features = false, optional = true }
-
-[dev-dependencies]
-tokio = { version = "1.52", features = ["macros", "rt-multi-thread"] }
 
 [features]
-file_stream = ["tokio/fs", "tokio/io-util"]
+file_stream = []
 reader_progress = []
 cancel = []

--- a/bb-helper/src/file_stream.rs
+++ b/bb-helper/src/file_stream.rs
@@ -3,12 +3,10 @@
 //! This is designed to be used for large data streams that cannot live in memory.
 
 use std::{
-    io,
+    io::{self, Seek, Write},
     path::Path,
     sync::{Arc, Condvar, Mutex},
 };
-
-use tokio::io::{AsyncSeekExt, AsyncWriteExt};
 
 type SharedState = Arc<(Mutex<bool>, Condvar)>;
 
@@ -17,56 +15,40 @@ type SharedState = Arc<(Mutex<bool>, Condvar)>;
 /// Writes data asynchronously to a temporary file. The data can be persisted
 /// to a permanent location using [`persist`](Self::persist).
 pub struct WriterFileStream {
-    file: tokio::fs::File,
+    file: std::fs::File,
     writing: SharedState,
 }
 
 impl WriterFileStream {
-    const fn new(file: tokio::fs::File, writing: SharedState) -> Self {
+    const fn new(file: std::fs::File, writing: SharedState) -> Self {
         Self { file, writing }
     }
 
     /// Persists the written data to a permanent file location.
     ///
     /// Copies all data from the temporary file to the specified path.
-    pub async fn persist(&mut self, path: &Path) -> io::Result<()> {
-        let mut f = tokio::fs::File::create(path).await?;
-        self.file.seek(io::SeekFrom::Start(0)).await?;
+    pub fn persist(&mut self, path: &Path) -> io::Result<()> {
+        let mut f = std::fs::File::create(path)?;
+        self.file.seek(io::SeekFrom::Start(0))?;
 
-        tokio::io::copy(&mut self.file, &mut f).await?;
+        std::io::copy(&mut self.file, &mut f)?;
 
         // Causes errors if not present
-        f.flush().await?;
-
-        Ok(())
+        f.flush()
     }
 }
 
-impl tokio::io::AsyncWrite for WriterFileStream {
-    fn poll_write(
-        mut self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-        buf: &[u8],
-    ) -> std::task::Poll<Result<usize, io::Error>> {
-        let res = std::pin::Pin::new(&mut self.file).poll_write(cx, buf);
+impl std::io::Write for WriterFileStream {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let res = self.file.write(buf)?;
         self.writing.1.notify_all();
-        res
+        Ok(res)
     }
 
-    fn poll_flush(
-        mut self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Result<(), io::Error>> {
-        let res = std::pin::Pin::new(&mut self.file).poll_flush(cx);
+    fn flush(&mut self) -> io::Result<()> {
+        self.file.flush()?;
         self.writing.1.notify_all();
-        res
-    }
-
-    fn poll_shutdown(
-        mut self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Result<(), io::Error>> {
-        std::pin::Pin::new(&mut self.file).poll_shutdown(cx)
+        Ok(())
     }
 }
 
@@ -171,7 +153,7 @@ pub fn file_stream() -> io::Result<(WriterFileStream, ReaderFileStream)> {
     let flag = Arc::new((Mutex::new(true), Condvar::new()));
 
     let reader = ReaderFileStream::new(file.reopen()?, flag.clone());
-    let writer = WriterFileStream::new(file.into_file().into(), flag);
+    let writer = WriterFileStream::new(file.into_file(), flag);
 
     Ok((writer, reader))
 }
@@ -182,90 +164,70 @@ mod tests {
 
     use super::*;
 
-    #[tokio::test]
-    async fn seek_from_start_works() {
+    #[test]
+    fn seek_from_start_works() {
         let (mut writer, mut reader) = file_stream().unwrap();
 
-        writer.write_all(b"abcdef").await.unwrap();
-        writer.flush().await.unwrap();
+        writer.write_all(b"abcdef").unwrap();
+        writer.flush().unwrap();
 
-        tokio::task::spawn_blocking(move || {
-            reader.seek(SeekFrom::Start(2)).unwrap();
+        reader.seek(SeekFrom::Start(2)).unwrap();
 
-            let mut buf = [0u8; 2];
-            reader.read_exact(&mut buf).unwrap();
+        let mut buf = [0u8; 2];
+        reader.read_exact(&mut buf).unwrap();
 
-            assert_eq!(&buf, b"cd");
-        })
-        .await
-        .unwrap()
+        assert_eq!(&buf, b"cd");
     }
 
-    #[tokio::test]
-    async fn seek_from_current_works() {
+    #[test]
+    fn seek_from_current_works() {
         let (mut writer, mut reader) = file_stream().unwrap();
 
-        writer.write_all(b"abcdef").await.unwrap();
-        writer.flush().await.unwrap();
+        writer.write_all(b"abcdef").unwrap();
+        writer.flush().unwrap();
 
-        tokio::task::spawn_blocking(move || {
-            reader.seek(SeekFrom::Start(1)).unwrap();
-            reader.seek(SeekFrom::Current(2)).unwrap();
+        reader.seek(SeekFrom::Start(1)).unwrap();
+        reader.seek(SeekFrom::Current(2)).unwrap();
 
-            let mut buf = [0u8; 1];
-            reader.read_exact(&mut buf).unwrap();
+        let mut buf = [0u8; 1];
+        reader.read_exact(&mut buf).unwrap();
 
-            assert_eq!(&buf, b"d");
-        })
-        .await
-        .unwrap()
+        assert_eq!(&buf, b"d");
     }
 
-    #[tokio::test]
-    async fn seek_from_end_fails_while_writer_alive() {
+    #[test]
+    fn seek_from_end_fails_while_writer_alive() {
         let (_writer, mut reader) = file_stream().unwrap();
 
-        tokio::task::spawn_blocking(move || {
-            let err = reader.seek(SeekFrom::End(0)).unwrap_err();
-            assert_eq!(err.kind(), io::ErrorKind::Unsupported);
-        })
-        .await
-        .unwrap()
+        let err = reader.seek(SeekFrom::End(0)).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::Unsupported);
     }
 
-    #[tokio::test]
-    async fn seek_from_end_works_after_writer_drop() {
+    #[test]
+    fn seek_from_end_works_after_writer_drop() {
         let (mut writer, mut reader) = file_stream().unwrap();
 
-        writer.write_all(b"abcdef").await.unwrap();
-        writer.flush().await.unwrap();
+        writer.write_all(b"abcdef").unwrap();
+        writer.flush().unwrap();
         drop(writer);
 
-        tokio::task::spawn_blocking(move || {
-            let pos = reader.seek(SeekFrom::End(-2)).unwrap();
-            assert_eq!(pos, 4);
+        let pos = reader.seek(SeekFrom::End(-2)).unwrap();
+        assert_eq!(pos, 4);
 
-            let mut buf = [0u8; 2];
-            reader.read_exact(&mut buf).unwrap();
+        let mut buf = [0u8; 2];
+        reader.read_exact(&mut buf).unwrap();
 
-            assert_eq!(&buf, b"ef");
-        })
-        .await
-        .unwrap()
+        assert_eq!(&buf, b"ef");
     }
 
-    #[tokio::test]
-    async fn invalid_negative_seek_fails() {
+    #[test]
+    fn invalid_negative_seek_fails() {
         let (mut writer, mut reader) = file_stream().unwrap();
 
-        writer.write_all(b"abc").await.unwrap();
-        writer.flush().await.unwrap();
+        writer.write_all(b"abc").unwrap();
+        writer.flush().unwrap();
 
-        tokio::task::spawn_blocking(move || {
-            let err = reader.seek(SeekFrom::Current(-10)).unwrap_err();
-            assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
-        })
-        .await
-        .unwrap()
+        let err = reader.seek(SeekFrom::Current(-10)).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
     }
 }

--- a/bb-imager-gui/src/helpers.rs
+++ b/bb-imager-gui/src/helpers.rs
@@ -1038,8 +1038,8 @@ pub(crate) fn fetch_images(
             async move { downloader.download(icon_clone).await },
             move |p| match p {
                 Ok(p) => BBImagerMessage::ResolveImage(icon_clone2, p),
-                Err(_) => {
-                    tracing::warn!("Failed to fetch image {}", icon);
+                Err(e) => {
+                    tracing::warn!("Failed to fetch image {icon}: {e}");
                     BBImagerMessage::Null
                 }
             },


### PR DESCRIPTION
- tokio::fs does not support wasm.
- Just use normal std fs.
- Related to #368 