### PR TITLE
bb-drivelist: device: Make enumerator Cow

### DIFF
--- a/bb-drivelist/src/device.rs
+++ b/bb-drivelist/src/device.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 #[derive(Debug, Default, Clone)]
 /// Mountpoints of a drive
 pub struct MountPoint {
@@ -21,7 +23,7 @@ impl MountPoint {
 #[derive(Debug, Clone)]
 /// Device Description
 pub struct DeviceDescriptor {
-    pub enumerator: String,
+    pub enumerator: Cow<'static, str>,
     pub bus_type: Option<String>,
     pub bus_version: Option<String>,
     pub device: String,

--- a/bb-drivelist/src/pal/linux.rs
+++ b/bb-drivelist/src/pal/linux.rs
@@ -1,4 +1,4 @@
-use std::process::Command;
+use std::{borrow::Cow, process::Command};
 
 use crate::device::{DeviceDescriptor, MountPoint};
 use serde::Deserialize;
@@ -86,7 +86,7 @@ impl From<Device> for DeviceDescriptor {
         let is_system = value.is_system();
 
         Self {
-            enumerator: "lsblk:json".to_string(),
+            enumerator: Cow::Borrowed("lsblk:json"),
             bus_type: Some(value.tran.as_deref().unwrap_or("UNKNOWN").to_uppercase()),
             device: value.name,
             raw: value.kname,

--- a/bb-drivelist/src/pal/macos.rs
+++ b/bb-drivelist/src/pal/macos.rs
@@ -1,7 +1,7 @@
-use core::ffi::c_void;
 use std::collections::HashMap;
-use std::ffi::{CStr, c_char};
+use std::ffi::{CStr, c_char, c_void};
 use std::ptr::NonNull;
+use std::borrow::Cow;
 
 use crate::MountPoint;
 use crate::device::DeviceDescriptor;
@@ -274,7 +274,7 @@ impl DeviceDescriptorFromDiskDescription for DeviceDescriptor {
             }
         }
 
-        device.enumerator = "DiskArbitration".to_string();
+        device.enumerator = Cow::Borrowed("DiskArbitration");
         device.bus_type = device_protocol.as_ref().map(|s| s.to_string());
         device.bus_version = None;
         device.device = format!("/dev/{}", disk_bsd_name);

--- a/bb-drivelist/src/pal/windows.rs
+++ b/bb-drivelist/src/pal/windows.rs
@@ -66,7 +66,7 @@ pub(crate) fn drive_list() -> crate::Result<Vec<DeviceDescriptor>> {
 
             let mut item = DeviceDescriptor {
                 description: friendly_name.clone(),
-                enumerator: enumerator_name.clone(),
+                enumerator: enumerator_name.clone().into(),
                 is_usb: is_usb_drive(&enumerator_name),
                 is_removable: is_removable(h_device_info, &mut device_info_data),
                 ..Default::default()


### PR DESCRIPTION
Removes 1 allocation from linux and macos paths.