### PR TITLE
bb-drivelist: Make drive_list smoke test host-independent

### DIFF
--- a/bb-drivelist/tests/run.rs
+++ b/bb-drivelist/tests/run.rs
@@ -1,5 +1,25 @@
+//! Smoke test for the public `drive_list()` entry point.
+//!
+//! The number of drives is host-dependent (a minimal CI container may expose
+//! none), so this asserts `drive_list()` succeeds and checks per-descriptor
+//! invariants rather than a non-empty count. The field-level classification
+//! logic (is_usb / is_removable / ... derived from lsblk JSON) needs a parse
+//! seam to exercise from an integration test and is deferred.
+
 #[test]
-fn basic() {
-    let temp = bb_drivelist::drive_list().unwrap();
-    assert!(!temp.is_empty());
+fn drive_list_succeeds_and_descriptors_are_well_formed() {
+    let devices = bb_drivelist::drive_list().expect("drive_list should succeed");
+
+    for device in &devices {
+        // The enumerator identifies the backend and is always populated.
+        assert!(
+            !device.enumerator.is_empty(),
+            "every descriptor should have an enumerator: {device:?}"
+        );
+        // The raw device identifier is always populated.
+        assert!(
+            !device.raw.is_empty(),
+            "every descriptor should have a raw device id: {device:?}"
+        );
+    }
 }


### PR DESCRIPTION
The old test asserted drive_list() returns a non-empty vec, which is host-dependent and can fail in minimal CI containers with no block devices. Assert instead that drive_list() succeeds and that each returned descriptor satisfies backend-neutral invariants (non-empty enumerator and raw id), which hold on any host and add real checks when devices are present.

Field-level classification testing (is_usb/is_removable/... from lsblk JSON) is deferred pending a parse_lsblk(&[u8]) seam.


Claude-Session: https://claude.ai/code/session_01GfcLorS49BN3n176K52RsG