### PR TITLE
bb-imager-gui: Set window icon

### DIFF
--- a/bb-imager-gui/src/main.rs
+++ b/bb-imager-gui/src/main.rs
@@ -59,6 +59,7 @@ fn main() -> iced::Result {
     let settings = iced::window::Settings {
         min_size: Some(constants::WINDOW_SIZE),
         size: constants::WINDOW_SIZE,
+        icon,
         ..Default::default()
     };
 


### PR DESCRIPTION
Not sure when the regression happened, but the window icon was never used.