### PR TITLE
Fix cargo deny

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -55,7 +55,8 @@ ignore = [
     { id = "RUSTSEC-2025-0141", reason = "Need to update mbrman" },
     { id = "RUSTSEC-2026-0192", reason = "Needed by iced" },
     { id = "RUSTSEC-2026-0195", reason = "Needed by iced" },
-    { id = "RUSTSEC-2026-0194", reason = "Needed by iced" }
+    { id = "RUSTSEC-2026-0194", reason = "Needed by iced" },
+    { id = "RUSTSEC-2026-0206", reason = "Needed by iced" }
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.


### PR DESCRIPTION
- The list of dep errors due to iced seems to just keep on increasing.
- I hate Rust std is so minimal. I could at least remove some of the external deps if it had a simple http client and some other stuff.