### PR TITLE
bb-downloader: Replace tokio-stream with futures-util

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -520,13 +520,13 @@ version = "0.2.0"
 dependencies = [
  "bb-helper",
  "const-hex",
+ "futures-util",
  "httpmock",
  "reqwest",
  "serde",
  "sha2",
  "tempfile",
  "tokio",
- "tokio-stream",
  "tracing",
 ]
 

--- a/bb-downloader/Cargo.toml
+++ b/bb-downloader/Cargo.toml
@@ -19,7 +19,7 @@ tokio = { version = "1.52", default-features = false, features = ["fs"] }
 const-hex = "1.19"
 tempfile = "3.27"
 bb-helper = { path = "../bb-helper", features = ["file_stream"] }
-tokio-stream = "0.1.18"
+futures-util = "0.3"
 
 [features]
 default = ["rustls"]

--- a/bb-downloader/src/lib.rs
+++ b/bb-downloader/src/lib.rs
@@ -22,7 +22,7 @@ use std::{
     time::Duration,
 };
 use tokio::io::AsyncWriteExt;
-use tokio_stream::StreamExt;
+use futures_util::StreamExt;
 
 pub use reqwest::IntoUrl;
 


### PR DESCRIPTION
- Was considering switching to chunks, but well, wasm does not even have that. So I guess will stick to stream for now.
- futures-util is more standard than tokio-stream.