### PR TITLE
bb-flasher: Do not enable sd by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ _check_common:
 		--exclude bb-flasher --exclude bb-imager-gui --exclude bb-imager-cli --exclude xtask \
 		--exclude bb-downloader --exclude bb-config
 	$(_CARGO_CHECK) --all-targets -p bb-flasher-bcf -F msp430,static
-	$(_CARGO_CHECK) --all-targets -p bb-flasher -F bcf,bcf_msp430,pb2_mspm0,dfu,static,mspm0_uart,mspm0_i2c,piped_image
+	$(_CARGO_CHECK) --all-targets -p bb-flasher -F bcf,bcf_msp430,pb2_mspm0,dfu,static,mspm0_uart,mspm0_i2c,piped_image,sd
 	
 ## housekeeping: check: Run code quality checks.
 .PHONY: check

--- a/bb-flasher/Cargo.toml
+++ b/bb-flasher/Cargo.toml
@@ -35,7 +35,7 @@ tempfile = "3.27"
 zip = { version = "8.6", default-features = false }
 
 [features]
-default = ["sd"]
+default = []
 serde = ["dep:serde"]
 sd = ["bb-flasher-sd", "serde", "dep:yaml_serde"]
 sd_linux_udev = ["bb-flasher-sd/udev"]

--- a/bb-flasher/src/common.rs
+++ b/bb-flasher/src/common.rs
@@ -46,7 +46,7 @@ where
 
 // Should only be used when image is expected to rather small and can fit in heap.
 pub(crate) fn resolve_img(
-    img: impl FnOnce() -> std::io::Result<(crate::OsImage, u64)>,
+    img: impl FnOnce() -> std::io::Result<(crate::img::OsImage, u64)>,
 ) -> Result<Vec<u8>, FlasherError> {
     let (mut img, _) = img().map_err(|source| FlasherError::ImageResolvingError { source })?;
 

--- a/bb-flasher/src/flasher/bcf/cc1352p7.rs
+++ b/bb-flasher/src/flasher/bcf/cc1352p7.rs
@@ -8,7 +8,7 @@ use std::{borrow::Cow, fmt::Display};
 
 use bb_helper::cancel::CancellationToken;
 
-use crate::BBFlasherTarget;
+use crate::common::{BBFlasherTarget, DownloadFlashingStatus};
 
 /// BeagleConnect Freedom target
 #[derive(Hash, PartialEq, Eq, Clone, Debug)]
@@ -75,11 +75,11 @@ impl<I> Flasher<I> {
 
 impl<I> Flasher<I>
 where
-    I: FnOnce() -> std::io::Result<(crate::OsImage, u64)> + Send + 'static,
+    I: FnOnce() -> std::io::Result<(crate::img::OsImage, u64)> + Send + 'static,
 {
     pub fn flash(
         self,
-        chan: Option<mpsc::SyncSender<crate::DownloadFlashingStatus>>,
+        chan: Option<mpsc::SyncSender<DownloadFlashingStatus>>,
     ) -> anyhow::Result<()> {
         let port = self.port;
         let verify = self.verify;

--- a/bb-flasher/src/flasher/bcf/mod.rs
+++ b/bb-flasher/src/flasher/bcf/mod.rs
@@ -10,7 +10,7 @@ pub mod cc1352p7;
 #[cfg(feature = "bcf_msp430")]
 pub mod msp430;
 
-impl From<bb_flasher_bcf::Status> for crate::DownloadFlashingStatus {
+impl From<bb_flasher_bcf::Status> for crate::common::DownloadFlashingStatus {
     fn from(value: bb_flasher_bcf::Status) -> Self {
         match value {
             bb_flasher_bcf::Status::Preparing => Self::Preparing,

--- a/bb-flasher/src/flasher/bcf/msp430.rs
+++ b/bb-flasher/src/flasher/bcf/msp430.rs
@@ -7,7 +7,7 @@
 use std::sync::mpsc;
 use std::{borrow::Cow, ffi::CString, fmt::Display};
 
-use crate::BBFlasherTarget;
+use crate::common::{BBFlasherTarget, DownloadFlashingStatus};
 
 /// BeagleConnect Freedom MSP430 target
 #[derive(Debug, Hash, PartialEq, Eq, Clone)]
@@ -83,11 +83,11 @@ impl<I> Flasher<I> {
 
 impl<I> Flasher<I>
 where
-    I: FnOnce() -> std::io::Result<(crate::OsImage, u64)> + Send + 'static,
+    I: FnOnce() -> std::io::Result<(crate::img::OsImage, u64)> + Send + 'static,
 {
     pub fn flash(
         self,
-        chan: Option<mpsc::SyncSender<crate::DownloadFlashingStatus>>,
+        chan: Option<mpsc::SyncSender<DownloadFlashingStatus>>,
     ) -> anyhow::Result<()> {
         let dst = self.port;
         let img = crate::common::resolve_img(self.img)?;

--- a/bb-flasher/src/flasher/dfu.rs
+++ b/bb-flasher/src/flasher/dfu.rs
@@ -1,4 +1,4 @@
-use crate::{BBFlasherTarget, DownloadFlashingStatus};
+use crate::common::{BBFlasherTarget, DownloadFlashingStatus};
 
 use std::borrow::Cow;
 use std::collections::HashSet;
@@ -114,7 +114,7 @@ impl<R> Flasher<R> {
 
 impl<R> Flasher<R>
 where
-    R: FnOnce() -> std::io::Result<(crate::OsImage, u64)>,
+    R: FnOnce() -> std::io::Result<(crate::img::OsImage, u64)>,
 {
     pub fn flash(
         self,

--- a/bb-flasher/src/flasher/mspm0/mod.rs
+++ b/bb-flasher/src/flasher/mspm0/mod.rs
@@ -5,7 +5,7 @@ use std::{borrow::Cow, fmt::Display};
 
 use bb_helper::cancel::CancellationToken;
 
-use crate::BBFlasherTarget;
+use crate::common::{BBFlasherTarget, DownloadFlashingStatus};
 
 /// MSPM0 UART target
 #[derive(Hash, PartialEq, Eq, Clone, Debug)]
@@ -146,12 +146,12 @@ impl<I> Flasher<I, Box<dyn FnOnce() -> bb_flasher_mspm0::Result<()> + Send>> {
 
 impl<I, P> Flasher<I, P>
 where
-    I: FnOnce() -> std::io::Result<(crate::OsImage, u64)> + Send + 'static,
+    I: FnOnce() -> std::io::Result<(crate::img::OsImage, u64)> + Send + 'static,
     P: FnOnce() -> bb_flasher_mspm0::Result<()> + Send + 'static,
 {
     pub fn flash(
         self,
-        chan: Option<mpsc::SyncSender<crate::DownloadFlashingStatus>>,
+        chan: Option<mpsc::SyncSender<DownloadFlashingStatus>>,
     ) -> anyhow::Result<()> {
         let port = self.port;
         let verify = self.verify;
@@ -191,7 +191,7 @@ where
     }
 }
 
-impl From<bb_flasher_mspm0::Status> for crate::DownloadFlashingStatus {
+impl From<bb_flasher_mspm0::Status> for DownloadFlashingStatus {
     fn from(value: bb_flasher_mspm0::Status) -> Self {
         match value {
             bb_flasher_mspm0::Status::Preparing => Self::Preparing,

--- a/bb-flasher/src/flasher/pb2/mspm0/mod.rs
+++ b/bb-flasher/src/flasher/pb2/mspm0/mod.rs
@@ -11,7 +11,7 @@ use std::borrow::Cow;
 use std::collections::HashSet;
 use std::sync::mpsc;
 
-use crate::BBFlasherTarget;
+use crate::common::{DownloadFlashingStatus, BBFlasherTarget};
 
 /// [PocketBeagle 2] [MSPM0L1105] target
 ///
@@ -68,11 +68,11 @@ impl<I> Flasher<I> {
 
 impl<I> Flasher<I>
 where
-    I: FnOnce() -> std::io::Result<(crate::OsImage, u64)> + Send + 'static,
+    I: FnOnce() -> std::io::Result<(crate::img::OsImage, u64)> + Send + 'static,
 {
     pub fn flash(
         self,
-        chan: Option<mpsc::SyncSender<crate::DownloadFlashingStatus>>,
+        chan: Option<mpsc::SyncSender<DownloadFlashingStatus>>,
     ) -> anyhow::Result<()> {
         let img = self.img;
         let img = crate::common::resolve_img(img)?;

--- a/bb-flasher/src/flasher/pb2/mspm0/raw.rs
+++ b/bb-flasher/src/flasher/pb2/mspm0/raw.rs
@@ -1,5 +1,7 @@
 use std::sync::mpsc;
 
+use crate::common::DownloadFlashingStatus;
+
 use bb_flasher_pb2_mspm0::Error;
 
 pub(crate) fn destinations() -> (String, String) {
@@ -9,7 +11,7 @@ pub(crate) fn destinations() -> (String, String) {
 
 pub(crate) fn flash(
     img: bin_file::BinFile,
-    chan: Option<mpsc::SyncSender<crate::DownloadFlashingStatus>>,
+    chan: Option<mpsc::SyncSender<DownloadFlashingStatus>>,
     persist_eeprom: bool,
 ) -> Result<(), Error> {
     std::thread::scope(|s| {
@@ -29,7 +31,7 @@ pub(crate) fn flash(
     })
 }
 
-impl From<bb_flasher_pb2_mspm0::Status> for crate::DownloadFlashingStatus {
+impl From<bb_flasher_pb2_mspm0::Status> for DownloadFlashingStatus {
     fn from(value: bb_flasher_pb2_mspm0::Status) -> Self {
         match value {
             bb_flasher_pb2_mspm0::Status::Preparing => Self::Preparing,

--- a/bb-flasher/src/flasher/sd/mod.rs
+++ b/bb-flasher/src/flasher/sd/mod.rs
@@ -9,7 +9,7 @@ mod cloud_init;
 use bb_helper::cancel::CancellationToken;
 use std::{borrow::Cow, fmt::Display, path::PathBuf};
 
-use crate::{BBFlasherTarget, DownloadFlashingStatus};
+use crate::common::{BBFlasherTarget, DownloadFlashingStatus};
 
 /// SD Card
 #[derive(Debug, Hash, PartialEq, Eq, Clone)]
@@ -218,7 +218,7 @@ impl<I> Flasher<I, std::future::Ready<std::io::Result<Box<str>>>> {
 
 impl<I, B> Flasher<I, B>
 where
-    I: FnOnce() -> std::io::Result<(crate::OsImage, u64)> + Send,
+    I: FnOnce() -> std::io::Result<(crate::img::OsImage, u64)> + Send,
     B: FnOnce() -> std::io::Result<Box<str>> + Send,
 {
     pub fn flash(

--- a/bb-flasher/src/img/mod.rs
+++ b/bb-flasher/src/img/mod.rs
@@ -1,14 +1,15 @@
 //! Module to handle extraction of compressed firmware, auto detection of type of extraction, etc
 
+#[cfg(feature = "sd")]
 use bb_flasher_sd::ContentType;
 #[cfg(feature = "piped_image")]
 use bb_helper::file_stream::ReaderFileStream;
-use bb_helper::reader_progress::ReaderWithProgress;
 use rc_zip_sync::ReadZipStreaming;
+#[cfg(feature = "sd")]
+use std::sync::mpsc;
 use std::{
     io::{self, Read, Seek, SeekFrom},
     path::Path,
-    sync::mpsc,
 };
 #[cfg(feature = "piped_image")]
 use tokio_util::task::AbortOnDropHandle;
@@ -18,13 +19,15 @@ mod test;
 
 const XZ_MAGIC: [u8; 6] = [0xfd, 0x37, 0x7a, 0x58, 0x5a, 0x00];
 
+#[cfg(feature = "sd")]
 pub struct OsArchive {
     inner: OsArchiveCompression,
 }
 
+#[cfg(feature = "sd")]
 impl OsArchive {
     fn new(img: OsImageSource, chan: Option<mpsc::SyncSender<f32>>, size: u64) -> io::Result<Self> {
-        let img = ReaderWithProgress::new(img, size, chan);
+        let img = bb_helper::reader_progress::ReaderWithProgress::new(img, size, chan);
         let img = OsArchiveCompression::new(img)?;
         Ok(Self { inner: img })
     }
@@ -52,6 +55,7 @@ impl OsArchive {
     }
 }
 
+#[cfg(feature = "sd")]
 impl<'a> IntoIterator for &'a mut OsArchive {
     type Item = (Box<str>, ContentType<'a>);
     type IntoIter = Box<dyn Iterator<Item = Self::Item> + 'a>;
@@ -68,6 +72,7 @@ impl<'a> IntoIterator for &'a mut OsArchive {
     }
 }
 
+#[cfg(feature = "sd")]
 fn flat_map_with_log<'a, R: Read>(
     entry: io::Result<tar::Entry<'a, R>>,
 ) -> Option<(Box<str>, ContentType<'a>)> {
@@ -80,6 +85,7 @@ fn flat_map_with_log<'a, R: Read>(
     }
 }
 
+#[cfg(feature = "sd")]
 fn tar_entry_map<'a, R: Read>(entry: tar::Entry<'a, R>) -> (Box<str>, ContentType<'a>) {
     let p = entry.path().unwrap().to_string_lossy().to_string().into();
     let f = if entry.header().entry_type().is_dir() {
@@ -92,13 +98,16 @@ fn tar_entry_map<'a, R: Read>(entry: tar::Entry<'a, R>) -> (Box<str>, ContentTyp
     (p, f)
 }
 
-type ProgressSource = ReaderWithProgress<OsImageSource>;
+#[cfg(feature = "sd")]
+type ProgressSource = bb_helper::reader_progress::ReaderWithProgress<OsImageSource>;
 
+#[cfg(feature = "sd")]
 enum OsArchiveCompression {
     TarXz(tar::Archive<liblzma::read::XzDecoder<ProgressSource>>),
     Tar(tar::Archive<io::BufReader<ProgressSource>>),
 }
 
+#[cfg(feature = "sd")]
 impl OsArchiveCompression {
     fn new(mut img: ProgressSource) -> io::Result<Self> {
         let mut magic = [0u8; 6];

--- a/bb-flasher/src/lib.rs
+++ b/bb-flasher/src/lib.rs
@@ -39,13 +39,12 @@
 
 mod common;
 mod flasher;
-mod img;
+pub mod img;
 
 use std::path::Path;
 
 pub use common::*;
 pub use flasher::*;
-pub use img::{OsArchive, OsImage};
 
 /// An Os Image present in the local filesystem
 #[derive(Debug, Clone)]
@@ -66,20 +65,21 @@ impl LocalImage {
         self.0.file_name().unwrap()
     }
 
-    pub fn into_image_fn(self) -> impl FnOnce() -> std::io::Result<(OsImage, u64)> {
+    pub fn into_image_fn(self) -> impl FnOnce() -> std::io::Result<(img::OsImage, u64)> {
         move || {
-            let img = OsImage::from_path(&self.0)?;
+            let img = img::OsImage::from_path(&self.0)?;
             let size = img.size();
 
             Ok((img, size))
         }
     }
 
+    #[cfg(feature = "sd")]
     pub fn into_archive_fn(
         self,
         tx: Option<std::sync::mpsc::SyncSender<f32>>,
-    ) -> impl FnOnce() -> std::io::Result<OsArchive> {
-        move || OsArchive::from_path(&self.0, tx)
+    ) -> impl FnOnce() -> std::io::Result<img::OsArchive> {
+        move || img::OsArchive::from_path(&self.0, tx)
     }
 }
 

--- a/bb-imager-cli/Cargo.toml
+++ b/bb-imager-cli/Cargo.toml
@@ -9,7 +9,7 @@ license.workspace = true
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
-bb-flasher = { path = "../bb-flasher" }
+bb-flasher = { path = "../bb-flasher", features = ["sd"] }
 indicatif = "0.18"
 console = "0.16"
 clap_complete = "4.6"

--- a/bb-imager-gui/Cargo.toml
+++ b/bb-imager-gui/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 [dependencies]
 iced = { version = "0.14.0", features = ["image", "svg", "tokio", "advanced", "lazy", "canvas"] }
 rfd = { version = "0.17.2", features = ["file-handle-inner"] }
-bb-flasher = { path = "../bb-flasher", features = ["serde", "piped_image"] }
+bb-flasher = { path = "../bb-flasher", features = ["serde", "piped_image", "sd"] }
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 tracing = "0.1.44"
 iced_aw = { version = "0.14.1", default-features = false, features = ["spinner"] }
@@ -43,11 +43,11 @@ embed-resource = "3.0"
 chrono = "0.4"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-bb-flasher = { path = "../bb-flasher", features = ["sd_linux_udev", "serde"] }
+bb-flasher = { path = "../bb-flasher", features = ["sd", "sd_linux_udev", "serde"] }
 ashpd = { version = "0.13", features = ["notification"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-bb-flasher = { path = "../bb-flasher", features = ["sd_macos_authopen", "serde"] }
+bb-flasher = { path = "../bb-flasher", features = ["sd", "sd_macos_authopen", "serde"] }
 
 [features]
 default = ["static"]

--- a/bb-imager-gui/src/helpers.rs
+++ b/bb-imager-gui/src/helpers.rs
@@ -4,7 +4,10 @@ use std::{
 
 use crate::{BBImagerMessage, PACKAGE_QUALIFIER, constants};
 use bb_config::config;
-use bb_flasher::{BBFlasherTarget, DownloadFlashingStatus};
+use bb_flasher::{
+    BBFlasherTarget, DownloadFlashingStatus,
+    img::{OsArchive, OsImage},
+};
 use iced::widget;
 use std::sync::mpsc;
 use tokio_util::task::AbortOnDropHandle;
@@ -270,7 +273,7 @@ impl RemoteImage {
     fn into_archive_fn(
         self,
         tx: Option<mpsc::SyncSender<f32>>,
-    ) -> impl FnOnce() -> std::io::Result<bb_flasher::OsArchive> {
+    ) -> impl FnOnce() -> std::io::Result<OsArchive> {
         let rt = tokio::runtime::Handle::current();
         move || {
             let downloader = self.downloader.clone();
@@ -278,7 +281,7 @@ impl RemoteImage {
 
             if let Some(path) = cache {
                 tracing::info!("Found the remote image in cache");
-                return bb_flasher::OsArchive::from_path(&path, tx);
+                return OsArchive::from_path(&path, tx);
             }
 
             tracing::info!("Remote image not found in cache. Downloading");
@@ -300,11 +303,11 @@ impl RemoteImage {
                 Ok(())
             });
 
-            bb_flasher::OsArchive::from_piped(rx, AbortOnDropHandle::new(t), self.extract_size, tx)
+            OsArchive::from_piped(rx, AbortOnDropHandle::new(t), self.extract_size, tx)
         }
     }
 
-    fn into_image_fn(self) -> impl FnOnce() -> std::io::Result<(bb_flasher::OsImage, u64)> {
+    fn into_image_fn(self) -> impl FnOnce() -> std::io::Result<(OsImage, u64)> {
         let rt = tokio::runtime::Handle::current();
         move || {
             let downloader = self.downloader.clone();
@@ -312,7 +315,7 @@ impl RemoteImage {
 
             if let Some(path) = cache {
                 tracing::info!("Found the remote image in cache");
-                return Ok((bb_flasher::OsImage::from_path(&path)?, self.extract_size));
+                return Ok((OsImage::from_path(&path)?, self.extract_size));
             }
 
             tracing::info!("Remote image not found in cache. Downloading");
@@ -334,8 +337,7 @@ impl RemoteImage {
                 Ok(())
             });
 
-            let img =
-                bb_flasher::OsImage::from_piped(rx, AbortOnDropHandle::new(t), self.extract_size)?;
+            let img = OsImage::from_piped(rx, AbortOnDropHandle::new(t), self.extract_size)?;
             Ok((img, self.extract_size))
         }
     }
@@ -382,16 +384,14 @@ impl SelectedImage {
     fn into_archive_fn(
         self,
         tx: Option<mpsc::SyncSender<f32>>,
-    ) -> Box<dyn FnOnce() -> std::io::Result<bb_flasher::OsArchive>> {
+    ) -> Box<dyn FnOnce() -> std::io::Result<OsArchive>> {
         match self {
             SelectedImage::LocalImage(x) => Box::new(x.into_archive_fn(tx)),
             SelectedImage::RemoteImage(x) => Box::new(x.into_archive_fn(tx)),
         }
     }
 
-    fn into_image_fn(
-        self,
-    ) -> Box<dyn FnOnce() -> std::io::Result<(bb_flasher::OsImage, u64)> + Send> {
+    fn into_image_fn(self) -> Box<dyn FnOnce() -> std::io::Result<(OsImage, u64)> + Send> {
         match self {
             SelectedImage::LocalImage(x) => Box::new(x.into_image_fn()),
             SelectedImage::RemoteImage(x) => Box::new(x.into_image_fn()),


### PR DESCRIPTION
Cannot be supported in wasm. So make it truly optional.
Related to #368 