### PR TITLE
refactor(gui): share the list/detail pane layout between screens

### DIFF
--- a/bb-imager-gui/src/ui/board_selection.rs
+++ b/bb-imager-gui/src/ui/board_selection.rs
@@ -1,16 +1,9 @@
-use iced::{
-    Element,
-    widget::{self, button, column, row, text},
-};
+use iced::{Element, widget};
 
 use crate::{
     BBImagerMessage,
     state::ChooseBoardState,
-    ui::helpers::{self, LIST_COL_PADDING, VIEW_COL_PADDING, svg_icon_style},
-};
-use crate::{
-    constants,
-    ui::helpers::{card_btn_style, page_type1},
+    ui::helpers::{self, page_type1, svg_icon_style},
 };
 
 const ICON_WIDTH: u32 = 100;
@@ -45,47 +38,21 @@ fn board_list_pane<'a>(state: &'a ChooseBoardState) -> Element<'a, BBImagerMessa
                     .style(svg_icon_style)
                     .into(),
             };
-            button(
-                row![img, text(&dev.name).size(18).width(iced::Length::Fill)]
-                    .spacing(12)
-                    .padding(8)
-                    .align_y(iced::alignment::Vertical::Center),
-            )
             // TODO: Make selected_board proper id
-            .on_press(BBImagerMessage::SelectBoardById(dev.id))
-            .style(move |theme, status| card_btn_style(theme, status, is_selected))
+            helpers::list_item(
+                [img, helpers::list_label(&dev.name).into()],
+                is_selected,
+                BBImagerMessage::SelectBoardById(dev.id),
+            )
         })
         .map(Into::into);
 
-    widget::scrollable(
-        column(
-            [
-                helpers::search_box(&state.search_text).into(),
-                widget::center(widget::rule::horizontal(2))
-                    .padding(iced::Padding {
-                        left: 16.0,
-                        ..Default::default()
-                    })
-                    .into(),
-            ]
-            .into_iter()
-            .chain(items),
-        )
-        .padding(LIST_COL_PADDING),
-    )
-    .id(state.common.scroll_id.clone())
-    .into()
+    helpers::list_pane(&state.search_text, &state.common.scroll_id, [], items)
 }
 
 fn board_view_pane<'a>(state: &'a ChooseBoardState) -> Element<'a, BBImagerMessage> {
     match state.selected_board.as_ref() {
         Some(dev) => helpers::board_view_pane(dev, &state.common),
-        None => widget::center(
-            text("Please Select a Board")
-                .font(constants::FONT_BOLD)
-                .size(28),
-        )
-        .padding(VIEW_COL_PADDING)
-        .into(),
+        None => helpers::placeholder_pane("Please Select a Board"),
     }
 }

--- a/bb-imager-gui/src/ui/configuration.rs
+++ b/bb-imager-gui/src/ui/configuration.rs
@@ -7,7 +7,9 @@ use crate::{
     BBImagerMessage,
     helpers::{self, FlashingCustomization},
     persistance,
-    ui::helpers::{VIEW_COL_PADDING, element_with_element, element_with_label, page_type2},
+    ui::helpers::{
+        VIEW_COL_PADDING, detail_pane, element_with_element, element_with_label, page_type2,
+    },
 };
 
 const INPUT_WIDTH: u32 = 200;
@@ -277,9 +279,7 @@ fn linux_sd_card_cloudinit<'a>(
     config: &'a persistance::SdSysconfCustomization,
 ) -> Element<'a, BBImagerMessage> {
     let col = linux_sd_card_common(state, config, FlashingCustomization::LinuxSdCloudInit);
-    widget::scrollable(col.spacing(16).padding(VIEW_COL_PADDING))
-        .id(state.common.scroll_id.clone())
-        .into()
+    detail_pane(col, &state.common.scroll_id)
 }
 
 fn linux_sd_card_sysconfig<'a>(
