### PR TITLE
bb-flasher-pb2-mspm0: Add inline tests for the sysfs upload state mac…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,6 +608,7 @@ dependencies = [
 name = "bb-flasher-pb2-mspm0"
 version = "0.1.0"
 dependencies = [
+ "tempfile",
  "thiserror 2.0.18",
 ]
 

--- a/bb-flasher-pb2-mspm0/Cargo.toml
+++ b/bb-flasher-pb2-mspm0/Cargo.toml
@@ -11,3 +11,6 @@ keywords = ["pocketbeagle", "mspm0", "flasher", "beagle"]
 
 [dependencies]
 thiserror = "2.0"
+
+[dev-dependencies]
+tempfile = "3.27"

--- a/bb-flasher-pb2-mspm0/src/lib.rs
+++ b/bb-flasher-pb2-mspm0/src/lib.rs
@@ -282,3 +282,83 @@ pub struct Device {
     pub path: String,
     pub flash_size: usize,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::mpsc;
+
+    /// Build a fake firmware-upload sysfs directory. `status` is seeded with
+    /// "idle" so `flash_fw_api`'s polling loop terminates after one read (any
+    /// non-terminal status would spin forever against a static file), and
+    /// `error` carries whatever terminal state we want to exercise.
+    fn fake_sysfs(error: &str) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path();
+        std::fs::write(p.join("loading"), b"").unwrap();
+        std::fs::write(p.join("data"), b"").unwrap();
+        std::fs::write(p.join("status"), b"idle").unwrap();
+        std::fs::write(p.join("error"), error.as_bytes()).unwrap();
+        dir
+    }
+
+    #[test]
+    fn flash_fw_api_writes_firmware_and_reports_success() {
+        let dir = fake_sysfs("none");
+        let (tx, _rx) = mpsc::sync_channel(4);
+        const FW: &[u8] = b"firmware-bytes";
+
+        flash_fw_api(dir.path(), FW, &tx).unwrap();
+
+        // The payload is written verbatim to the `data` entry...
+        assert_eq!(std::fs::read(dir.path().join("data")).unwrap(), FW);
+        // ...and `loading` is toggled 1 (start) then 0 (end) on one handle.
+        assert_eq!(std::fs::read(dir.path().join("loading")).unwrap(), b"10");
+    }
+
+    #[test]
+    fn flash_fw_api_empty_error_is_success() {
+        let dir = fake_sysfs("");
+        let (tx, _rx) = mpsc::sync_channel(1);
+        flash_fw_api(dir.path(), b"x", &tx).unwrap();
+    }
+
+    #[test]
+    fn flash_fw_api_firmware_invalid_is_skipped() {
+        // The driver reports this when the same image is already present; the
+        // flasher treats it as a successful skip, not a failure.
+        let dir = fake_sysfs("preparing:firmware-invalid");
+        let (tx, _rx) = mpsc::sync_channel(1);
+        flash_fw_api(dir.path(), b"x", &tx).unwrap();
+    }
+
+    #[test]
+    fn flash_fw_api_surfaces_flashing_error() {
+        let dir = fake_sysfs("write:0x1234");
+        let (tx, _rx) = mpsc::sync_channel(1);
+
+        match flash_fw_api(dir.path(), b"x", &tx).unwrap_err() {
+            Error::FlashingError { stage, code } => {
+                assert_eq!(stage, "write");
+                assert_eq!(code, "0x1234");
+            }
+            other => panic!("expected FlashingError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn flash_fw_api_missing_loading_entry_fails_to_open() {
+        // `sysfs_w_open` uses create(false); a missing `loading` entry must
+        // surface as FailedToOpen rather than silently creating the file.
+        let dir = tempfile::tempdir().unwrap();
+        let (tx, _rx) = mpsc::sync_channel(1);
+
+        assert!(matches!(
+            flash_fw_api(dir.path(), b"x", &tx).unwrap_err(),
+            Error::FailedToOpen {
+                fname: "loading",
+                ..
+            }
+        ));
+    }
+}


### PR DESCRIPTION
…hine

`flash_fw_api` drives the Linux firmware-upload sysfs protocol (toggle `loading`, write `data`, poll `status`, then interpret `error`) but had no coverage. It already takes an injectable `base: &Path`, so point it at a tempdir seeded with fake sysfs entries to exercise the terminal paths without hardware:

- success (`error` = "none"): firmware written verbatim to `data`, `loading` toggled 1 then 0
- empty `error` treated as success
- "preparing:firmware-invalid" treated as a skip (Ok), not a failure
- non-trivial `error` parsed into FlashingError { stage, code }
- missing `loading` entry surfaces FailedToOpen (create(false)), not a silently-created file

`status` is seeded with "idle" so the poll loop terminates; the progress/transferring branches need a status file that mutates between reads and aren't reachable with static fixtures.


Claude-Session: https://claude.ai/code/session_01GfcLorS49BN3n176K52RsG