### PR TITLE
bb-imager-gui: windows: Resize logo

### DIFF
--- a/bb-imager-gui/Package.appxmanifest
+++ b/bb-imager-gui/Package.appxmanifest
@@ -19,7 +19,7 @@
   <Properties>
     <DisplayName>BeagleBoard Imager</DisplayName>
     <PublisherDisplayName>BeagleBoard.org</PublisherDisplayName>
-    <Logo>assets\icons\icon.png</Logo>
+    <Logo>assets\icons\icon.scale-50.png</Logo>
   </Properties>
 
   <Dependencies>

--- a/bb-imager-gui/assets/icons/icon.scale-50.png
+++ b/bb-imager-gui/assets/icons/icon.scale-50.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:93503b93d9e098c464defd7b5dd43b3b5fbf4b3c9988df6182d29a8e33b5c624
+size 3419


### PR DESCRIPTION
Windows app validation expects 50x50.