@@ -300,9 +300,7 @@ fn linux_sd_card_sysconfig<'a>(
             }),
     );
 
-    widget::scrollable(col.spacing(16).padding(VIEW_COL_PADDING))
-        .id(state.common.scroll_id.clone())
-        .into()
+    detail_pane(col, &state.common.scroll_id)
 }
 
 fn input_with_label<'a, F>(

--- a/bb-imager-gui/src/ui/destination_selection.rs
+++ b/bb-imager-gui/src/ui/destination_selection.rs
@@ -1,16 +1,13 @@
 use iced::{
     Element,
-    widget::{self, button, text},
+    widget::{self, text},
 };
 
 use crate::{
     BBImagerMessage, constants,
     helpers::DestinationItem,
     state::ChooseDestState,
-    ui::helpers::{
-        self, LIST_COL_PADDING, VIEW_COL_PADDING, card_btn_style, detail_entry, page_type1,
-        svg_icon_style,
-    },
+    ui::helpers::{self, detail_entry, page_type1, svg_icon_style},
 };
 
 const ICON_WIDTH: u32 = 60;
@@ -48,54 +45,30 @@ fn dest_list_pane<'a>(state: &'a ChooseDestState) -> Element<'a, BBImagerMessage
             .style(svg_icon_style)
             .into();
 
-            let title: widget::Text<'_, _> = text(dest.to_string()).size(18);
-            let col: iced::Element<'_, _> = match dest.subtitle() {
-                Some(x) => widget::column![title, text(x)]
+            let label: Element<'_, _> = match dest.subtitle() {
+                Some(x) => widget::column![text(dest.to_string()).size(18), text(x)]
                     .width(iced::Length::Fill)
                     .into(),
-                None => title.width(iced::Length::Fill).into(),
+                None => helpers::list_label(dest.to_string()).into(),
             };
-            button(
-                widget::row![icon, col]
-                    .spacing(12)
-                    .padding(8)
-                    .align_y(iced::alignment::Vertical::Center),
-            )
-            .on_press(dest.msg())
-            .style(move |theme, status| card_btn_style(theme, status, is_selected))
+
+            helpers::list_item([icon, label], is_selected, dest.msg())
         })
         .map(Into::into);
 
-    let hrule_pad = iced::Padding {
-        left: 16.0,
-        ..Default::default()
-    };
-
-    widget::scrollable(
-        widget::column(
-            [
-                helpers::search_box(&state.search_text).into(),
-                widget::center(widget::rule::horizontal(2))
-                    .padding(hrule_pad)
-                    .into(),
-                widget::container(
-                    widget::toggler(!state.filter_destination)
-                        .label("Show all destinations")
-                        .on_toggle(|x| BBImagerMessage::DestinationFilter(!x)),
-                )
-                .padding(16)
-                .into(),
-                widget::center(widget::rule::horizontal(2))
-                    .padding(hrule_pad)
-                    .into(),
-            ]
-            .into_iter()
-            .chain(items),
-        )
-        .padding(LIST_COL_PADDING),
+    let filter_toggle = widget::container(
+        widget::toggler(!state.filter_destination)
+            .label("Show all destinations")
+            .on_toggle(|x| BBImagerMessage::DestinationFilter(!x)),
     )
-    .id(state.common.scroll_id.clone())
-    .into()
+    .padding(16);
+
+    helpers::list_pane(
+        &state.search_text,
+        &state.common.scroll_id,
+        [filter_toggle.into(), helpers::list_separator()],
+        items,
+    )
 }
 
 fn dest_view_pane<'a>(state: &'a crate::state::ChooseDestState) -> Element<'a, BBImagerMessage> {
@@ -122,18 +95,10 @@ fn dest_view_pane<'a>(state: &'a crate::state::ChooseDestState) -> Element<'a, B
                     .map(Into::into),
             );
 
