### PR TITLE
refactor(gui): drop pass-through state accessors

### DIFF
--- a/bb-imager-gui/src/main.rs
+++ b/bb-imager-gui/src/main.rs
@@ -35,7 +35,7 @@ fn main() -> iced::Result {
         .with(
             tracing_subscriber::fmt::layer()
                 .with_ansi(false)
-                .with_writer(std::fs::File::create(helpers::log_file_path()).unwrap()),
+                .with_writer(std::fs::File::create(&log_file_p).unwrap()),
         )
         .try_init()
         .expect("Failed to register tracing_subscriber");
@@ -474,7 +474,8 @@ impl BBImager {
             Self::Review(inner) => match &inner.customization {
                 helpers::FlashingCustomization::LinuxSdSysconfig(c) => {
                     let mut temp = inner
-                        .app_config()
+                        .common
+                        .app_config
                         .sd_customization
                         .clone()
                         .unwrap_or_default();

--- a/bb-imager-gui/src/message.rs
+++ b/bb-imager-gui/src/message.rs
@@ -186,14 +186,14 @@ pub(crate) fn update(state: &mut BBImager, message: BBImagerMessage) -> Task<BBI
             BBImager::ChooseOs(inner) => {
                 inner.selected_image = Some((
                     helpers::OsImageId::OsImage(image.id),
-                    helpers::BoardImage::remote(image, flasher, inner.downloader().clone()),
+                    helpers::BoardImage::remote(image, flasher, inner.common.downloader.clone()),
                 ));
             }
             BBImager::AppInfo(overlay_state) => match &mut overlay_state.page {
                 OverlayData::ChooseOs(inner) => {
                     inner.selected_image = Some((
                         helpers::OsImageId::OsImage(image.id),
-                        helpers::BoardImage::remote(image, flasher, inner.downloader().clone()),
+                        helpers::BoardImage::remote(image, flasher, inner.common.downloader.clone()),
                     ));
                 }
                 _ => panic!("Unexpected message"),

--- a/bb-imager-gui/src/state.rs
+++ b/bb-imager-gui/src/state.rs
@@ -65,14 +65,6 @@ pub(crate) struct ChooseBoardState {
 }
 
 impl ChooseBoardState {
-    pub(crate) fn selected_board(&self) -> Option<&Board> {
-        self.selected_board.as_ref()
-    }
-
-    pub(crate) fn image_handle_cache(&self) -> &helpers::ImageHandleCache {
-        &self.common.img_handle_cache
-    }
-
     pub(crate) fn refresh_board_list(&self) -> Task<BBImagerMessage> {
         let db = self.common.db.clone();
         let search = self.search_text.clone();
@@ -112,13 +104,6 @@ pub(crate) struct ChooseOsState {
 }
 
 impl ChooseOsState {
-    pub(crate) fn selected_image(&self) -> Option<(&OsImageId, &helpers::BoardImage)> {
-        match &self.selected_image {
-            Some((x, y)) => Some((x, y)),
-            None => None,
-        }
-    }
-
     pub(crate) fn update_images(&mut self, mut imgs: Vec<OsImageItem>, pos: Option<i64>) {
         match self.flasher {
             config::Flasher::SdCard => imgs.extend([
@@ -130,14 +115,6 @@ impl ChooseOsState {
 
         self.images = imgs;
         self.pos = pos;
-    }
-
-    pub(crate) fn image_handle_cache(&self) -> &helpers::ImageHandleCache {
-        &self.common.img_handle_cache
-    }
-
-    pub(crate) fn downloader(&self) -> &bb_downloader::Downloader {
-        &self.common.downloader
     }
 
     pub(crate) fn img_json(&self) -> Option<String> {
@@ -213,15 +190,7 @@ impl ChooseOsState {
 
 impl From<CustomizeState> for ChooseOsState {
     fn from(value: CustomizeState) -> Self {
-        Self {
-            common: value.common,
-            images: Vec::new(),
-            flasher: value.selected_board.flasher,
-            selected_board: value.selected_board,
-            pos: None,
-            selected_image: Some(value.selected_image),
-            search_text: String::new(),
-        }
+        ChooseDestState::from(value).into()
     }
 }
 
@@ -262,14 +231,10 @@ impl ChooseDestState {
         iter.chain(temp)
     }
 
-    pub(crate) fn selected_board(&self) -> &Board {
-        &self.selected_board
-    }
-
     pub(crate) fn instruction(&self) -> Option<&str> {
         match self.selected_image.1.info_text() {
             Some(x) => Some(x),
-            None => self.selected_board().instructions.as_deref(),
+            None => self.selected_board.instructions.as_deref(),
         }
     }
 
@@ -302,34 +267,14 @@ pub(crate) struct CustomizeState {
 }
 
 impl CustomizeState {
-    pub(crate) fn timezones(&self) -> &widget::combo_box::State<String> {
-        &self.common.timezones
-    }
-
-    pub(crate) fn keymaps(&self) -> &widget::combo_box::State<String> {
-        &self.common.keymaps
-    }
-
-    pub(crate) fn app_config(&self) -> &persistance::GuiConfiguration {
-        &self.common.app_config
-    }
-
     pub(crate) fn save_app_config(&self) -> Task<BBImagerMessage> {
-        let config = self.app_config().clone();
+        let config = self.common.app_config.clone();
         Task::future(blocking_future(move || {
             if let Err(e) = config.save() {
                 tracing::error!("Failed to save config: {e}");
             }
             BBImagerMessage::Null
         }))
-    }
-
-    pub(crate) fn selected_board(&self) -> &str {
-        self.selected_board.name.as_str()
-    }
-
-    pub(crate) fn selected_image(&self) -> String {
-        self.selected_image.1.to_string()
     }
 
     pub(crate) fn selected_destination(&self) -> String {
@@ -382,10 +327,6 @@ pub(crate) struct FlashingState {
 }
 
 impl FlashingState {
-    pub(crate) fn selected_board(&self) -> &Board {
-        &self.selected_board
-    }
-
     pub(crate) fn time_remaining(&self) -> Option<Duration> {
         time_remaining_from(self.progress, self.start_timestamp.map(|t| t.elapsed()))
     }
@@ -441,12 +382,6 @@ pub(crate) struct FlashingFinishState {
     pub(crate) common: BBImagerCommon,
     pub(crate) selected_board: Board,
     pub(crate) is_download: bool,
-}
-
-impl FlashingFinishState {
-    pub(crate) fn selected_board(&self) -> &Board {
-        &self.selected_board
-    }
 }
 
 impl From<FlashingState> for FlashingFinishState {

--- a/bb-imager-gui/src/ui/board_selection.rs
+++ b/bb-imager-gui/src/ui/board_selection.rs
@@ -36,7 +36,7 @@ fn board_list_pane<'a>(state: &'a ChooseBoardState) -> Element<'a, BBImagerMessa
                 .map(|x| x.id == dev.id)
                 .unwrap_or(false);
             let img: Element<BBImagerMessage> = match &dev.icon {
-                Some(u) => match state.image_handle_cache().get(u) {
+                Some(u) => match state.common.img_handle_cache.get(u) {
                     Some(handle) => handle.view(ICON_WIDTH, iced::Shrink),
                     _ => iced_aw::Spinner::new().width(ICON_WIDTH).into(),
                 },
@@ -78,7 +78,7 @@ fn board_list_pane<'a>(state: &'a ChooseBoardState) -> Element<'a, BBImagerMessa
 }
 
 fn board_view_pane<'a>(state: &'a ChooseBoardState) -> Element<'a, BBImagerMessage> {
-    match state.selected_board() {
+    match state.selected_board.as_ref() {
         Some(dev) => helpers::board_view_pane(dev, &state.common),
         None => widget::center(
             text("Please Select a Board")

--- a/bb-imager-gui/src/ui/configuration.rs
+++ b/bb-imager-gui/src/ui/configuration.rs
@@ -177,7 +177,7 @@ fn linux_sd_card_common<'a>(
             col.push(element_with_element(
                 toggle.into(),
                 widget::combo_box(
-                    state.timezones(),
+                    &state.common.timezones,
                     "Timezone",
                     Some(&tz.to_owned()),
                     move |t| {
@@ -237,7 +237,7 @@ fn linux_sd_card_common<'a>(
             col.push(element_with_element(
                 toggle.into(),
                 widget::combo_box(
-                    state.keymaps(),
+                    &state.common.keymaps,
                     "Keymap",
                     Some(&keymap.to_owned()),
                     move |t| {

--- a/bb-imager-gui/src/ui/flash.rs
+++ b/bb-imager-gui/src/ui/flash.rs
@@ -42,5 +42,5 @@ pub(crate) fn progress_view(state: &FlashingState) -> Element<'_, BBImagerMessag
 }
 
 pub(crate) fn info_view(state: &FlashingState) -> Element<'_, BBImagerMessage> {
-    helpers::board_view_pane(state.selected_board(), &state.common)
+    helpers::board_view_pane(&state.selected_board, &state.common)
 }

--- a/bb-imager-gui/src/ui/flash_cancel.rs
+++ b/bb-imager-gui/src/ui/flash_cancel.rs
@@ -24,5 +24,5 @@ pub(crate) fn view(state: &FlashingFinishState) -> Element<'_, BBImagerMessage> 
 }
 
 pub(crate) fn info_view(state: &FlashingFinishState) -> Element<'_, BBImagerMessage> {
-    board_view_pane(state.selected_board(), &state.common)
+    board_view_pane(&state.selected_board, &state.common)
 }

--- a/bb-imager-gui/src/ui/flash_success.rs
+++ b/bb-imager-gui/src/ui/flash_success.rs
@@ -30,5 +30,5 @@ pub(crate) fn progress_view(state: &FlashingFinishState) -> Element<'static, BBI
 }
 
 pub(crate) fn info_view(state: &FlashingFinishState) -> Element<'_, BBImagerMessage> {
-    board_view_pane(state.selected_board(), &state.common)
+    board_view_pane(&state.selected_board, &state.common)
 }

--- a/bb-imager-gui/src/ui/image_selection.rs
+++ b/bb-imager-gui/src/ui/image_selection.rs
@@ -23,7 +23,7 @@ pub(crate) fn view<'a>(state: &'a crate::state::ChooseOsState) -> Element<'a, BB
                 .on_press(BBImagerMessage::Back)
                 .style(widget::button::secondary),
             widget::button("NEXT")
-                .on_press_maybe(state.selected_image().map(|_| BBImagerMessage::Next)),
+                .on_press_maybe(state.selected_image.as_ref().map(|_| BBImagerMessage::Next)),
         ],
     )
 }
@@ -64,7 +64,8 @@ fn os_list_pane<'a>(state: &'a crate::state::ChooseOsState) -> Element<'a, BBIma
                     crate::helpers::OsImageId::OsImage(_)
                     | crate::helpers::OsImageId::OsSublist(_) => {
                         match state
-                            .image_handle_cache()
+                            .common
+                            .img_handle_cache
                             .get(img.icon.as_ref().expect("Missing Os Image icon"))
                         {
                             Some(handle) => handle.view(ICON_WIDTH, ICON_WIDTH),
@@ -134,11 +135,11 @@ fn os_list_pane<'a>(state: &'a crate::state::ChooseOsState) -> Element<'a, BBIma
 }
 
 fn os_view_pane<'a>(state: &'a crate::state::ChooseOsState) -> Element<'a, BBImagerMessage> {
-    match state.selected_image() {
+    match state.selected_image.as_ref() {
         Some((_, img)) => {
             let icon = match img.icon() {
                 crate::helpers::BoardImageIcon::Remote(url) => {
-                    match state.image_handle_cache().get(url) {
+                    match state.common.img_handle_cache.get(url) {
                         Some(x) => x.view(iced::Length::Fill, 100),
                         None => iced_aw::Spinner::new().width(iced::Length::Fill).into(),
                     }

--- a/bb-imager-gui/src/ui/review.rs
+++ b/bb-imager-gui/src/ui/review.rs
@@ -42,9 +42,9 @@ fn review_view<'a>(state: &'a CustomizeState) -> Element<'a, BBImagerMessage> {
             .size(HEADING_SIZE),
         widget::grid![
             text("Device"),
-            text(state.selected_board()),
+            text(state.selected_board.name.as_str()),
             text("Operating System"),
-            text(state.selected_image()),
+            text(state.selected_image.1.to_string()),
             text("Storage"),
             text(state.selected_destination())
         ]


### PR DESCRIPTION
The per-screen state structs in bb-imager-gui exposed a dozen methods that only forwarded to an already `pub(crate)` field. They bought no encapsulation and were applied inconsistently: the same view function would read `state.common.scroll_id` directly on one line and go through `state.image_handle_cache()` on the next. Worse, `selected_board()` meant four different things depending on the receiver — `Option<&Board>` on ChooseBoardState, `&Board` on ChooseDestState and FlashingState, and `&str` on CustomizeState — so the name carried no information at a call site.

Delete the forwarding methods and access the fields directly. Accessors that actually compute something (img_json, instruction, destinations, selected_destination, is_download, modifications, save_app_config) are kept.

Also collapse `From<CustomizeState> for ChooseOsState` into the existing CustomizeState -> ChooseDestState -> ChooseOsState chain instead of restating the field list, and reuse the already-computed log path in main() rather than recomputing it.

No functional change.


Claude-Session: https://claude.ai/code/session_01RF4HsWDh9FuwyEVLJ13kRG