### PR TITLE
bb-iced-widgets: Add cached_icon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,6 +647,7 @@ name = "bb-iced-widgets"
 version = "1.0.13"
 dependencies = [
  "iced",
+ "iced_aw",
  "image",
 ]
 

--- a/bb-iced-widgets/Cargo.toml
+++ b/bb-iced-widgets/Cargo.toml
@@ -9,3 +9,4 @@ license.workspace = true
 [dependencies]
 iced = { version = "0.14", features = ["advanced", "canvas", "image", "svg"] }
 image = "0.25"
+iced_aw = { version = "0.14.1", default-features = false, features = ["spinner"] }

--- a/bb-iced-widgets/src/cached_icon.rs
+++ b/bb-iced-widgets/src/cached_icon.rs
@@ -1,0 +1,67 @@
+use std::{collections::HashMap, hash::Hash, path::PathBuf};
+
+use iced::Length;
+
+#[derive(Debug)]
+pub struct Cache<K: Eq + Hash>(HashMap<K, Option<crate::icon::Handle>>);
+
+impl<K: Eq + Hash> Default for Cache<K> {
+    fn default() -> Self {
+        Self(HashMap::new())
+    }
+}
+
+impl<K: Eq + Hash> Cache<K> {
+    pub fn get(&self, u: &K) -> Option<&crate::icon::Handle> {
+        self.0.get(u)?.as_ref()
+    }
+
+    pub fn insert(&mut self, u: K, path: PathBuf) {
+        self.0.insert(u, Some(path.into()));
+    }
+
+    pub fn mark_fetching(&mut self, u: K) {
+        self.0.insert(u, None);
+    }
+
+    pub fn contains(&self, u: &K) -> bool {
+        self.0.contains_key(u)
+    }
+}
+
+pub enum CachedIcon<'a> {
+    Icon(crate::icon::Icon<'a>),
+    Spinner(iced_aw::Spinner),
+}
+
+impl<'a> CachedIcon<'a> {
+    pub fn new<K: Eq + Hash>(cache: &Cache<K>, key: &K) -> Self {
+        match cache.get(key) {
+            Some(v) => Self::Icon(crate::icon(v.clone())),
+            None => Self::Spinner(iced_aw::Spinner::new()),
+        }
+    }
+
+    pub fn width(self, width: impl Into<Length>) -> Self {
+        match self {
+            CachedIcon::Icon(icon) => Self::Icon(icon.width(width)),
+            CachedIcon::Spinner(spinner) => Self::Spinner(spinner.width(width)),
+        }
+    }
+
+    pub fn height(self, height: impl Into<Length>) -> Self {
+        match self {
+            CachedIcon::Icon(icon) => Self::Icon(icon.height(height)),
+            CachedIcon::Spinner(spinner) => Self::Spinner(spinner.height(height)),
+        }
+    }
+}
+
+impl<'a, M> From<CachedIcon<'a>> for iced::Element<'a, M> {
+    fn from(value: CachedIcon<'a>) -> Self {
+        match value {
+            CachedIcon::Icon(icon) => icon.into(),
+            CachedIcon::Spinner(spinner) => spinner.into(),
+        }
+    }
+}

--- a/bb-iced-widgets/src/lib.rs
+++ b/bb-iced-widgets/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod cached_icon;
 pub mod circle_bar;
 pub mod icon;
 pub mod progress_circle;
@@ -22,4 +23,11 @@ pub fn circle_bar<T>(
 
 pub fn icon<'a>(handle: impl Into<icon::Handle>) -> icon::Icon<'a> {
     icon::Icon::new(handle)
+}
+
+pub fn cached_icon<'a, K: Eq + std::hash::Hash>(
+    cache: &cached_icon::Cache<K>,
+    key: &K,
+) -> cached_icon::CachedIcon<'a> {
+    cached_icon::CachedIcon::new(cache, key)
 }

--- a/bb-imager-gui/src/helpers.rs
+++ b/bb-imager-gui/src/helpers.rs
@@ -1,7 +1,5 @@
 use std::io;
-use std::{
-    borrow::Cow, collections::HashMap, fmt::Display, path::PathBuf, sync::LazyLock, time::Duration,
-};
+use std::{borrow::Cow, fmt::Display, path::PathBuf, sync::LazyLock, time::Duration};
 
 use crate::{BBImagerMessage, PACKAGE_QUALIFIER, constants};
 use bb_config::config;
@@ -807,42 +805,6 @@ pub(crate) fn log_file_path() -> PathBuf {
     ))
 }
 
-#[derive(Default, Debug)]
-pub(crate) struct ImageHandleCache(HashMap<url::Url, Option<bb_iced_widgets::icon::Handle>>);
-
-impl ImageHandleCache {
-    pub(crate) fn get(&self, u: &url::Url) -> Option<&bb_iced_widgets::icon::Handle> {
-        self.0.get(u)?.as_ref()
-    }
-
-    pub(crate) fn insert(&mut self, u: url::Url, path: PathBuf) {
-        self.0.insert(u, Some(path.into()));
-    }
-
-    pub(crate) fn mark_fetching(&mut self, u: url::Url) {
-        self.0.insert(u, None);
-    }
-
-    pub(crate) fn contains(&self, u: &url::Url) -> bool {
-        self.0.contains_key(u)
-    }
-
-    pub(crate) fn view(
-        &self,
-        u: &url::Url,
-        width: impl Into<iced::Length>,
-        height: impl Into<iced::Length>,
-    ) -> iced::Element<'_, BBImagerMessage> {
-        match self.get(u) {
-            Some(handle) => bb_iced_widgets::icon(handle.clone())
-                .width(width)
-                .height(height)
-                .into(),
-            None => iced_aw::Spinner::new().width(width).height(height).into(),
-        }
-    }
-}
-
 pub(crate) fn pretty_bytes(bytes: u64) -> String {
     const UNITS: [&str; 7] = ["B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB"];
 
@@ -1380,20 +1342,6 @@ mod tests {
             OsImageId::OsSublist((7, config::Flasher::SdCard))
         );
         assert!(sublist.is_sublist());
-    }
-
-    #[test]
-    fn image_handle_cache_tracks_fetch_state() {
-        let url = Url::parse("https://example.com/a.png").unwrap();
-        let mut cache = ImageHandleCache::default();
-
-        assert!(!cache.contains(&url));
-        assert!(cache.get(&url).is_none());
-
-        cache.mark_fetching(url.clone());
-        assert!(cache.contains(&url));
-        // Marked-but-unresolved entries have no value yet.
-        assert!(cache.get(&url).is_none());
     }
 
     #[test]

