### PR TITLE
bb-flasher-mspm0: Add basic integration test

### DIFF
--- a/bb-flasher-mspm0/src/lib.rs
+++ b/bb-flasher-mspm0/src/lib.rs
@@ -6,7 +6,8 @@ mod helpers;
 pub mod i2c;
 #[cfg(feature = "uart")]
 pub mod uart;
-pub mod mock_bsl;
+#[cfg(test)]
+pub(crate) mod mock_bsl;
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 

--- a/bb-flasher-mspm0/src/mock_bsl.rs
+++ b/bb-flasher-mspm0/src/mock_bsl.rs
@@ -24,7 +24,7 @@ enum State {
     WaitingForCrc(crc_fast::Digest),
 }
 
-pub struct MockBsl {
+pub(crate) struct MockBsl {
     state: State,
     tx_data: VecDeque<u8>,
     is_uart: bool,
@@ -33,16 +33,6 @@ pub struct MockBsl {
 }
 
 impl MockBsl {
-    pub const fn uart() -> Self {
-        Self {
-            state: State::Waiting,
-            tx_data: VecDeque::new(),
-            is_uart: true,
-            flash: Vec::new(),
-            start_crc: 0,
-        }
-    }
-
     pub const fn with_start_crc(start_crc: u32) -> Self {
         Self {
             state: State::Waiting,

--- a/bb-flasher-mspm0/tests/basic.rs
+++ b/bb-flasher-mspm0/tests/basic.rs
@@ -1,0 +1,11 @@
+#[test]
+#[cfg(feature = "uart")]
+fn serial_ports() {
+    bb_flasher_mspm0::uart::ports();
+}
+
+#[test]
+#[cfg(all(feature = "i2c", target_os = "linux"))]
+fn i2c_ports() {
+    bb_flasher_mspm0::i2c::ports();
+}


### PR DESCRIPTION
- Just basic tests to see that ports function does not panic.
- Cannot use MockBsl for integration tests since it does not appear as serial device to OS.