### PR TITLE
bb-imager-gui: Optimize image download

### DIFF
--- a/bb-downloader/src/lib.rs
+++ b/bb-downloader/src/lib.rs
@@ -179,6 +179,7 @@ impl Downloader {
     /// cached file. The file is still cached in the end.
     async fn download_no_cache<U: reqwest::IntoUrl>(&self, url: U) -> io::Result<PathBuf> {
         let url = url.into_url().map_err(io::Error::other)?;
+        tracing::debug!("Donwloading: {}", url);
 
         let file_path = self.path_from_url(&url);
 

--- a/bb-imager-gui/src/helpers.rs
+++ b/bb-imager-gui/src/helpers.rs
@@ -803,7 +803,7 @@ pub(crate) fn log_file_path() -> PathBuf {
 }
 
 #[derive(Default, Debug)]
-pub(crate) struct ImageHandleCache(HashMap<url::Url, ImageHandleCacheValue>);
+pub(crate) struct ImageHandleCache(HashMap<url::Url, Option<ImageHandleCacheValue>>);
 
 #[derive(Debug)]
 pub(crate) enum ImageHandleCacheValue {
@@ -841,29 +841,19 @@ impl ImageHandleCacheValue {
 
 impl ImageHandleCache {
     pub(crate) fn get(&self, u: &url::Url) -> Option<&ImageHandleCacheValue> {
-        self.0.get(u)
+        self.0.get(u)?.as_ref()
     }
 
     pub(crate) fn insert(&mut self, u: url::Url, path: PathBuf) {
-        self.0.insert(u, path.into());
+        self.0.insert(u, Some(path.into()));
+    }
+
+    pub(crate) fn mark_fetching(&mut self, u: url::Url) {
+        self.0.insert(u, None);
     }
 
     pub(crate) fn contains(&self, u: &url::Url) -> bool {
         self.0.contains_key(u)
-    }
-}
-
-impl Extend<(url::Url, PathBuf)> for ImageHandleCache {
-    fn extend<T: IntoIterator<Item = (url::Url, PathBuf)>>(&mut self, iter: T) {
-        self.0.extend(iter.into_iter().map(|(k, p)| (k, p.into())))
-    }
-}
-
-impl FromIterator<(url::Url, PathBuf)> for ImageHandleCache {
-    fn from_iter<T: IntoIterator<Item = (url::Url, PathBuf)>>(iter: T) -> Self {
-        Self(HashMap::from_iter(
-            iter.into_iter().map(|(k, p)| (k, p.into())),
-        ))
     }
 }
 

--- a/bb-imager-gui/src/message.rs
+++ b/bb-imager-gui/src/message.rs
@@ -215,10 +215,16 @@ pub(crate) fn update(state: &mut BBImager, message: BBImagerMessage) -> Task<BBI
         BBImagerMessage::Back => return state.back(),
         BBImagerMessage::ResolveImage(k, v) => state.image_cache_insert(k, v),
         BBImagerMessage::FilterResolveImages(x) => {
+            let common = state.common_mut();
             let iter = x
                 .into_iter()
-                .filter(|x| !state.common().img_handle_cache.contains(x));
-            return helpers::fetch_images(&state.common().downloader, iter);
+                .filter(|x| if common.img_handle_cache.contains(x) {
+                    false
+                } else {
+                    common.img_handle_cache.mark_fetching(x.clone());
+                    true
+                });
+            return helpers::fetch_images(&common.downloader, iter);
         }
         BBImagerMessage::ExtendConfig((u, c)) => {
             tracing::debug!("Update Config: {:#?}", c);

--- a/bb-imager-gui/src/state.rs
+++ b/bb-imager-gui/src/state.rs
@@ -49,9 +49,10 @@ impl BBImagerCommon {
 
     pub(crate) fn fetch_board_images(&self) -> Task<BBImagerMessage> {
         let db = self.db.clone();
-        let downloader = self.downloader.clone();
-        Task::future(async move { db.board_icons().await.unwrap() })
-            .then(move |iter| helpers::fetch_images(&downloader, iter))
+        Task::perform(
+            async move { db.board_icons().await.unwrap() },
+            BBImagerMessage::FilterResolveImages,
+        )
     }
 }
 


### PR DESCRIPTION
- Now mark images in cache which are in download queue.
- Prevents duplicate icon downloads.