--- a/bb-imager-gui/src/main.rs
+++ b/bb-imager-gui/src/main.rs
@@ -130,7 +130,7 @@ impl BBImager {
                     .collect(),
             ),
 
-            img_handle_cache: helpers::ImageHandleCache::default(),
+            img_handle_cache: bb_iced_widgets::cached_icon::Cache::default(),
 
             scroll_id: widget::Id::unique(),
             db: db.clone(),

--- a/bb-imager-gui/src/state.rs
+++ b/bb-imager-gui/src/state.rs
@@ -18,7 +18,7 @@ pub(crate) struct BBImagerCommon {
     pub(crate) timezones: widget::combo_box::State<String>,
     pub(crate) keymaps: widget::combo_box::State<String>,
 
-    pub(crate) img_handle_cache: helpers::ImageHandleCache,
+    pub(crate) img_handle_cache: bb_iced_widgets::cached_icon::Cache<url::Url>,
 
     pub(crate) scroll_id: widget::Id,
     pub(crate) db: db::Db,
@@ -610,11 +610,17 @@ mod tests {
     #[test]
     fn non_progress_states_have_no_eta() {
         assert_eq!(
-            time_remaining_from(DownloadFlashingStatus::Preparing, Some(Duration::from_secs(5))),
+            time_remaining_from(
+                DownloadFlashingStatus::Preparing,
+                Some(Duration::from_secs(5))
+            ),
             None
         );
         assert_eq!(
-            time_remaining_from(DownloadFlashingStatus::Verifying, Some(Duration::from_secs(5))),
+            time_remaining_from(
+                DownloadFlashingStatus::Verifying,
+                Some(Duration::from_secs(5))
+            ),
             None
         );
     }

--- a/bb-imager-gui/src/ui/helpers.rs
+++ b/bb-imager-gui/src/ui/helpers.rs
@@ -393,14 +393,17 @@ pub(crate) fn progress_finish_view<'a>(
 }
 
 pub(crate) fn network_image_or_default<'a>(
-    cache: &'a crate::helpers::ImageHandleCache,
+    cache: &'a bb_iced_widgets::cached_icon::Cache<url::Url>,
     img: Option<&url::Url>,
     def: svg::Handle,
     width: impl Into<iced::Length>,
     height: impl Into<iced::Length>,
 ) -> Element<'a, BBImagerMessage> {
     match img {
-        Some(u) => cache.view(u, width, height),
+        Some(u) => bb_iced_widgets::cached_icon(cache, u)
+            .width(width)
+            .height(height)
+            .into(),
         None => widget::svg(def)
             .width(width)
             .height(height)

--- a/bb-imager-gui/src/ui/image_selection.rs
+++ b/bb-imager-gui/src/ui/image_selection.rs
@@ -59,13 +59,13 @@ fn os_list_pane<'a>(state: &'a crate::state::ChooseOsState) -> Element<'a, BBIma
                             .into()
                     }
                     crate::helpers::OsImageId::OsImage(_)
-                    | crate::helpers::OsImageId::OsSublist(_) => {
-                        state.common.img_handle_cache.view(
-                            img.icon.as_ref().expect("Missing Os Image icon"),
-                            ICON_WIDTH,
-                            ICON_WIDTH,
-                        )
-                    }
+                    | crate::helpers::OsImageId::OsSublist(_) => bb_iced_widgets::cached_icon(
+                        &state.common.img_handle_cache,
+                        img.icon.as_ref().expect("Missing Os Image icon"),
+                    )
+                    .width(ICON_WIDTH)
+                    .height(ICON_WIDTH)
+                    .into(),
                 };
 
                 let mut contents = vec![icon, helpers::list_label(img.label()).into()];
@@ -108,12 +108,12 @@ fn os_list_pane<'a>(state: &'a crate::state::ChooseOsState) -> Element<'a, BBIma
 fn os_view_pane<'a>(state: &'a crate::state::ChooseOsState) -> Element<'a, BBImagerMessage> {
     match state.selected_image.as_ref() {
         Some((_, img)) => {
-            let icon = match img.icon() {
+            let icon: Element<'a, BBImagerMessage> = match img.icon() {
                 crate::helpers::BoardImageIcon::Remote(url) => {
-                    state
-                        .common
-                        .img_handle_cache
-                        .view(url, iced::Length::Fill, 100)
+                    bb_iced_widgets::cached_icon(&state.common.img_handle_cache, url)
+                        .width(iced::Length::Fill)
+                        .height(100)
+                        .into()
                 }
                 crate::helpers::BoardImageIcon::Local => {
                     widget::svg(helpers::FILE_ADD_ICON.clone())


### PR DESCRIPTION
Mainly for network images, but can be used for other purposes if required.