### PR TITLE
bb-imager-gui: Improve destination ordering

### DIFF
--- a/bb-flasher-bcf/src/cc1352p7.rs
+++ b/bb-flasher-bcf/src/cc1352p7.rs
@@ -375,7 +375,7 @@ pub fn flash(
 }
 
 /// Returns all paths to ports having BeagleConnect Freedom.
-pub fn ports(filter: bool) -> std::collections::HashSet<String> {
+pub fn ports(filter: bool) -> Vec<String> {
     serialport::available_ports()
         .expect("Unsupported OS")
         .into_iter()

--- a/bb-flasher-bcf/src/msp430.rs
+++ b/bb-flasher-bcf/src/msp430.rs
@@ -245,7 +245,7 @@ pub fn flash(
 }
 
 /// Returns all paths to ports having BeagleConnect Freedom.
-pub fn devices(filter: bool) -> std::collections::HashSet<CString> {
+pub fn devices(filter: bool) -> Vec<CString> {
     hidapi::HidApi::new()
         .expect("Failed to create hidapi context")
         .device_list()

--- a/bb-flasher-dfu/src/lib.rs
+++ b/bb-flasher-dfu/src/lib.rs
@@ -1,7 +1,7 @@
 mod flashing;
 mod helpers;
 
-use std::{collections::HashSet, io, sync::mpsc};
+use std::{io, sync::mpsc};
 use thiserror::Error;
 
 use flashing::dfu_write;
@@ -48,7 +48,7 @@ pub struct Device {
     pub name: String,
 }
 
-pub fn devices(filter: bool) -> HashSet<Device> {
+pub fn devices(filter: bool) -> Vec<Device> {
     rusb::devices()
         .expect("rusb seems to not be implemented for this platform")
         .iter()

--- a/bb-flasher-mspm0/src/i2c.rs
+++ b/bb-flasher-mspm0/src/i2c.rs
@@ -59,7 +59,7 @@ pub fn flash(
 }
 
 /// Returns all paths to serial ports.
-pub fn ports() -> std::collections::HashSet<PathBuf> {
+pub fn ports() -> Vec<PathBuf> {
     std::fs::read_dir("/dev")
         .unwrap()
         .filter_map(|x| x.ok())

--- a/bb-flasher-mspm0/src/uart.rs
+++ b/bb-flasher-mspm0/src/uart.rs
@@ -40,7 +40,7 @@ pub fn flash(
 }
 
 /// Returns all paths to serial ports.
-pub fn ports() -> std::collections::HashSet<String> {
+pub fn ports() -> Vec<String> {
     serialport::available_ports()
         .expect("Unsupported OS")
         .into_iter()

--- a/bb-flasher-sd/src/lib.rs
+++ b/bb-flasher-sd/src/lib.rs
@@ -107,7 +107,7 @@ pub enum Error {
 }
 
 /// Enumerate all SD Cards in system
-pub fn devices(filter: bool) -> std::collections::HashSet<Device> {
+pub fn devices(filter: bool) -> Vec<Device> {
     bb_drivelist::drive_list()
         .expect("Unsupported OS for Sd Card")
         .into_iter()

--- a/bb-flasher/src/common.rs
+++ b/bb-flasher/src/common.rs
@@ -1,6 +1,6 @@
 //! Stuff common to all the flashers
 
-use std::{borrow::Cow, collections::HashSet, io::Read};
+use std::{borrow::Cow, io::Read};
 
 use thiserror::Error;
 
@@ -38,7 +38,7 @@ where
     const IS_DESTINATION_SELECTABLE: bool = true;
 
     /// A list of possible flasher targets
-    fn destinations(filter: bool) -> HashSet<Self>;
+    fn destinations(filter: bool) -> Vec<Self>;
 
     /// A sort of device ID (mostly a Path).
     fn identifier<'a>(&'a self) -> Cow<'a, str>;

--- a/bb-flasher/src/flasher/bcf/cc1352p7.rs
+++ b/bb-flasher/src/flasher/bcf/cc1352p7.rs
@@ -29,7 +29,7 @@ impl From<String> for Target {
 impl BBFlasherTarget for Target {
     const FILE_TYPES: &[&str] = &["bin", "hex", "txt", "xz"];
 
-    fn destinations(filter: bool) -> std::collections::HashSet<Self> {
+    fn destinations(filter: bool) -> Vec<Self> {
         bb_flasher_bcf::cc1352p7::ports(filter)
             .into_iter()
             .map(Self)

--- a/bb-flasher/src/flasher/bcf/msp430.rs
+++ b/bb-flasher/src/flasher/bcf/msp430.rs
@@ -40,7 +40,7 @@ impl From<String> for Target {
 impl BBFlasherTarget for Target {
     const FILE_TYPES: &[&str] = &["hex", "txt", "xz"];
 
-    fn destinations(filter: bool) -> std::collections::HashSet<Self> {
+    fn destinations(filter: bool) -> Vec<Self> {
         bb_flasher_bcf::msp430::devices(filter)
             .into_iter()
             .map(|x| Self {

--- a/bb-flasher/src/flasher/dfu.rs
+++ b/bb-flasher/src/flasher/dfu.rs
@@ -1,7 +1,6 @@
 use crate::common::{BBFlasherTarget, DownloadFlashingStatus};
 
 use std::borrow::Cow;
-use std::collections::HashSet;
 use std::io;
 use std::sync::mpsc;
 
@@ -11,7 +10,7 @@ use bb_helper::cancel::CancellationToken;
 pub struct Target(bb_flasher_dfu::Device);
 
 impl Target {
-    fn destinations_internal(filter: bool) -> HashSet<Self> {
+    fn destinations_internal(filter: bool) -> Vec<Self> {
         bb_flasher_dfu::devices(filter)
             .into_iter()
             .map(Self)
@@ -44,7 +43,7 @@ impl std::fmt::Display for Target {
 impl BBFlasherTarget for Target {
     const FILE_TYPES: &[&str] = &[];
 
-    fn destinations(filter: bool) -> HashSet<Self> {
+    fn destinations(filter: bool) -> Vec<Self> {
         Self::destinations_internal(filter)
     }
 

--- a/bb-flasher/src/flasher/mspm0/mod.rs
+++ b/bb-flasher/src/flasher/mspm0/mod.rs
@@ -51,8 +51,8 @@ impl From<String> for Target {
 impl BBFlasherTarget for Target {
     const FILE_TYPES: &[&str] = &["bin", "hex", "txt", "xz"];
 
-    fn destinations(_: bool) -> std::collections::HashSet<Self> {
-        let mut dsts = std::collections::HashSet::new();
+    fn destinations(_: bool) -> Vec<Self> {
+        let mut dsts = Vec::new();
 
         #[cfg(feature = "mspm0_uart")]
         dsts.extend(bb_flasher_mspm0::uart::ports().into_iter().map(Self::Uart));

--- a/bb-flasher/src/flasher/pb2/mspm0/mod.rs
+++ b/bb-flasher/src/flasher/pb2/mspm0/mod.rs
@@ -8,10 +8,9 @@ mod raw;
 use raw::*;
 
 use std::borrow::Cow;
-use std::collections::HashSet;
 use std::sync::mpsc;
 
-use crate::common::{DownloadFlashingStatus, BBFlasherTarget};
+use crate::common::{BBFlasherTarget, DownloadFlashingStatus};
 
 /// [PocketBeagle 2] [MSPM0L1105] target
 ///
@@ -28,12 +27,12 @@ impl BBFlasherTarget for Target {
     const IS_DESTINATION_SELECTABLE: bool = false;
 
     // Since only a single destination is possible, no need for filters
-    fn destinations(_: bool) -> HashSet<Self> {
+    fn destinations(_: bool) -> Vec<Self> {
         let temp = destinations();
-        HashSet::from([Target {
+        vec![Target {
             name: temp.0,
             path: temp.1,
-        }])
+        }]
     }
 
     fn identifier(&self) -> Cow<'_, str> {

--- a/bb-flasher/src/flasher/sd/mod.rs
+++ b/bb-flasher/src/flasher/sd/mod.rs
@@ -16,7 +16,7 @@ use crate::common::{BBFlasherTarget, DownloadFlashingStatus};
 pub struct Target(bb_flasher_sd::Device);
 
 impl Target {
-    fn destinations_internal(filter: bool) -> std::collections::HashSet<Self> {
+    fn destinations_internal(filter: bool) -> Vec<Self> {
         bb_flasher_sd::devices(filter)
             .into_iter()
             .map(Self)
@@ -56,7 +56,7 @@ impl TryFrom<PathBuf> for Target {
 impl BBFlasherTarget for Target {
     const FILE_TYPES: &[&str] = &["img", "xz", "qcow2"];
 
-    fn destinations(filter: bool) -> std::collections::HashSet<Self> {
+    fn destinations(filter: bool) -> Vec<Self> {
         Self::destinations_internal(filter)
     }
 

--- a/bb-imager-gui/src/main.rs
+++ b/bb-imager-gui/src/main.rs
@@ -234,7 +234,7 @@ impl BBImager {
                     iced::futures::stream::unfold(
                         (*flasher, *filter, search_text.clone()),
                         async move |(flasher, filter, search_text)| {
-                            let mut dest: Vec<helpers::Destination> =
+                            let dest: Vec<helpers::Destination> =
                                 blocking_future(move || helpers::destinations(flasher, filter))
                                     .await
                                     .into_iter()
@@ -243,8 +243,6 @@ impl BBImager {
                                             || t.to_string().to_lowercase().contains(&search_text)
                                     })
                                     .collect();
-
-                            dest.sort_by_key(|x| x.to_string());
 
                             let msg = BBImagerMessage::Destinations(dest);
                             Some((msg, (flasher, filter, search_text)))


### PR DESCRIPTION
Remove any conversion to HashSet since that is a non-ordered structure.
Related to #597 