### PR TITLE
bb-flasher-sd: Add destination integration test

### DIFF
--- a/bb-drivelist/tests/run.rs
+++ b/bb-drivelist/tests/run.rs
@@ -1,4 +1,5 @@
 #[test]
 fn basic() {
-    bb_drivelist::drive_list().unwrap();
+    let temp = bb_drivelist::drive_list().unwrap();
+    assert!(temp.len() > 0);
 }

--- a/bb-flasher-sd/tests/flashing.rs
+++ b/bb-flasher-sd/tests/flashing.rs
@@ -72,3 +72,9 @@ fn test_public_flash_with_temp_file() {
     assert!(!progress_updates.is_empty());
     assert_eq!(*progress_updates.last().unwrap(), 1.0);
 }
+
+#[test]
+fn destinations() {
+    let temp = bb_flasher_sd::devices(false);
+    assert!(temp.len() > 0);
+}


### PR DESCRIPTION
There should at least be 1 value returned for destination.