### PR TITLE
bb-flasher: Switch qcow2-core to upstream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4851,8 +4851,9 @@ checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
 
 [[package]]
 name = "qcow2-core"
-version = "0.3.0"
-source = "git+https://github.com/Ayush1325/qcow2-forensic.git?branch=core-reader#0a95ca91cde8b5839582d1019a63e865a6f33cd9"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b074b1f76bdfe7f5ac0d52d91d666c4ddb17d7c35797594c2e388c2f673e3a9a"
 dependencies = [
  "flate2",
  "thiserror 2.0.18",

--- a/bb-flasher/Cargo.toml
+++ b/bb-flasher/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["beagle", "flasher"]
 categories = ["development-tools", "embedded", "hardware-support"]
 
 [dependencies]
-qcow2-core = { git = "https://github.com/Ayush1325/qcow2-forensic.git", branch = "core-reader" }
+qcow2-core = "0.3"
 liblzma = "0.4"
 serde = { version = "1.0", features = ["derive"], optional = true }
 yaml_serde = { version = "0.10", optional = true }

--- a/bb-flasher/src/img/mod.rs
+++ b/bb-flasher/src/img/mod.rs
@@ -184,11 +184,11 @@ impl Read for OsImage {
 enum OsImageCompression<I: Read + Seek> {
     Xz(liblzma::read::XzDecoder<I>),
     Zip(rc_zip_sync::StreamingEntryReader<I>),
-    QCow2(qcow2::Qcow2Reader<I>),
+    QCow2(qcow2::Qcow2Reader),
     Uncompressed(io::BufReader<I>),
 }
 
-impl<I: Read + Seek> OsImageCompression<I> {
+impl<I: Read + Seek + Sync + Send + 'static> OsImageCompression<I> {
     fn new(mut img: I) -> io::Result<Self> {
         let mut magic = [0u8; 6];
         img.read_exact(&mut magic)?;
@@ -198,7 +198,7 @@ impl<I: Read + Seek> OsImageCompression<I> {
             XZ_MAGIC => Ok(Self::Xz(liblzma_new(img))),
             [0x51, 0x46, 0x49, _, _, _] => {
                 tracing::info!("Detected qcow2 image");
-                qcow2::Qcow2Reader::from_reader(img)
+                qcow2::Qcow2Reader::open_reader(Box::new(img))
                     .map_err(io::Error::other)
                     .map(Self::QCow2)
             }


### PR DESCRIPTION
- The Box::dyn approach upstream has settled on works fine.
- Maybe will fork in the future if qcow2 support starts becoming important.