### PR TITLE
bb-imager-gui: Use std fs for persistance

### DIFF
--- a/bb-imager-gui/src/persistance.rs
+++ b/bb-imager-gui/src/persistance.rs
@@ -1,9 +1,9 @@
 //! This module contains persistance for configuration
 
-use std::{io::Read, path::PathBuf};
+use std::io::{Read, Write};
+use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
-use tokio::io::AsyncWriteExt;
 
 /// Configuration for GUI that should be presisted
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
@@ -27,21 +27,20 @@ impl GuiConfiguration {
         Ok(serde_json::from_slice(&data).unwrap())
     }
 
-    pub(crate) async fn save(&self) -> std::io::Result<()> {
+    pub(crate) fn save(&self) -> std::io::Result<()> {
         let data = serde_json::to_string_pretty(self).unwrap();
         let config_p = Self::config_path().unwrap();
 
         tracing::info!("Configuration Path: {:?}", config_p);
-        tokio::fs::create_dir_all(config_p.parent().unwrap()).await?;
+        std::fs::create_dir_all(config_p.parent().unwrap())?;
 
-        let mut config = tokio::fs::OpenOptions::new()
+        let mut config = std::fs::OpenOptions::new()
             .write(true)
             .create(true)
             .truncate(true)
-            .open(config_p)
-            .await?;
+            .open(config_p)?;
 
-        config.write_all(data.as_bytes()).await?;
+        config.write_all(data.as_bytes())?;
 
         Ok(())
     }

--- a/bb-imager-gui/src/state.rs
+++ b/bb-imager-gui/src/state.rs
@@ -316,12 +316,12 @@ impl CustomizeState {
 
     pub(crate) fn save_app_config(&self) -> Task<BBImagerMessage> {
         let config = self.app_config().clone();
-        Task::future(async move {
-            if let Err(e) = config.save().await {
+        Task::future(blocking_future(move || {
+            if let Err(e) = config.save() {
                 tracing::error!("Failed to save config: {e}");
             }
             BBImagerMessage::Null
-        })
+        }))
     }
 
     pub(crate) fn selected_board(&self) -> &str {


### PR DESCRIPTION
Since tokio::fs does not even compile for wasm, use std::fs. No major change here.
Related to #368 