### PR TITLE
Makefile: Add GUI profiling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,10 @@ members = [
 lto = true
 codegen-units = 1
 
+[profile.profiling]
+inherits = "release"
+debug = 1
+
 [workspace.package]
 version = "1.0.14"
 edition = "2024"

--- a/Makefile
+++ b/Makefile
@@ -174,6 +174,7 @@ clean:
 	rm -rf cargo-vendor.tar.zst
 	rm -rf vendor .cargo
 	rm -f *.snap
+	rm -f *.zst
 
 ## housekeeping: packaging-checks: Some checks to ensure good packaging
 .PHONY: package-checks
@@ -522,3 +523,9 @@ package-gui-snap:
 .PHONY: debug-gui
 debug-gui:
 	$(_DIOXUS_CLI) serve -p bb-imager-gui ${_RUST_ARGS_GUI} --features debug
+
+## housekeeping: profile-gui: Use heaptrace to profile GUI.
+.PHONY: profile-gui
+profile-gui:
+	$(RUST_BUILD) --profile profiling -p bb-imager-gui --target $(TARGET) $(_RUST_ARGS_GUI)
+	heaptrack target/${TARGET}/profiling/bb-imager-gui


### PR DESCRIPTION
Profiling for memory use. Taken from new UI repo since it is helpful in general.
Only for linux since uses heaptrack.