-            widget::scrollable(col.spacing(16).padding(VIEW_COL_PADDING))
-                .id(state.common.scroll_id.clone())
-                .into()
+            helpers::detail_pane(col, &state.common.scroll_id)
         }
         None => {
-            let col = widget::column![
-                text("Please Select a Destination")
-                    .size(28)
-                    .width(iced::Fill)
-                    .align_x(iced::Center)
-                    .font(constants::FONT_BOLD)
-            ];
+            let col = widget::column![helpers::placeholder_heading("Please Select a Destination")];
 
             let col = match state.instruction() {
                 Some(x) => col.extend([
@@ -147,11 +112,7 @@ fn dest_view_pane<'a>(state: &'a crate::state::ChooseDestState) -> Element<'a, B
                 None => col,
             };
 
-            widget::center(
-                widget::scrollable(col.padding(VIEW_COL_PADDING).spacing(16))
-                    .id(state.common.scroll_id.clone()),
-            )
-            .into()
+            widget::center(helpers::detail_pane(col, &state.common.scroll_id)).into()
         }
     }
 }

--- a/bb-imager-gui/src/ui/flash.rs
+++ b/bb-imager-gui/src/ui/flash.rs
@@ -11,7 +11,7 @@ use crate::{
 
 pub(crate) fn view(state: &FlashingState) -> Element<'_, BBImagerMessage> {
     page_type1(
-        info_view(state),
+        helpers::board_view_pane(&state.selected_board, &state.common),
         progress_view(state),
         [button("Cancel")
             .style(widget::button::danger)
@@ -19,7 +19,7 @@ pub(crate) fn view(state: &FlashingState) -> Element<'_, BBImagerMessage> {
     )
 }
 
-pub(crate) fn progress_view(state: &FlashingState) -> Element<'_, BBImagerMessage> {
+fn progress_view(state: &FlashingState) -> Element<'_, BBImagerMessage> {
     let (prog, label) = match state.progress {
         bb_flasher::DownloadFlashingStatus::Preparing => (0.0, "Preparing ..."),
         bb_flasher::DownloadFlashingStatus::DownloadingProgress(x) => (x, "Downloading ..."),
@@ -39,8 +39,4 @@ pub(crate) fn progress_view(state: &FlashingState) -> Element<'_, BBImagerMessag
     }
 
     col.align_x(iced::Center).padding(VIEW_COL_PADDING).into()
-}
-
-pub(crate) fn info_view(state: &FlashingState) -> Element<'_, BBImagerMessage> {
-    helpers::board_view_pane(&state.selected_board, &state.common)
 }

--- a/bb-imager-gui/src/ui/flash_cancel.rs
+++ b/bb-imager-gui/src/ui/flash_cancel.rs
@@ -11,7 +11,7 @@ use crate::{
 
 pub(crate) fn view(state: &FlashingFinishState) -> Element<'_, BBImagerMessage> {
     page_type1(
-        info_view(state),
+        board_view_pane(&state.selected_board, &state.common),
         progress_finish_view(
             "Cancelled",
             constants::DANGER,
@@ -21,8 +21,4 @@ pub(crate) fn view(state: &FlashingFinishState) -> Element<'_, BBImagerMessage> 
             .style(widget::button::danger)
             .on_press(BBImagerMessage::Restart)],
     )
-}
-
-pub(crate) fn info_view(state: &FlashingFinishState) -> Element<'_, BBImagerMessage> {
-    board_view_pane(&state.selected_board, &state.common)
 }

