### PR TITLE
.github: workflows: release: Fix appimage release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ env:
   VERBOSE: 1
   PRE_RELEASE: ${{ github.ref_type != 'tag' && '1' || '0' }}
   VERSION: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
-  APPIMAGE_RELEASE_TAG: ${{ github.ref_type == 'tag' && github.ref_name || 'continuous-release' }}
+  APPIMAGE_RELEASE_TAG: ${{ github.ref_type == 'tag' && 'latest' || 'continuous-release' }}
 
 defaults:
   run:


### PR DESCRIPTION
Just use latest tag since appimage supposably understands it.