### PR TITLE
bb-imager-gui: Replace localzone with iana-time-zone

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -672,10 +672,10 @@ dependencies = [
  "const-hex",
  "directories",
  "embed-resource",
+ "iana-time-zone",
  "iced",
  "iced_aw",
  "image",
- "localzone",
  "notify-rust",
  "rfd",
  "rusqlite",
@@ -3418,16 +3418,6 @@ dependencies = [
  "objc-foundation",
  "regex",
  "winapi",
-]
-
-[[package]]
-name = "localzone"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718530aa7b3842752f82224791ea1db5e6b7260513b8ab45706937dbf54f7b4d"
-dependencies = [
- "js-sys",
- "windows 0.54.0",
 ]
 
 [[package]]
@@ -7361,16 +7351,6 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
-dependencies = [
- "windows-core 0.54.0",
- "windows-targets",
-]
-
-[[package]]
-name = "windows"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
@@ -7420,16 +7400,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
  "windows-core 0.62.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
-dependencies = [
- "windows-result 0.1.2",
- "windows-targets",
 ]
 
 [[package]]
@@ -7567,15 +7537,6 @@ checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
  "windows-core 0.62.2",
  "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
-dependencies = [
- "windows-targets",
 ]
 
 [[package]]

--- a/bb-imager-gui/Cargo.toml
+++ b/bb-imager-gui/Cargo.toml
@@ -20,7 +20,7 @@ webbrowser = "1.2.1"
 notify-rust = { version = "4.17.0", default-features = false, features = ["z-with-tokio"], optional = true }
 url = "2.5.4"
 whoami = "2.1"
-localzone = "0.3.1"
+iana-time-zone = "0.1"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = { version = "1.0.150" }
 directories = "6.0.0"

--- a/bb-imager-gui/src/helpers.rs
+++ b/bb-imager-gui/src/helpers.rs
@@ -206,7 +206,8 @@ impl std::fmt::Display for BoardImage {
 }
 
 pub(crate) fn system_timezone() -> Option<&'static String> {
-    static SYSTEM_TIMEZONE: LazyLock<Option<String>> = LazyLock::new(localzone::get_local_zone);
+    static SYSTEM_TIMEZONE: LazyLock<Option<String>> =
+        LazyLock::new(|| iana_time_zone::get_timezone().ok());
     (*SYSTEM_TIMEZONE).as_ref()
 }
 


### PR DESCRIPTION
localzone is a small, low-activity crate (last release 0.3.1 in April 2024) used in a single place to look up the system's IANA timezone name for cloud-init customization defaults.

iana-time-zone is the de-facto, actively maintained crate for the same task and returns the same IANA zone string. Swap `localzone::get_local_zone` for `iana_time_zone::get_timezone().ok()`, preserving the existing Option<String> semantics.


Claude-Session: https://claude.ai/code/session_01GdYqMiB9QeRdPCxRXEn7Wf