### PR TITLE
bb-imager-cli: Add end-to-end tests for CLI commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -648,11 +648,13 @@ version = "1.0.13"
 dependencies = [
  "anyhow",
  "bb-flasher",
+ "bb-flasher-sd",
  "clap",
  "clap_complete",
  "clap_mangen",
  "console",
  "indicatif",
+ "tar",
  "tempfile",
  "tracing",
  "tracing-subscriber",

--- a/bb-imager-cli/Cargo.toml
+++ b/bb-imager-cli/Cargo.toml
@@ -14,6 +14,10 @@ clap_mangen = "0.3"
 
 [dev-dependencies]
 tempfile = "3.27"
+# `mock_sd` provides a real MBR + FAT32 image, which lets the integration tests
+# drive `flash sd` end-to-end against a file destination.
+bb-flasher-sd = { path = "../bb-flasher-sd", features = ["mock_sd"] }
+tar = "0.4"
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }

--- a/bb-imager-cli/src/cli.rs
+++ b/bb-imager-cli/src/cli.rs
@@ -133,7 +133,7 @@ pub enum TargetCommands {
 
         /// The destination is a file instead of SD Card
         #[arg(long)]
-        file_destination: bool
+        file_destination: bool,
     },
     /// Update boot partition with contents from archive
     SdBootUpdate {
@@ -364,9 +364,14 @@ mod tests {
 
     #[test]
     fn format_and_verbose_parse() {
-        let opt =
-            Opt::try_parse_from(["bb-imager-cli", "--verbose", "format", "/dev/sdX", "--quiet"])
-                .expect("valid format invocation");
+        let opt = Opt::try_parse_from([
+            "bb-imager-cli",
+            "--verbose",
+            "format",
+            "/dev/sdX",
+            "--quiet",
+        ])
+        .expect("valid format invocation");
         assert!(opt.verbose);
         match opt.command {
             Commands::Format { dst, quiet } => {
@@ -396,9 +401,14 @@ mod tests {
 
     #[test]
     fn sd_boot_update_parses() {
-        let opt =
-            Opt::try_parse_from(["bb-imager-cli", "flash", "sd-boot-update", "boot.tar", "/dev/sdX"])
-                .expect("valid sd-boot-update");
+        let opt = Opt::try_parse_from([
+            "bb-imager-cli",
+            "flash",
+            "sd-boot-update",
+            "boot.tar",
+            "/dev/sdX",
+        ])
+        .expect("valid sd-boot-update");
         match opt.command {
             Commands::Flash { target, .. } => match *target {
                 TargetCommands::SdBootUpdate { img, dst } => {

--- a/bb-imager-cli/src/lib.rs
+++ b/bb-imager-cli/src/lib.rs
@@ -2,7 +2,7 @@ pub mod cli;
 mod helpers;
 
 use bb_flasher::{BBFlasherTarget, DownloadFlashingStatus, LocalImage};
-use clap::{CommandFactory};
+use clap::CommandFactory;
 use cli::{Commands, DestinationsTarget, Opt, TargetCommands};
 use helpers::LocalStringFile;
 use std::path::PathBuf;

--- a/bb-imager-cli/tests/commands.rs
+++ b/bb-imager-cli/tests/commands.rs
@@ -1,0 +1,62 @@
+//! Tests for the non-flashing subcommands dispatched by `run`.
+//!
+//! `generate-completion` and `list-destinations` write straight to the process
+//! stdout, so these assert on reachability and absence of panics (both commands
+//! index into derived clap/`Target` metadata, which is where they break) rather
+//! than on captured output. `format` is deliberately not covered: it needs a
+//! real block device and would destroy it.
+
+use bb_imager_cli::cli::Opt;
+use clap::{Parser, ValueEnum};
+
+fn run_cli(args: &[&str]) {
+    let opt = Opt::try_parse_from(args).expect("argv should parse");
+    bb_imager_cli::run(opt);
+}
+
+/// `generate_completion` feeds the derived command tree to `clap_complete`,
+/// which panics on a malformed tree (e.g. a positional after a subcommand).
+/// Generating for every supported shell keeps that regression visible.
+#[test]
+fn generate_completion_succeeds_for_every_shell() {
+    for shell in clap_complete::Shell::value_variants() {
+        let shell = shell.to_possible_value().unwrap();
+        run_cli(&["bb-imager-cli", "generate-completion", shell.get_name()]);
+    }
+}
+
+/// Destination enumeration is read-only, but the number of drives is
+/// host-dependent (a CI container may expose none), so this asserts the command
+/// completes for each output mode instead of an exact listing.
+#[test]
+fn list_destinations_sd_runs_in_every_output_mode() {
+    run_cli(&["bb-imager-cli", "list-destinations", "sd"]);
+    run_cli(&["bb-imager-cli", "list-destinations", "sd", "--no-frills"]);
+    run_cli(&["bb-imager-cli", "list-destinations", "sd", "--no-filter"]);
+    run_cli(&[
+        "bb-imager-cli",
+        "list-destinations",
+        "sd",
+        "--no-frills",
+        "--no-filter",
+    ]);
+}
+
+#[cfg(feature = "pb2_mspm0")]
+#[test]
+fn list_destinations_pb2_mspm0_runs() {
+    run_cli(&["bb-imager-cli", "list-destinations", "pb2-mspm0"]);
+    run_cli(&[
+        "bb-imager-cli",
+        "list-destinations",
+        "pb2-mspm0",
+        "--no-frills",
+    ]);
+}
+
+#[cfg(any(feature = "zepto_uart", feature = "zepto_i2c"))]
+#[test]
+fn list_destinations_zepto_runs() {
+    run_cli(&["bb-imager-cli", "list-destinations", "zepto"]);
+    run_cli(&["bb-imager-cli", "list-destinations", "zepto", "--no-frills"]);
+}

--- a/bb-imager-cli/tests/flash_sd.rs
+++ b/bb-imager-cli/tests/flash_sd.rs
@@ -1,0 +1,468 @@
+//! End-to-end tests for the `flash sd` / `flash sd-boot-update` subcommands.
+//!
+//! These drive the real entry point (`Opt::try_parse_from` -> `run`) instead of
+//! calling the flasher directly, so argv parsing, the argument -> customization
+//! mapping and the progress-rendering thread are all exercised together.
+//!
+//! `--file-destination` makes the destination a plain file, so no SD card (and
+//! no elevated privileges) are needed. Where boot-partition contents matter,
+//! the image is a [`MockSd`] (MBR + FAT32) flashed back onto its own path,
+//! which lets `MockSd::open_boot` inspect the result.
+
+use std::io::{Read, Seek, Write};
+
+use bb_flasher_sd::mock_sd::MockSd;
+use bb_imager_cli::cli::Opt;
+use clap::Parser;
+use tempfile::NamedTempFile;
+
+/// Run the CLI exactly as `main` would, from an argv.
+fn run_cli<const N: usize>(args: [&str; N]) {
+    let opt = Opt::try_parse_from(args).expect("argv should parse");
+    bb_imager_cli::run(opt);
+}
+
+/// A deterministic non-image payload, used where only the raw copy matters.
+fn pattern_file(len: usize) -> NamedTempFile {
+    let data: Vec<u8> = (0..len).map(|x| (x % 251) as u8).collect();
+    let mut f = NamedTempFile::new().unwrap();
+    f.write_all(&data).unwrap();
+    f.flush().unwrap();
+    f
+}
+
+/// A `MockSd` plus a copy of its initial bytes stored as a separate file, so
+/// the copy can be used as the OS image while the `MockSd` itself is the
+/// destination (flashing truncates the destination).
+struct SdFixture {
+    mock: MockSd,
+    image: NamedTempFile,
+}
+
+impl SdFixture {
+    fn new() -> Self {
+        Self::with_boot_dirs(&[])
+    }
+
+    /// Like [`Self::new`], but the image's boot partition already contains
+    /// `dirs`. Customization writes files with `create_file`, which does not
+    /// create missing parent directories, so any nested target needs its parent
+    /// to exist in the image beforehand.
+    fn with_boot_dirs(dirs: &[&str]) -> Self {
+        let mut mock = MockSd::new();
+
+        if !dirs.is_empty() {
+            let fs = mock.open_boot();
+            for dir in dirs {
+                fs.root_dir().create_dir(dir).unwrap();
+            }
+            fs.unmount().unwrap();
+        }
+
+        let mut image = NamedTempFile::new().unwrap();
+        let mut src = std::fs::File::open(mock.path()).unwrap();
+        std::io::copy(&mut src, image.as_file_mut()).unwrap();
+        image.flush().unwrap();
+
+        Self { mock, image }
+    }
+
+    fn img(&self) -> &str {
+        self.image.path().to_str().unwrap()
+    }
+
+    fn dst(&self) -> &str {
+        self.mock.path().to_str().unwrap()
+    }
+
+    /// Read a file from the boot partition of the flashed result.
+    fn boot_file(&mut self, name: &str) -> std::io::Result<String> {
+        // `open_boot` reads the partition table from the current cursor.
+        self.mock.rewind().unwrap();
+        let fs = self.mock.open_boot();
+        let mut out = String::new();
+        fs.root_dir()
+            .open_file(name)
+            .map_err(std::io::Error::other)?
+            .read_to_string(&mut out)?;
+        Ok(out)
+    }
+}
+
+fn read_all(path: &std::path::Path) -> Vec<u8> {
+    std::fs::read(path).unwrap()
+}
+
+#[test]
+fn flash_sd_file_destination_copies_image_verbatim() {
+    let img = pattern_file(64 * 1024);
+    let dst = NamedTempFile::new().unwrap();
+
+    run_cli([
+        "bb-imager-cli",
+        "flash",
+        "--quiet",
+        "sd",
+        img.path().to_str().unwrap(),
+        dst.path().to_str().unwrap(),
+        "--file-destination",
+    ]);
+
+    assert_eq!(read_all(dst.path()), read_all(img.path()));
+}
+
+/// Same flash without `--quiet`, which routes progress through the
+/// `indicatif`/`console` rendering thread in `run`.
+#[test]
+fn flash_sd_renders_progress_when_not_quiet() {
+    let img = pattern_file(64 * 1024);
+    let dst = NamedTempFile::new().unwrap();
+
+    run_cli([
+        "bb-imager-cli",
+        "flash",
+        "sd",
+        img.path().to_str().unwrap(),
+        dst.path().to_str().unwrap(),
+        "--file-destination",
+    ]);
+
+    assert_eq!(read_all(dst.path()), read_all(img.path()));
+}
+
+/// The destination file is created when it does not already exist.
+#[test]
+fn flash_sd_creates_missing_destination_file() {
+    let img = pattern_file(4 * 1024);
+    let dir = tempfile::tempdir().unwrap();
+    let dst = dir.path().join("out.img");
+
+    run_cli([
+        "bb-imager-cli",
+        "flash",
+        "--quiet",
+        "sd",
+        img.path().to_str().unwrap(),
+        dst.to_str().unwrap(),
+        "--file-destination",
+    ]);
+
+    assert_eq!(read_all(&dst), read_all(img.path()));
+}
+
+/// With no customization flags the CLI passes `FlashingSdLinuxConfig::none()`,
+/// so the boot partition must come out exactly as the image had it.
+#[test]
+fn flash_sd_without_customization_flags_writes_no_config() {
+    let mut fixture = SdFixture::new();
+
+    run_cli([
+        "bb-imager-cli",
+        "flash",
+        "--quiet",
+        "sd",
+        fixture.img(),
+        fixture.dst(),
+        "--file-destination",
+    ]);
+
+    assert!(
+        fixture.boot_file("sysconf.txt").is_err(),
+        "sysconf.txt should not be created without customization flags"
+    );
+}
+
+/// Every sysconfig-backed flag maps to a `key=value` line, in the order
+/// `FlashingSdLinuxConfig::sysconfig` writes them.
+#[test]
+fn flash_sd_sysconfig_writes_every_supplied_key() {
+    let mut fixture = SdFixture::new();
+
+    run_cli([
+        "bb-imager-cli",
+        "flash",
+        "--quiet",
+        "sd",
+        fixture.img(),
+        fixture.dst(),
+        "--file-destination",
+        "--sysconfig",
+        "--hostname",
+        "beagle",
+        "--timezone",
+        "Asia/Kolkata",
+        "--keymap",
+        "us",
+        "--user-name",
+        "bob",
+        "--user-password",
+        "hunter2",
+        "--ssh-key",
+        "ssh-ed25519 AAAA",
+        "--usb-enable-dhcp",
+    ]);
+
+    assert_eq!(
+        fixture.boot_file("sysconf.txt").unwrap(),
+        "hostname=beagle\n\
+         timezone=Asia/Kolkata\n\
+         keymap=us\n\
+         user_name=bob\n\
+         user_password=hunter2\n\
+         user_authorized_key=ssh-ed25519 AAAA\n\
+         usb_enable_dhcp=yes\n"
+    );
+}
+
+/// A single flag is enough to trigger customization; unset fields are omitted
+/// rather than written empty.
+#[test]
+fn flash_sd_sysconfig_omits_unset_keys() {
+    let mut fixture = SdFixture::new();
+
+    run_cli([
+        "bb-imager-cli",
+        "flash",
+        "--quiet",
+        "sd",
+        fixture.img(),
+        fixture.dst(),
+        "--file-destination",
+        "--sysconfig",
+        "--hostname",
+        "beagle",
+    ]);
+
+    assert_eq!(
+        fixture.boot_file("sysconf.txt").unwrap(),
+        "hostname=beagle\n"
+    );
+}
+
+/// `--usb-enable-dhcp` is a bool, so it is only meaningful as a positive
+/// assertion: leaving it off must not emit the key.
+#[test]
+fn flash_sd_without_usb_dhcp_flag_omits_the_key() {
+    let mut fixture = SdFixture::new();
+
+    run_cli([
+        "bb-imager-cli",
+        "flash",
+        "--quiet",
+        "sd",
+        fixture.img(),
+        fixture.dst(),
+        "--file-destination",
+        "--sysconfig",
+        "--keymap",
+        "us",
+    ]);
+
+    assert_eq!(fixture.boot_file("sysconf.txt").unwrap(), "keymap=us\n");
+}
+
+/// Wi-Fi credentials are split across two files: the sysconfig key points at a
+/// per-SSID PSK file written under `services/`.
+///
+/// NOTE: `services/` must already exist in the image's boot partition — the
+/// customization writer uses `create_file`, which does not create parent
+/// directories, so `--wifi-ssid` on an image without that directory fails the
+/// whole flash with "Failed to create customization services/<ssid>.psk".
+#[test]
+fn flash_sd_wifi_writes_psk_file_next_to_sysconfig() {
+    let mut fixture = SdFixture::with_boot_dirs(&["services"]);
+
+    run_cli([
+        "bb-imager-cli",
+        "flash",
+        "--quiet",
+        "sd",
+        fixture.img(),
+        fixture.dst(),
+        "--file-destination",
+        "--sysconfig",
+        "--wifi-ssid",
+        "mynet",
+        "--wifi-password",
+        "hunter2",
+    ]);
+
+    assert_eq!(
+        fixture.boot_file("sysconf.txt").unwrap(),
+        "iwd_psk_file=mynet.psk\n"
+    );
+    assert_eq!(
+        fixture.boot_file("services/mynet.psk").unwrap(),
+        "[Security]\nPassphrase=hunter2\n\n[Settings]\nAutoConnect=true"
+    );
+}
+
+/// `--cloud-init` adds a cloud-init document *in addition to* sysconfig: the
+/// CLI still generates sysconfig unconditionally (see the fallback TODO in
+/// `flash_internal`). This test pins that current behaviour.
+#[test]
+fn flash_sd_cloud_init_emits_both_configs() {
+    let mut fixture = SdFixture::new();
+
+    run_cli([
+        "bb-imager-cli",
+        "flash",
+        "--quiet",
+        "sd",
+        fixture.img(),
+        fixture.dst(),
+        "--file-destination",
+        "--cloud-init",
+        "--hostname",
+        "beagle",
+        "--user-name",
+        "bob",
+        "--user-password",
+        "hunter2",
+    ]);
+
+    let cloud_init = fixture.boot_file("cloud-init").unwrap();
+    assert!(
+        cloud_init.starts_with("#cloud-config\n"),
+        "cloud-init must carry the cloud-config header, got: {cloud_init}"
+    );
+    assert!(
+        cloud_init.contains("beagle"),
+        "cloud-init should carry the hostname, got: {cloud_init}"
+    );
+
+    assert!(
+        fixture.boot_file("sysconf.txt").is_ok(),
+        "sysconfig is still generated alongside cloud-init"
+    );
+}
+
+/// Customization is only applied to images with a readable boot partition;
+/// a raw payload has no partition table, so the flash must fail loudly rather
+/// than silently dropping the requested config.
+#[test]
+#[should_panic(expected = "Failed to flash")]
+fn flash_sd_customization_on_partitionless_image_fails() {
+    let img = pattern_file(64 * 1024);
+    let dst = NamedTempFile::new().unwrap();
+
+    run_cli([
+        "bb-imager-cli",
+        "flash",
+        "--quiet",
+        "sd",
+        img.path().to_str().unwrap(),
+        dst.path().to_str().unwrap(),
+        "--file-destination",
+        "--sysconfig",
+        "--hostname",
+        "beagle",
+    ]);
+}
+
+#[test]
+#[should_panic(expected = "Failed to flash")]
+fn flash_sd_missing_image_fails() {
+    let dst = NamedTempFile::new().unwrap();
+
+    run_cli([
+        "bb-imager-cli",
+        "flash",
+        "--quiet",
+        "sd",
+        "/nonexistent/image.img",
+        dst.path().to_str().unwrap(),
+        "--file-destination",
+    ]);
+}
+
+/// `--bmap` is resolved lazily through `LocalStringFile`; an unreadable path
+/// must abort the flash rather than fall back to a full copy.
+#[test]
+#[should_panic(expected = "Failed to flash")]
+fn flash_sd_unreadable_bmap_fails() {
+    let img = pattern_file(4 * 1024);
+    let dst = NamedTempFile::new().unwrap();
+
+    run_cli([
+        "bb-imager-cli",
+        "flash",
+        "--quiet",
+        "sd",
+        img.path().to_str().unwrap(),
+        dst.path().to_str().unwrap(),
+        "--file-destination",
+        "--bmap",
+        "/nonexistent/image.bmap",
+    ]);
+}
+
+/// Build a tar archive containing `entries`, as consumed by `sd-boot-update`.
+fn tar_archive(entries: &[(&str, &str)]) -> NamedTempFile {
+    let file = NamedTempFile::new().unwrap();
+    {
+        let mut builder = tar::Builder::new(file.reopen().unwrap());
+        for (name, contents) in entries {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(contents.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            builder
+                .append_data(&mut header, name, contents.as_bytes())
+                .unwrap();
+        }
+        builder.finish().unwrap();
+    }
+    file
+}
+
+#[test]
+fn sd_boot_update_writes_archive_into_boot_partition() {
+    let mut fixture = SdFixture::new();
+    let archive = tar_archive(&[("extlinux.conf", "LABEL Linux\n")]);
+
+    run_cli([
+        "bb-imager-cli",
+        "flash",
+        "--quiet",
+        "sd-boot-update",
+        archive.path().to_str().unwrap(),
+        fixture.dst(),
+    ]);
+
+    assert_eq!(fixture.boot_file("extlinux.conf").unwrap(), "LABEL Linux\n");
+}
+
+/// The non-quiet path for `sd-boot-update` runs its own progress-forwarding
+/// thread (which rewrites archive progress into `FlashingProgress`), so it
+/// needs separate coverage from the quiet path.
+#[test]
+fn sd_boot_update_renders_progress_when_not_quiet() {
+    let mut fixture = SdFixture::new();
+    let archive = tar_archive(&[("uEnv.txt", "console=ttyS2\n")]);
+
+    run_cli([
+        "bb-imager-cli",
+        "flash",
+        "sd-boot-update",
+        archive.path().to_str().unwrap(),
+        fixture.dst(),
+    ]);
+
+    assert_eq!(fixture.boot_file("uEnv.txt").unwrap(), "console=ttyS2\n");
+}
+
+#[test]
+#[should_panic(expected = "Failed to flash")]
+fn sd_boot_update_missing_archive_fails() {
+    let fixture = SdFixture::new();
+
+    run_cli([
+        "bb-imager-cli",
+        "flash",
+        "--quiet",
+        "sd-boot-update",
+        "/nonexistent/boot.tar",
+        fixture.dst(),
+    ]);
+}


### PR DESCRIPTION
The CLI was only covered by unit tests over argv parsing and pure helpers. Now that the crate is a lib, `run()` itself can be driven from a parsed argv, so the argument to customization mapping, the flashing call and the progress rendering threads can be tested together.

Add integration tests that flash for real without hardware or root: `--file-destination` writes to a plain file, and where boot partition contents matter the image is a MockSd (MBR + FAT32) flashed back onto its own path so `open_boot` can inspect the result. Cover the verbatim copy, destination creation, sysconfig/cloud-init/wifi customization, sd-boot-update, the failure paths, and both the quiet and progress rendering paths. Also cover `run()` dispatch for generate-completion and list-destinations.

Fix the rustfmt violations this surfaced in cli.rs and lib.rs.


Claude-Session: https://claude.ai/code/session_01Tiu4HSimRXke8SeqkZVkAv