### PR TITLE
bb-imager-cli: Add inline tests for the CLI contract and helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -653,6 +653,7 @@ dependencies = [
  "clap_complete",
  "console",
  "indicatif",
+ "tempfile",
  "tracing",
  "tracing-subscriber",
 ]

--- a/bb-imager-cli/Cargo.toml
+++ b/bb-imager-cli/Cargo.toml
@@ -7,6 +7,9 @@ edition.workspace = true
 repository.workspace = true
 license.workspace = true
 
+[dev-dependencies]
+tempfile = "3.27"
+
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
 bb-flasher = { path = "../bb-flasher", features = ["sd"] }

--- a/bb-imager-cli/src/cli.rs
+++ b/bb-imager-cli/src/cli.rs
@@ -212,3 +212,225 @@ pub enum DestinationsTarget {
     #[cfg(any(feature = "zepto_uart", feature = "zepto_i2c"))]
     Zepto,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::CommandFactory;
+
+    /// clap's own recommended smoke test: validates the entire derived command
+    /// tree (no duplicate args, well-formed `requires`/`conflicts`, etc.).
+    #[test]
+    fn cli_definition_is_valid() {
+        Opt::command().debug_assert();
+    }
+
+    #[test]
+    fn flash_sd_minimal_parses() {
+        let opt = Opt::try_parse_from(["bb-imager-cli", "flash", "sd", "img.xz", "/dev/sdX"])
+            .expect("valid sd flash invocation");
+        assert!(!opt.verbose);
+        match opt.command {
+            Commands::Flash { target, quiet } => {
+                assert!(!quiet);
+                match *target {
+                    TargetCommands::Sd { img, dst, .. } => {
+                        assert_eq!(img.as_ref(), Path::new("img.xz"));
+                        assert_eq!(dst, PathBuf::from("/dev/sdX"));
+                    }
+                    other => panic!("expected Sd, got {other:?}"),
+                }
+            }
+            other => panic!("expected Flash, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn flash_sd_customization_flags_parse() {
+        let opt = Opt::try_parse_from([
+            "bb-imager-cli",
+            "flash",
+            "sd",
+            "img.xz",
+            "/dev/sdX",
+            "--hostname",
+            "beagle",
+            "--usb-enable-dhcp",
+            "--file-destination",
+        ])
+        .expect("valid customized sd flash");
+        match opt.command {
+            Commands::Flash { target, .. } => match *target {
+                TargetCommands::Sd {
+                    hostname,
+                    usb_enable_dhcp,
+                    file_destination,
+                    ..
+                } => {
+                    assert_eq!(hostname.as_deref(), Some("beagle"));
+                    assert!(usb_enable_dhcp);
+                    assert!(file_destination);
+                }
+                other => panic!("expected Sd, got {other:?}"),
+            },
+            other => panic!("expected Flash, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn user_name_requires_password() {
+        // `--user-name` declares `requires = "user_password"`.
+        assert!(
+            Opt::try_parse_from([
+                "bb-imager-cli",
+                "flash",
+                "sd",
+                "i",
+                "/d",
+                "--user-name",
+                "bob",
+            ])
+            .is_err()
+        );
+        assert!(
+            Opt::try_parse_from([
+                "bb-imager-cli",
+                "flash",
+                "sd",
+                "i",
+                "/d",
+                "--user-name",
+                "bob",
+                "--user-password",
+                "pw",
+            ])
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn wifi_ssid_requires_password() {
+        assert!(
+            Opt::try_parse_from([
+                "bb-imager-cli",
+                "flash",
+                "sd",
+                "i",
+                "/d",
+                "--wifi-ssid",
+                "net",
+            ])
+            .is_err()
+        );
+        assert!(
+            Opt::try_parse_from([
+                "bb-imager-cli",
+                "flash",
+                "sd",
+                "i",
+                "/d",
+                "--wifi-ssid",
+                "net",
+                "--wifi-password",
+                "pw",
+            ])
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn list_destinations_flags_parse() {
+        let opt = Opt::try_parse_from([
+            "bb-imager-cli",
+            "list-destinations",
+            "sd",
+            "--no-frills",
+            "--no-filter",
+        ])
+        .expect("valid list-destinations");
+        match opt.command {
+            Commands::ListDestinations {
+                target,
+                no_frills,
+                no_filter,
+            } => {
+                assert!(matches!(target, DestinationsTarget::Sd));
+                assert!(no_frills);
+                assert!(no_filter);
+            }
+            other => panic!("expected ListDestinations, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn format_and_verbose_parse() {
+        let opt =
+            Opt::try_parse_from(["bb-imager-cli", "--verbose", "format", "/dev/sdX", "--quiet"])
+                .expect("valid format invocation");
+        assert!(opt.verbose);
+        match opt.command {
+            Commands::Format { dst, quiet } => {
+                assert_eq!(dst, PathBuf::from("/dev/sdX"));
+                assert!(quiet);
+            }
+            other => panic!("expected Format, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn generate_completion_parses_shell() {
+        let opt = Opt::try_parse_from(["bb-imager-cli", "generate-completion", "bash"])
+            .expect("valid completion invocation");
+        assert!(matches!(
+            opt.command,
+            Commands::GenerateCompletion {
+                shell: clap_complete::Shell::Bash
+            }
+        ));
+    }
+
+    #[test]
+    fn unknown_subcommand_is_rejected() {
+        assert!(Opt::try_parse_from(["bb-imager-cli", "bogus"]).is_err());
+    }
+
+    #[test]
+    fn sd_boot_update_parses() {
+        let opt =
+            Opt::try_parse_from(["bb-imager-cli", "flash", "sd-boot-update", "boot.tar", "/dev/sdX"])
+                .expect("valid sd-boot-update");
+        match opt.command {
+            Commands::Flash { target, .. } => match *target {
+                TargetCommands::SdBootUpdate { img, dst } => {
+                    assert_eq!(img.as_ref(), Path::new("boot.tar"));
+                    assert_eq!(dst, PathBuf::from("/dev/sdX"));
+                }
+                other => panic!("expected SdBootUpdate, got {other:?}"),
+            },
+            other => panic!("expected Flash, got {other:?}"),
+        }
+    }
+
+    #[cfg(feature = "pb2_mspm0")]
+    #[test]
+    fn pb2_mspm0_variant_parses() {
+        let opt = Opt::try_parse_from([
+            "bb-imager-cli",
+            "flash",
+            "pb2-mspm0",
+            "fw.bin",
+            "--no-eeprom",
+        ])
+        .expect("valid pb2-mspm0 flash");
+        match opt.command {
+            Commands::Flash { target, .. } => match *target {
+                TargetCommands::Pb2Mspm0 { no_eeprom, img } => {
+                    assert!(no_eeprom);
+                    assert_eq!(img.as_ref(), Path::new("fw.bin"));
+                }
+                other => panic!("expected Pb2Mspm0, got {other:?}"),
+            },
+            other => panic!("expected Flash, got {other:?}"),
+        }
+    }
+}

--- a/bb-imager-cli/src/main.rs
+++ b/bb-imager-cli/src/main.rs
@@ -598,3 +598,62 @@ fn generate_completion(target: clap_complete::Shell) {
 
     clap_complete::generate(target, &mut cmd, BIN_NAME, &mut std::io::stdout())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn progress_msg_maps_each_status() {
+        assert_eq!(progress_msg(DownloadFlashingStatus::Preparing), "Preparing  ");
+        assert_eq!(
+            progress_msg(DownloadFlashingStatus::DownloadingProgress(0.5)),
+            "Downloading"
+        );
+        assert_eq!(
+            progress_msg(DownloadFlashingStatus::FlashingProgress(0.5)),
+            "Flashing"
+        );
+        assert_eq!(progress_msg(DownloadFlashingStatus::Verifying), "Verifying");
+        assert_eq!(
+            progress_msg(DownloadFlashingStatus::Customizing),
+            "Customizing"
+        );
+    }
+
+    #[test]
+    fn stage_msg_prefixes_stage_number() {
+        assert_eq!(
+            stage_msg(DownloadFlashingStatus::Preparing, 3),
+            "[3] Preparing  "
+        );
+        assert_eq!(
+            stage_msg(DownloadFlashingStatus::Verifying, 1),
+            "[1] Verifying"
+        );
+    }
+
+    #[test]
+    fn local_string_file_reads_contents() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bmap.txt");
+        std::fs::write(&path, "bmap-contents").unwrap();
+
+        let read = LocalStringFile::new(path.into_boxed_path()).into_fn();
+        assert_eq!(&*read().unwrap(), "bmap-contents");
+    }
+
+    #[test]
+    fn local_string_file_missing_path_errors() {
+        let read =
+            LocalStringFile::new(PathBuf::from("/nonexistent/bmap.txt").into_boxed_path()).into_fn();
+        assert!(read().is_err());
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn check_macos_device_path_is_identity_off_macos() {
+        let dst = PathBuf::from("/dev/disk2");
+        assert_eq!(check_macos_device_path(dst.clone()), dst);
+    }
+}


### PR DESCRIPTION
The crate had no tests. Almost every command terminates in a real flash/format/list against hardware or the flasher backend, so the testable surface is the argument contract and the pure helpers:

- cli.rs: clap `debug_assert()` plus parse round-trips covering subcommand routing, the `--user-name`/`--user-password` and `--wifi-ssid`/`--wifi-password` `requires` relationships, list-destinations flags, `--verbose`+format, completion shell parsing, and unknown-subcommand rejection. A pb2-mspm0 parse test is gated behind its feature.
- main.rs: progress_msg/stage_msg status mapping, LocalStringFile read success and missing-path error, and the non-macOS check_macos_device_path identity.

Tests run in CI via `cargo test -p bb-imager-cli -F pb2_mspm0,zepto_i2c`.


Claude-Session: https://claude.ai/code/session_01GfcLorS49BN3n176K52RsG