### PR TITLE
bb-config: Replace unmaintained serde-tuple-vec-map with serde_with

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,7 +502,6 @@ dependencies = [
  "const-hex",
  "rusqlite",
  "serde",
- "serde-tuple-vec-map",
  "serde_json",
  "serde_with",
  "url",
@@ -5607,15 +5606,6 @@ name = "serde-big-array"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde-tuple-vec-map"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a04d0ebe0de77d7d445bb729a895dcb0a288854b267ca85f030ce51cdc578c82"
 dependencies = [
  "serde",
 ]

--- a/bb-config/Cargo.toml
+++ b/bb-config/Cargo.toml
@@ -16,7 +16,6 @@ serde_with = "3.19"
 chrono = { version = "0.4", default-features = false, features = ["serde"] }
 url = { version = "2.5", default-features = false, features = ["serde"] }
 const-hex = { version = "1.19", default-features = false, features = ["serde"] }
-serde-tuple-vec-map = "1.0.1"
 rusqlite = "0.40"
 
 [dev-dependencies]

--- a/bb-config/src/config.rs
+++ b/bb-config/src/config.rs
@@ -3,7 +3,7 @@
 use std::collections::HashSet;
 
 use serde::{Deserialize, Serialize};
-use serde_with::{VecSkipError, serde_as};
+use serde_with::{Map, VecSkipError, serde_as};
 use url::Url;
 
 /// [BeagleBoard.org] distros.json abstraction.
@@ -38,6 +38,7 @@ pub struct Imager {
 /// Structure describing [BeagleBoard.org] board
 ///
 /// [BeagleBoard.org]: https://www.beagleboard.org/
+#[serde_as]
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
 pub struct Device {
     /// Board Name
@@ -56,7 +57,7 @@ pub struct Device {
     /// Special Instructions for flashing board.
     pub instructions: Option<String>,
     #[serde(default)]
-    #[serde(with = "tuple_vec_map")]
+    #[serde_as(as = "Map<_, _>")]
     /// Board Specification. With order preserved
     pub specification: Vec<(String, String)>,
     /// OSHW details for the device.

--- a/bb-config/tests/config.rs
+++ b/bb-config/tests/config.rs
@@ -79,7 +79,7 @@ fn full_config_round_trip() {
     assert_eq!(first.imager.devices.len(), 1);
     let device = &first.imager.devices[0];
     assert_eq!(device.flasher, Flasher::SdCard);
-    // `specification` uses tuple_vec_map, which preserves insertion order.
+    // `specification` is (de)serialized as a map via `serde_with::Map`, preserving insertion order.
     assert_eq!(
         device.specification,
         vec![


### PR DESCRIPTION
The serde-tuple-vec-map crate has been unmaintained since 2022 (last release 1.0.1 in April 2022). It was used in a single place to serialize the board `specification` field as an ordered map (JSON object) backed by a `Vec<(String, String)>`.

bb-config already depends on serde_with, which provides the identical behavior via `serde_with::Map`. Switch `specification` to `#[serde_as(as = "Map<_, _>")]` and drop the extra dependency, removing an abandoned crate from the tree at no net cost.

Insertion order is still preserved; the full_config_round_trip test covers this.


Claude-Session: https://claude.ai/code/session_01GdYqMiB9QeRdPCxRXEn7Wf