--- a/bb-imager-gui/src/ui/flash_success.rs
+++ b/bb-imager-gui/src/ui/flash_success.rs
@@ -11,7 +11,7 @@ use crate::{
 
 pub(crate) fn view(state: &FlashingFinishState) -> Element<'_, BBImagerMessage> {
     page_type1(
-        info_view(state),
+        board_view_pane(&state.selected_board, &state.common),
         progress_view(state),
         [button("Flash Another")
             .style(widget::button::primary)
@@ -19,7 +19,7 @@ pub(crate) fn view(state: &FlashingFinishState) -> Element<'_, BBImagerMessage> 
     )
 }
 
-pub(crate) fn progress_view(state: &FlashingFinishState) -> Element<'static, BBImagerMessage> {
+fn progress_view(state: &FlashingFinishState) -> Element<'static, BBImagerMessage> {
     let msg = if state.is_download {
         "Successfully Downloaded Image"
     } else {
@@ -27,8 +27,4 @@ pub(crate) fn progress_view(state: &FlashingFinishState) -> Element<'static, BBI
     };
 
     progress_finish_view("100%", constants::CHECK_MARK_GREEN, msg)
-}
-
-pub(crate) fn info_view(state: &FlashingFinishState) -> Element<'_, BBImagerMessage> {
-    board_view_pane(&state.selected_board, &state.common)
 }

--- a/bb-imager-gui/src/ui/helpers.rs
+++ b/bb-imager-gui/src/ui/helpers.rs
@@ -283,8 +283,7 @@ pub(crate) fn board_view_pane<'a>(
         widget::text(&dev.description)
             .align_x(iced::alignment::Alignment::Center)
             .width(iced::Length::Fill),
-    ]
-    .spacing(16);
+    ];
 
     let cols = cols.extend(
         dev.specification
@@ -313,11 +312,10 @@ pub(crate) fn board_view_pane<'a>(
         );
     }
 
-    let cols = cols.push(widget::center(widget::row(btns).spacing(16)));
-
-    widget::scrollable(cols.padding(VIEW_COL_PADDING))
-        .id(state.scroll_id.clone())
-        .into()
+    detail_pane(
+        cols.push(widget::center(widget::row(btns).spacing(16))),
+        &state.scroll_id,
+    )
 }
 
 #[derive(Debug)]
@@ -443,7 +441,79 @@ pub(crate) fn copy_btn<'a>(handle: svg::Handle) -> widget::Button<'a, BBImagerMe
         .style(widget::button::secondary)
 }
 
