### PR TITLE
bb-imager-gui: windows: manifest: Make DPI aware

### DIFF
--- a/bb-imager-gui/assets/packages/windows/gui.exe.manifest
+++ b/bb-imager-gui/assets/packages/windows/gui.exe.manifest
@@ -8,4 +8,11 @@
 			</requestedPrivileges>
 		</security>
 	</trustInfo>
+        <assemblyIdentity version="1.0.12.0" name="BeagleBoard.org.BBImager"/>
+        <application xmlns="urn:schemas-microsoft-com:asm.v3">
+                <windowsSettings>
+                        <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/PM</dpiAware>
+                        <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+                </windowsSettings>
+        </application>
 </assembly>


### PR DESCRIPTION
- Flagged by Windows App validation kit.
- Not quite sure about the meaning.