### PR TITLE
bb-flasher: Remove positioned-io dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4577,17 +4577,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "positioned-io"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4ec4b80060f033312b99b6874025d9503d2af87aef2dd4c516e253fbfcdada7"
-dependencies = [
- "byteorder",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4980,7 +4969,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa6adff915a3efce163d0d8a06d7e72ac6fa5a9da0c76e979895eca0c6ac000"
 dependencies = [
  "oval",
- "positioned-io",
  "rc-zip",
  "tracing",
 ]

--- a/bb-flasher/Cargo.toml
+++ b/bb-flasher/Cargo.toml
@@ -23,7 +23,7 @@ bb-flasher-sd = { path = "../bb-flasher-sd", optional = true }
 bin_file = { version = "0.2", optional = true }
 tokio-util = { version = "0.7", optional = true, features = ["rt"] }
 bb-helper = { path = "../bb-helper", features = ["cancel"] }
-rc-zip-sync = "4.4"
+rc-zip-sync = { version = "4.4", default-features = false, features = ["deflate"] }
 bb-flasher-dfu = { path = "../bb-flasher-dfu", optional = true }
 anyhow = "1.0"
 bb-flasher-mspm0 = { path = "../bb-flasher-mspm0", optional = true }


### PR DESCRIPTION
- Does not compile on wasm.
- Does not seem to be required for my use anyway.
- Related to #368 