-pub(crate) fn search_box<'a>(inp: &'a str) -> widget::Container<'a, BBImagerMessage> {
+/// Horizontal separator between rows of a list pane.
+pub(crate) fn list_separator<'a>() -> Element<'a, BBImagerMessage> {
+    widget::center(widget::rule::horizontal(2))
+        .padding(iced::Padding::ZERO.left(16))
+        .into()
+}
+
+/// Scrollable pane listing selectable items: a search box, a separator, any
+/// extra `header` rows, then the `items` themselves.
+pub(crate) fn list_pane<'a>(
+    search_text: &'a str,
+    scroll_id: &widget::Id,
+    header: impl IntoIterator<Item = Element<'a, BBImagerMessage>>,
+    items: impl IntoIterator<Item = Element<'a, BBImagerMessage>>,
+) -> Element<'a, BBImagerMessage> {
+    let top = [search_box(search_text).into(), list_separator()];
+
+    widget::scrollable(
+        widget::column(top.into_iter().chain(header).chain(items)).padding(LIST_COL_PADDING),
+    )
+    .id(scroll_id.clone())
+    .into()
+}
+
+/// A selectable row of a [`list_pane`], laid out as a horizontal run of
+/// `contents` (typically a leading icon followed by a label).
+pub(crate) fn list_item<'a>(
+    contents: impl IntoIterator<Item = Element<'a, BBImagerMessage>>,
+    is_selected: bool,
+    msg: BBImagerMessage,
+) -> widget::Button<'a, BBImagerMessage> {
+    widget::button(
+        widget::row(contents)
+            .spacing(12)
+            .padding(8)
+            .align_y(iced::alignment::Vertical::Center),
+    )
+    .on_press(msg)
+    .style(move |theme, status| card_btn_style(theme, status, is_selected))
+}
+
+/// The primary label of a [`list_item`].
+pub(crate) fn list_label<'a>(label: impl widget::text::IntoFragment<'a>) -> widget::Text<'a> {
+    widget::text(label).size(18).width(iced::Length::Fill)
+}
+
+/// Scrollable pane detailing whatever is currently selected in a [`list_pane`].
+pub(crate) fn detail_pane<'a>(
+    content: widget::Column<'a, BBImagerMessage>,
+    scroll_id: &widget::Id,
+) -> Element<'a, BBImagerMessage> {
+    widget::scrollable(content.spacing(16).padding(VIEW_COL_PADDING))
+        .id(scroll_id.clone())
+        .into()
+}
+
+/// Heading of a [`detail_pane`] with nothing selected yet.
+pub(crate) fn placeholder_heading<'a>(label: &'a str) -> widget::Text<'a> {
+    widget::text(label)
+        .size(28)
+        .width(iced::Fill)
+        .align_x(iced::Center)
+        .font(constants::FONT_BOLD)
+}
+
+/// A [`detail_pane`] with nothing selected yet.
+pub(crate) fn placeholder_pane<'a>(label: &'a str) -> Element<'a, BBImagerMessage> {
+    widget::center(placeholder_heading(label))
+        .padding(VIEW_COL_PADDING)
+        .into()
+}
+
+fn search_box<'a>(inp: &'a str) -> widget::Container<'a, BBImagerMessage> {
     widget::container(
         widget::row![
             widget::svg(SEARCH_ICON.clone())

--- a/bb-imager-gui/src/ui/image_selection.rs
+++ b/bb-imager-gui/src/ui/image_selection.rs
@@ -6,10 +6,7 @@ use iced::{
 use crate::{
     constants,
     message::BBImagerMessage,
-    ui::helpers::{
-        self, LIST_COL_PADDING, VIEW_COL_PADDING, card_btn_style, detail_entry, page_type1,
-        svg_icon_style,
-    },
+    ui::helpers::{self, detail_entry, page_type1, svg_icon_style},
 };
 
 const ICON_WIDTH: u32 = 60;
@@ -77,60 +74,40 @@ fn os_list_pane<'a>(state: &'a crate::state::ChooseOsState) -> Element<'a, BBIma
                     }
                 };
 
-                let row = widget::row![icon, text(img.label()).size(18).width(iced::Length::Fill)];
-                let row = if img.is_sublist() {
-                    row.push(
+                let mut contents = vec![icon, helpers::list_label(img.label()).into()];
+                if img.is_sublist() {
+                    contents.push(
                         widget::svg(helpers::ARROW_FORWARD_IOS_ICON.clone())
                             .height(20)
                             .width(iced::Shrink)
-                            .style(svg_icon_style),
-                    )
-                } else {
-                    row
-                };
+                            .style(svg_icon_style)
+                            .into(),
+                    );
+                }
 
-                button(
-                    row.spacing(12)
-                        .padding(8)
-                        .align_y(iced::alignment::Vertical::Center),
-                )
-                .on_press(BBImagerMessage::SelectOs(img.id))
-                .style(move |theme, status| card_btn_style(theme, status, is_selected))
+                helpers::list_item(contents, is_selected, BBImagerMessage::SelectOs(img.id))
             })
             .map(Into::into);
 
