### PR TITLE
bb-iced-widgets: cached_icon: Fix spinner

### DIFF
--- a/bb-iced-widgets/src/cached_icon.rs
+++ b/bb-iced-widgets/src/cached_icon.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, hash::Hash, path::PathBuf};
 
-use iced::Length;
+use iced::{Length, widget};
 
 #[derive(Debug)]
 pub struct Cache<K: Eq + Hash>(HashMap<K, Option<crate::icon::Handle>>);
@@ -29,16 +29,16 @@ impl<K: Eq + Hash> Cache<K> {
     }
 }
 
-pub enum CachedIcon<'a> {
+pub enum CachedIcon<'a, M> {
     Icon(crate::icon::Icon<'a>),
-    Spinner(iced_aw::Spinner),
+    Spinner(widget::Container<'a, M>),
 }
 
-impl<'a> CachedIcon<'a> {
+impl<'a, M> CachedIcon<'a, M> {
     pub fn new<K: Eq + Hash>(cache: &Cache<K>, key: &K) -> Self {
         match cache.get(key) {
             Some(v) => Self::Icon(crate::icon(v.clone())),
-            None => Self::Spinner(iced_aw::Spinner::new()),
+            None => Self::Spinner(widget::center(iced_aw::Spinner::new())),
         }
     }
 
@@ -57,8 +57,8 @@ impl<'a> CachedIcon<'a> {
     }
 }
 
-impl<'a, M> From<CachedIcon<'a>> for iced::Element<'a, M> {
-    fn from(value: CachedIcon<'a>) -> Self {
+impl<'a, M: 'a> From<CachedIcon<'a, M>> for iced::Element<'a, M> {
+    fn from(value: CachedIcon<'a, M>) -> Self {
         match value {
             CachedIcon::Icon(icon) => icon.into(),
             CachedIcon::Spinner(spinner) => spinner.into(),

--- a/bb-iced-widgets/src/lib.rs
+++ b/bb-iced-widgets/src/lib.rs
@@ -25,9 +25,9 @@ pub fn icon<'a>(handle: impl Into<icon::Handle>) -> icon::Icon<'a> {
     icon::Icon::new(handle)
 }
 
-pub fn cached_icon<'a, K: Eq + std::hash::Hash>(
+pub fn cached_icon<'a, M, K: Eq + std::hash::Hash>(
     cache: &cached_icon::Cache<K>,
     key: &K,
-) -> cached_icon::CachedIcon<'a> {
+) -> cached_icon::CachedIcon<'a, M> {
     cached_icon::CachedIcon::new(cache, key)
 }


### PR DESCRIPTION
Seems setting Shrink as spinner height hit some sort of bug and cause the height to be infinite. Makes UI unusable.