### PR TITLE
bb-downloader: Remove unused code

### DIFF
--- a/bb-downloader/src/helpers.rs
+++ b/bb-downloader/src/helpers.rs
@@ -1,51 +1,6 @@
-use std::{
-    io,
-    path::Path,
-    pin::Pin,
-    task::{Context, Poll},
-};
+use std::{io, path::Path};
 
 use sha2::{Digest, Sha256};
-use tokio::io::{AsyncSeekExt, AsyncWriteExt};
-
-pub(crate) struct AsyncTempFile(tokio::fs::File);
-
-impl AsyncTempFile {
-    pub(crate) fn new() -> io::Result<Self> {
-        let f = tempfile::tempfile()?;
-        Ok(Self(tokio::fs::File::from_std(f)))
-    }
-
-    pub(crate) async fn persist(&mut self, path: &Path) -> io::Result<()> {
-        let mut f = tokio::fs::File::create(path).await?;
-        self.0.rewind().await?;
-
-        tokio::io::copy(&mut self.0, &mut f).await?;
-
-        // Causes errors if not present
-        f.flush().await?;
-
-        Ok(())
-    }
-}
-
-impl tokio::io::AsyncWrite for AsyncTempFile {
-    fn poll_write(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &[u8],
-    ) -> Poll<io::Result<usize>> {
-        Pin::new(&mut self.0).poll_write(cx, buf)
-    }
-
-    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        Pin::new(&mut self.0).poll_flush(cx)
-    }
-
-    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        Pin::new(&mut self.0).poll_shutdown(cx)
-    }
-}
 
 pub(crate) fn sha256_from_path(p: &Path) -> io::Result<[u8; 32]> {
     let file = std::fs::File::open(p)?;
@@ -68,48 +23,6 @@ mod tests {
     use std::io::Write;
 
     use super::*;
-    use tokio::io::AsyncReadExt;
-
-    #[tokio::test]
-    async fn test_new_and_write() -> io::Result<()> {
-        // 1. Create a new async temp file
-        let mut temp_file = AsyncTempFile::new()?;
-
-        // 2. Test AsyncWrite implementation
-        let data = b"Hello, Tokio async world!";
-        temp_file.write_all(data).await?;
-        temp_file.flush().await?;
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_persist() -> io::Result<()> {
-        let mut temp_file = AsyncTempFile::new()?;
-        let data = b"Persisted content data.";
-
-        // Write data to the temporary storage
-        temp_file.write_all(data).await?;
-        temp_file.flush().await?;
-
-        // Create a named temporary directory to house our persisted file safely
-        let target_dir = tempfile::tempdir()?;
-        let target_path = target_dir.path().join("persisted_output.txt");
-
-        // 3. Persist the file to the target path
-        temp_file.persist(&target_path).await?;
-
-        // 4. Verify the target file contains the exact data
-        assert!(target_path.exists(), "Target file was not created");
-
-        let mut verified_file = tokio::fs::File::open(&target_path).await?;
-        let mut contents = Vec::new();
-        verified_file.read_to_end(&mut contents).await?;
-
-        assert_eq!(contents, data);
-
-        Ok(())
-    }
 
     #[test]
     fn test_sha256_from_path() {

--- a/bb-downloader/src/lib.rs
+++ b/bb-downloader/src/lib.rs
@@ -11,7 +11,7 @@
 
 mod helpers;
 
-use helpers::{AsyncTempFile, sha256_from_path};
+use helpers::sha256_from_path;
 
 use futures_util::{StreamExt, TryStreamExt};
 #[cfg(feature = "json")]
@@ -140,44 +140,23 @@ impl Downloader {
             return Ok(p);
         }
 
-        self.download_no_cache(url).await
-    }
-
-    /// Downloads the file without checking cache.
-    ///
-    /// [`download_with_sha`](Self::download_with_sha) should be prefered when the SHA256 of the
-    /// file is known in advance.
-    ///
-    /// # Differences from [Self::download]
-    ///
-    /// This function does not check if the file is present in cache, and will ovewrite the old
-    /// cached file. The file is still cached in the end.
-    async fn download_no_cache<U: reqwest::IntoUrl>(&self, url: U) -> io::Result<PathBuf> {
-        let url = url.into_url().map_err(io::Error::other)?;
-        tracing::debug!("Donwloading: {}", url);
-
         let file_path = self.path_from_url(&url);
 
-        let mut file = AsyncTempFile::new()?;
-        {
-            let mut file = tokio::io::BufWriter::new(&mut file);
+        let response = self
+            .client
+            .get(url)
+            .send()
+            .await
+            .map_err(io::Error::other)?
+            .bytes()
+            .await
+            .map_err(io::Error::other)?;
 
-            let response = self
-                .client
-                .get(url)
-                .send()
-                .await
-                .map_err(io::Error::other)?;
-            let mut response_stream = response.bytes_stream().map_err(io::Error::other);
+        let fp_clone = file_path.clone();
+        tokio::task::spawn_blocking(move || std::fs::write(fp_clone, response))
+            .await
+            .unwrap()?;
 
-            while let Some(x) = response_stream.next().await {
-                file.write_all_buf(&mut x?).await?;
-            }
-
-            file.flush().await?
-        }
-
-        file.persist(&file_path).await?;
         Ok(file_path)
     }
 


### PR DESCRIPTION
Since bb-downloader has been greatly simplified in recent times, some private functions have only 1 callsite. So cleanup one such function.