### PR TITLE
Avoid allocating the keymap combo box options

### DIFF
--- a/bb-imager-gui/src/constants.rs
+++ b/bb-imager-gui/src/constants.rs
@@ -609,7 +609,7 @@ pub(crate) const TIMEZONES: &[&str] = &[
 
 #[cfg(test)]
 mod tests {
-    use super::TIMEZONES;
+    use super::{KEYMAP_LAYOUTS, TIMEZONES};
 
     /// The timezone combo box looks up its selection with `binary_search`, so new
     /// entries need to be inserted in byte order (note `_` sorts after uppercase
@@ -617,5 +617,12 @@ mod tests {
     #[test]
     fn timezones_sorted() {
         assert!(TIMEZONES.is_sorted());
+    }
+
+    /// The keymap combo box looks up its selection with `binary_search`, so new
+    /// entries need to be inserted in byte order.
+    #[test]
+    fn keymap_layouts_sorted() {
+        assert!(KEYMAP_LAYOUTS.is_sorted());
     }
 }

--- a/bb-imager-gui/src/helpers.rs
+++ b/bb-imager-gui/src/helpers.rs
@@ -220,8 +220,8 @@ pub(crate) fn system_timezone() -> Option<&'static str> {
     *SYSTEM_TIMEZONE
 }
 
-pub(crate) fn system_keymap() -> String {
-    static SYSTEM_KEYMAP: LazyLock<Option<String>> = LazyLock::new(|| {
+pub(crate) fn system_keymap() -> &'static str {
+    static SYSTEM_KEYMAP: LazyLock<Option<&'static str>> = LazyLock::new(|| {
         let lang = whoami::lang_prefs().ok()?.message_langs().next()?;
         let lang_str = lang.to_string();
 
@@ -236,16 +236,13 @@ pub(crate) fn system_keymap() -> String {
                     .iter()
                     .find(|k| k.eq_ignore_ascii_case(region))
             {
-                return Some(canon.to_string());
+                return Some(canon);
             }
         }
 
         None
     });
-    (*SYSTEM_KEYMAP)
-        .as_ref()
-        .cloned()
-        .unwrap_or_else(|| String::from("us"))
+    (*SYSTEM_KEYMAP).unwrap_or("us")
 }
 
 #[derive(Debug, Clone, serde::Serialize)]

--- a/bb-imager-gui/src/main.rs
+++ b/bb-imager-gui/src/main.rs
@@ -121,12 +121,7 @@ impl BBImager {
             app_config,
             downloader: downloader.clone(),
             timezones: widget::combo_box::State::new(constants::TIMEZONES.to_vec()),
-            keymaps: widget::combo_box::State::new(
-                constants::KEYMAP_LAYOUTS
-                    .iter()
-                    .map(|x| x.to_string())
-                    .collect(),
-            ),
+            keymaps: widget::combo_box::State::new(constants::KEYMAP_LAYOUTS.to_vec()),
 
             img_handle_cache: bb_iced_widgets::cached_icon::Cache::default(),
 

--- a/bb-imager-gui/src/state.rs
+++ b/bb-imager-gui/src/state.rs
@@ -16,7 +16,7 @@ pub(crate) struct BBImagerCommon {
     pub(crate) app_config: persistance::GuiConfiguration,
     pub(crate) downloader: bb_downloader::Downloader,
     pub(crate) timezones: widget::combo_box::State<&'static str>,
-    pub(crate) keymaps: widget::combo_box::State<String>,
+    pub(crate) keymaps: widget::combo_box::State<&'static str>,
 
     pub(crate) img_handle_cache: bb_iced_widgets::cached_icon::Cache<url::Url>,
 

--- a/bb-imager-gui/src/ui/configuration.rs
+++ b/bb-imager-gui/src/ui/configuration.rs
@@ -218,7 +218,7 @@ fn linux_sd_card_common<'a>(
         .label("Set Keymap")
         .on_toggle(move |t| {
             let keymap = if t {
-                Some(helpers::system_keymap())
+                Some(helpers::system_keymap().to_string())
             } else {
                 None
             };
@@ -227,17 +227,22 @@ fn linux_sd_card_common<'a>(
     col = match config.keymap.as_ref() {
         Some(keymap) => {
             let xc = config.clone();
+            // The current selection needs to be resolved back to one of the options,
+            // which are kept sorted (see `constants::KEYMAP_LAYOUTS`) to allow a binary
+            // search.
+            let options = state.common.keymaps.options();
+            let selection = options
+                .binary_search(&keymap.as_str())
+                .map(|x| &options[x])
+                .ok();
 
             col.push(element_with_element(
                 toggle.into(),
-                widget::combo_box(
-                    &state.common.keymaps,
-                    "Keymap",
-                    Some(&keymap.to_owned()),
-                    move |t| {
-                        BBImagerMessage::UpdateFlashConfig(wrap(xc.clone().update_keymap(Some(t))))
-                    },
-                )
+                widget::combo_box(&state.common.keymaps, "Keymap", selection, move |t| {
+                    BBImagerMessage::UpdateFlashConfig(wrap(
+                        xc.clone().update_keymap(Some(t.to_string())),
+                    ))
+                })
                 .width(INPUT_WIDTH)
                 .into(),
             ))


### PR DESCRIPTION
Apply the same treatment the timezone combo box just received: the keymap options are `&'static str`s from `constants::KEYMAP_LAYOUTS`, but were collected into `String`s to build a `combo_box::State<String>`, and the selection allocated once more per `view` call.

Type the state as `combo_box::State<&'static str>` and resolve the selection with a binary search over `State::options()`. `constants::KEYMAP_LAYOUTS` was already in byte order, so only the test guarding that is new. `system_keymap()` returns `&'static str` for the same reason, which it could already do since it canonicalises against the table and falls back to `us`.


Claude-Session: https://claude.ai/code/session_012tW6L2fxSsx3Bdp8nxitPg