### PR TITLE
bb-imager-gui: Make notify-rust optional in linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,8 @@ SYSTEM_DEPS ?= 0
 SHARED_HIDRAW ?= 0
 ## variable: UPDATER: Enable updater feature in GUI.
 UPDATER ?= 0
+## variable: NOTIFY_RUST: Use notify-rust for notification. Not needed when using xdg-portal on linux.
+NOTIFY_RUST ?= 1
 
 # Allow skipping build step
 ifeq ($(NO_BUILD),1)
@@ -120,6 +122,11 @@ endif
 # Add pre-relase feature
 ifeq ($(PRE_RELEASE),1)
 	_RUST_ARGS_GUI += -F pre-release
+endif
+
+# Add NOTIFY_RUST feature
+ifeq ($(NOTIFY_RUST),1)
+	_RUST_ARGS_GUI += -F notify-rust
 endif
 
 ## build: build: Build both CLI and GUI
@@ -430,7 +437,7 @@ _fetch-gui-deps:
 ## package: package-gui-flatpak: Build and install package in flatpak. Intended for use in flatpak manifest.
 .PHONY: package-gui-flatpak
 package-gui-flatpak:
-	$(MAKE) _fetch-gui-deps build-gui _install_gui SYSTEM_DEPS=1 PREFIX=${FLATPAK_DEST} GUI_NAME=${FLATPAK_ID} OFFLINE=1
+	$(MAKE) _fetch-gui-deps build-gui _install_gui SYSTEM_DEPS=1 PREFIX=${FLATPAK_DEST} GUI_NAME=${FLATPAK_ID} OFFLINE=1 NOTIFY_RUST=0
 
 ## install: uninstall-gui: Uninstall GUI. Intended for use in Linux.
 .PHONY: uninstall-gui

--- a/bb-imager-gui/Cargo.toml
+++ b/bb-imager-gui/Cargo.toml
@@ -17,7 +17,7 @@ iced_aw = { version = "0.14.1", default-features = false, features = ["spinner"]
 image = "0.25"
 tokio = { version = "1.52", default-features = false, features = ["macros"] }
 webbrowser = "1.2.1"
-notify-rust = { version = "4.17.0", default-features = false, features = ["z-with-tokio"] }
+notify-rust = { version = "4.17.0", default-features = false, features = ["z-with-tokio"], optional = true }
 url = "2.5.4"
 whoami = "2.1"
 localzone = "0.3.1"
@@ -61,6 +61,7 @@ zepto_i2c = ["bb-flasher/mspm0_i2c"]
 pre-release = []
 static-hidraw = ["bb-flasher/static_hidraw"]
 shared-hidraw = ["bb-flasher/shared_hidraw"]
+notify-rust = ["dep:notify-rust"]
 
 [package.metadata.packager]
 icons = ["assets/icons/icon.*"]

--- a/bb-imager-gui/src/helpers.rs
+++ b/bb-imager-gui/src/helpers.rs
@@ -777,13 +777,14 @@ async fn show_notification_xdg_portal(body: &str) -> ashpd::Result<()> {
         .await
 }
 
-pub(crate) async fn show_notification(body: String) -> notify_rust::error::Result<()> {
+pub(crate) async fn show_notification(body: String) -> anyhow::Result<()> {
     #[cfg(target_os = "linux")]
     if show_notification_xdg_portal(&body).await.is_ok() {
         return Ok(());
     }
 
-    tokio::task::spawn_blocking(move || {
+    #[cfg(feature = "notify-rust")]
+    if tokio::task::spawn_blocking(move || {
         notify_rust::Notification::new()
             .appname("BeagleBoard Imager")
             .body(&body)
@@ -792,7 +793,12 @@ pub(crate) async fn show_notification(body: String) -> notify_rust::error::Resul
     })
     .await
     .unwrap()
-    .map(|_| ())
+    .is_ok()
+    {
+        return Ok(());
+    };
+
+    Err(anyhow::anyhow!("Failed to send notification"))
 }
 
 pub(crate) fn project_dirs() -> Option<directories::ProjectDirs> {

--- a/snapcraft.gui.yaml
+++ b/snapcraft.gui.yaml
@@ -38,7 +38,7 @@ parts:
     override-build: |
       # Ensure cargo/rustc from rust-deps are on PATH
       export PATH="$HOME/.cargo/bin:$PATH"
-      make build-gui _install_gui DESTDIR=${CRAFT_PART_INSTALL} PREFIX=/usr SYSTEM_DEPS=1 GUI_NAME=org.beagleboard.imagingutility ZEPTO_I2C=0 BCF_MSP430=0
+      make build-gui _install_gui DESTDIR=${CRAFT_PART_INSTALL} PREFIX=/usr SYSTEM_DEPS=1 GUI_NAME=org.beagleboard.imagingutility ZEPTO_I2C=0 BCF_MSP430=0 NOTIFY_RUST=0
 
 apps:
   bb-imager:


### PR DESCRIPTION
- In case of flatpak and snap, just use xdg portal. It will always be available.
- In case of appimage, use notify-rust as fallback.
- In other OS, just use notify-rust.