### PR TITLE
bb-flasher-sd: Move mock_sd here

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -644,9 +644,6 @@ dependencies = [
 name = "bb-helper"
 version = "1.0.13"
 dependencies = [
- "fatfs",
- "fscommon",
- "mbrman",
  "tempfile",
  "tokio",
 ]

--- a/bb-flasher-sd/Cargo.toml
+++ b/bb-flasher-sd/Cargo.toml
@@ -22,10 +22,10 @@ bb-bmap-parser = { version = "0.1", path = "../bb-bmap-parser" }
 tokio = { version = "1.52", optional = true, default-features = false, features = ["rt", "signal"] }
 anyhow = "1.0"
 bb-helper = { path = "../bb-helper", features = ["cancel"] }
+tempfile = { version = "3.27", optional = true }
 
 [dev-dependencies]
 tempfile = "3.27"
-bb-helper = { path = "../bb-helper", features = ["mock_sd"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 udisks2 = { version = "0.3", optional = true }
@@ -41,3 +41,4 @@ nix = { version = "0.31", features = ["socket", "uio"], optional = true }
 [features]
 macos_authopen = ["dep:security-framework", "dep:nix"]
 udev = ["dep:udisks2", "dep:tokio"]
+mock_sd = ["dep:tempfile"]

--- a/bb-flasher-sd/src/bootfs_update.rs
+++ b/bb-flasher-sd/src/bootfs_update.rs
@@ -66,7 +66,7 @@ where
 
 #[cfg(test)]
 mod test {
-    use bb_helper::mock_sd::MockSd;
+    use crate::mock_sd::MockSd;
     use std::io;
 
     use super::*;

--- a/bb-flasher-sd/src/helpers.rs
+++ b/bb-flasher-sd/src/helpers.rs
@@ -34,13 +34,6 @@ impl Eject for std::fs::File {
     }
 }
 
-#[cfg(test)]
-impl Eject for bb_helper::mock_sd::MockSd {
-    fn eject(self) -> io::Result<()> {
-        self.as_file().sync_all()
-    }
-}
-
 const BLOCK_SIZE: usize = 4096;
 
 #[derive(Debug)]

--- a/bb-flasher-sd/src/lib.rs
+++ b/bb-flasher-sd/src/lib.rs
@@ -26,6 +26,8 @@ pub mod bootfs_update;
 pub(crate) mod customization;
 mod flashing;
 mod helpers;
+#[cfg(any(feature = "mock_sd", test))]
+pub mod mock_sd;
 pub(crate) mod pal;
 
 pub use customization::{ContentType, Customization, ParitionType};

--- a/bb-flasher-sd/src/mock_sd.rs
+++ b/bb-flasher-sd/src/mock_sd.rs
@@ -1,10 +1,9 @@
 use std::io::{self, Read, Seek, SeekFrom, Write};
 
-use fatfs::FileSystem;
 use fscommon::{BufStream, StreamSlice};
 use mbrman::{CHS, MBR, MBRPartitionEntry};
 
-use crate::cancel::CancellationToken;
+use bb_helper::cancel::CancellationToken;
 
 const DISK_SIZE: u64 = 128 * 1024 * 1024; // 128 MiB
 const SECTOR_SIZE: u32 = 512;
@@ -13,7 +12,7 @@ const FIRST_LBA: u32 = 2048;
 #[derive(Debug)]
 pub struct MockSd {
     file: tempfile::NamedTempFile,
-    fail: crate::cancel::CancellationToken,
+    fail: CancellationToken,
 }
 
 impl Default for MockSd {
@@ -85,19 +84,7 @@ impl MockSd {
     }
 
     pub fn open_boot(&mut self) -> fatfs::FileSystem<BufStream<StreamSlice<&mut Self>>> {
-        let (start_offset, end_offset) = {
-            let mbr = mbrman::MBRHeader::read_from(self).unwrap();
-
-            let boot_part = mbr.get(1).unwrap();
-            let start_offset: u64 = (boot_part.starting_lba * 512).into();
-            let end_offset: u64 = start_offset + u64::from(boot_part.sectors) * 512;
-
-            (start_offset, end_offset)
-        };
-
-        let slice = StreamSlice::new(self, start_offset, end_offset).unwrap();
-        let boot_stream = BufStream::new(slice);
-        FileSystem::new(boot_stream, fatfs::FsOptions::new()).unwrap()
+        crate::customization::ParitionType::Boot.open(self).unwrap()
     }
 }
 
@@ -136,5 +123,11 @@ impl Read for MockSd {
         } else {
             self.file.read(buf)
         }
+    }
+}
+
+impl crate::helpers::Eject for MockSd {
+    fn eject(self) -> io::Result<()> {
+        self.as_file().sync_all()
     }
 }

--- a/bb-flasher-sd/tests/bootfs_update.rs
+++ b/bb-flasher-sd/tests/bootfs_update.rs
@@ -1,6 +1,7 @@
+#![cfg(feature = "mock_sd")]
+
 use bb_flasher_sd::bootfs_update::flash;
 use bb_flasher_sd::{ContentType, Destination};
-use bb_helper::mock_sd::MockSd;
 use std::io::{self, Read, Write};
 use std::path::Path;
 use tempfile::NamedTempFile;
@@ -47,7 +48,7 @@ impl<'b> IntoIterator for &'b mut MockArchive {
 #[test]
 fn test_flash_workflow_with_helper_inspection() {
     // 1. Initialize the public mock storage block device
-    let mut mock_sd = MockSd::new();
+    let mut mock_sd = bb_flasher_sd::mock_sd::MockSd::new();
 
     let temp_file_data = "Hello World";
     let mut temp_file = NamedTempFile::new().unwrap();

--- a/bb-helper/Cargo.toml
+++ b/bb-helper/Cargo.toml
@@ -9,9 +9,6 @@ license.workspace = true
 [dependencies]
 tempfile = "3.27"
 tokio = { version = "1.52", default-features = false, optional = true }
-fatfs = { version = "0.3", optional = true }
-fscommon = { version = "0.1", optional = true }
-mbrman = { version = "0.6", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.52", features = ["macros", "rt-multi-thread"] }
@@ -20,4 +17,3 @@ tokio = { version = "1.52", features = ["macros", "rt-multi-thread"] }
 file_stream = ["tokio/fs", "tokio/io-util"]
 reader_progress = []
 cancel = []
-mock_sd = ["cancel", "dep:fatfs", "dep:fscommon", "dep:mbrman"]

--- a/bb-helper/src/lib.rs
+++ b/bb-helper/src/lib.rs
@@ -9,5 +9,3 @@ pub mod file_stream;
 pub mod reader_progress;
 #[cfg(feature = "cancel")]
 pub mod cancel;
-#[cfg(feature = "mock_sd")]
-pub mod mock_sd;


### PR DESCRIPTION
- Following pattern from mspm0. Just makes more sense here.
- Behind a feature flag since it does require tempfile.