-        let col = widget::column![
-            helpers::search_box(&state.search_text),
-            widget::center(widget::rule::horizontal(2)).padding(iced::Padding {
-                left: 16.0,
-                ..Default::default()
-            }),
-        ];
-
-        let col = if state.pos.is_none() {
-            col.extend(items)
+        // Nested sublists get a row to walk back up to their parent.
+        let back: Vec<Element<BBImagerMessage>> = if state.pos.is_none() {
+            Vec::new()
         } else {
             let icon = widget::svg(helpers::ARROW_BACK_ICON.clone())
                 .height(ICON_WIDTH)
                 .width(ICON_WIDTH)
                 .style(svg_icon_style);
-            let row = widget::row![icon, text("Back").size(18).width(iced::Length::Fill)]
-                .spacing(12)
-                .padding(8)
-                .align_y(iced::alignment::Vertical::Center);
-            col.extend(
-                [button(row)
-                    .on_press(BBImagerMessage::GotoOsListParent)
-                    .style(move |theme, status| card_btn_style(theme, status, false))
-                    .into()]
-                .into_iter()
-                .chain(items),
-            )
+            vec![
+                helpers::list_item(
+                    [icon.into(), helpers::list_label("Back").into()],
+                    false,
+                    BBImagerMessage::GotoOsListParent,
+                )
+                .into(),
+            ]
         };
 
-        widget::scrollable(col.padding(LIST_COL_PADDING))
-            .id(state.common.scroll_id.clone())
-            .into()
+        helpers::list_pane(&state.search_text, &state.common.scroll_id, back, items)
     }
 }
 
@@ -220,20 +197,8 @@ fn os_view_pane<'a>(state: &'a crate::state::ChooseOsState) -> Element<'a, BBIma
                 col = col.push(widget::center(row));
             }
 
-            widget::scrollable(col.spacing(16).padding(VIEW_COL_PADDING))
-                .id(state.common.scroll_id.clone())
-                .into()
+            helpers::detail_pane(col, &state.common.scroll_id)
         }
-        None => {
-            let col = widget::column![
-                text("Please Select an OS")
-                    .size(28)
-                    .width(iced::Fill)
-                    .align_x(iced::Center)
-                    .font(constants::FONT_BOLD)
-            ];
-
-            widget::center(col.padding(VIEW_COL_PADDING)).into()
-        }
+        None => helpers::placeholder_pane("Please Select an OS"),
     }
 }

--- a/bb-imager-gui/src/ui/review.rs
+++ b/bb-imager-gui/src/ui/review.rs
@@ -7,7 +7,7 @@ use crate::{
     constants,
     message::BBImagerMessage,
     state::CustomizeState,
-    ui::helpers::{VIEW_COL_PADDING, page_type2},
+    ui::helpers::{detail_pane, page_type2},
 };
 
 const HEADING_SIZE: u32 = 26;
@@ -67,7 +67,5 @@ fn review_view<'a>(state: &'a CustomizeState) -> Element<'a, BBImagerMessage> {
         ]);
     }
 
-    widget::scrollable(col.spacing(16).padding(VIEW_COL_PADDING))
-        .id(state.common.scroll_id.clone())
-        .into()
+    detail_pane(col, &state.common.scroll_id)
 }


### PR DESCRIPTION
The board, image and destination screens each hand-rolled the same two-pane layout independently. All three built a scrollable list column with a search box, a separator and LIST_COL_PADDING; all three built selectable rows as `button(row![icon, label].spacing(12).padding(8))` styled by card_btn_style; six places built the detail pane as
`scrollable(col.spacing(16).padding(VIEW_COL_PADDING)).id(scroll_id)`; and three built a "Please Select a ..." placeholder. The separator's `Padding { left: 16.0, .. }` alone was spelled out four times.

Add list_separator, list_pane, list_item, list_label, detail_pane, placeholder_heading and placeholder_pane to ui::helpers, and express the three screens in terms of them. search_box is now private, since list_pane is the only caller. board_view_pane and the customization/review panes go through detail_pane too.

Also inline the three single-call `info_view` indirections in flash, flash_cancel and flash_success, and make the now module-local progress_view helpers private.

No functional change. The board placeholder now uses the same heading widget as the other two, which adds width(Fill)/align_x(Center) to that text; it is already inside a `center`, so it renders identically.


Claude-Session: https://claude.ai/code/session_01RF4HsWDh9FuwyEVLJ13kRG