### PR TITLE
Add bb-destination-watcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,6 +508,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "bb-destination-watcher"
+version = "1.0.14"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "objc2-core-foundation",
+ "objc2-disk-arbitration",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "udisks2",
+ "windows 0.62.2",
+ "zbus",
+]
+
+[[package]]
 name = "bb-downloader"
 version = "0.2.0"
 dependencies = [
@@ -676,6 +694,7 @@ dependencies = [
  "anyhow",
  "ashpd",
  "bb-config",
+ "bb-destination-watcher",
  "bb-downloader",
  "bb-flasher",
  "bb-helper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,8 @@ members = [
         "bb-drivelist", 
         "bb-flasher-mspm0",
         "bb-bmap-parser",
-        "bb-iced-widgets"
+        "bb-iced-widgets",
+        "bb-destination-watcher"
 ]
 
 [profile.release]

--- a/bb-destination-watcher/Cargo.toml
+++ b/bb-destination-watcher/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "bb-destination-watcher"
+description = "Notifies when the set of attached storage destinations may have changed."
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+futures-core = "0.3"
+thiserror = "2.0"
+tracing = "0.1"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+udisks2 = "0.3"
+zbus = "5"
+futures-util = "0.3"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2-disk-arbitration = "0.3.2"
+objc2-core-foundation = { version = "0.3.2", features = ["CFRunLoop"] }
+futures-channel = "0.3"
+
+[target.'cfg(windows)'.dependencies]
+windows = { version = "0.62", features = [
+	"Win32_Devices_DeviceAndDriverInstallation",
+	"Win32_System_Ioctl",
+	"Win32_Foundation",
+] }
+futures-channel = "0.3"
+
+[dev-dependencies]
+futures-util = "0.3"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tokio = { version = "1.52", features = ["macros", "rt", "rt-multi-thread", "time"] }

--- a/bb-destination-watcher/examples/watch.rs
+++ b/bb-destination-watcher/examples/watch.rs
@@ -1,0 +1,45 @@
+//! Prints a line every time the platform reports a storage change.
+//!
+//! Useful for checking a backend by hand:
+//!
+//! ```text
+//! cargo run -p bb-destination-watcher --example watch
+//! ```
+//!
+//! then plug in a USB stick or an SD card. On Linux a loop device works too:
+//! `udisksctl loop-setup -f some.img`.
+
+use std::time::Instant;
+
+use futures_util::StreamExt;
+
+#[tokio::main]
+async fn main() {
+    // `RUST_LOG=debug` prints every signal the backend saw, including the ones
+    // filtered out.
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info".into()),
+        )
+        .with_writer(std::io::stderr)
+        .init();
+
+    let mut watcher = match bb_destination_watcher::Watcher::new().await {
+        Ok(w) => w,
+        Err(e) => {
+            eprintln!("no watcher available: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    // stderr: unbuffered, so output survives redirection and Ctrl-C.
+    eprintln!("watching for storage changes; Ctrl-C to stop");
+
+    let start = Instant::now();
+    while watcher.next().await.is_some() {
+        eprintln!("[{:>8.3}s] storage changed", start.elapsed().as_secs_f64());
+    }
+
+    eprintln!("watcher ended");
+}

--- a/bb-destination-watcher/src/lib.rs
+++ b/bb-destination-watcher/src/lib.rs
@@ -1,0 +1,91 @@
+//! Notifies when the set of attached storage destinations may have changed.
+//!
+//! Enumerating destinations is expensive on some platforms — on Linux it forks
+//! `lsblk`, which costs milliseconds and thousands of syscalls. Polling it on a
+//! timer means paying that continuously for as long as a destination list is on
+//! screen. This crate lets a caller wait for the OS to say something changed and
+//! re-enumerate only then.
+//!
+//! # What this is not
+//!
+//! [`Watcher`] reports *that* something changed, never *what*. Hotplug
+//! notifications differ enough between Linux, macOS and Windows that a shared
+//! delta type would be mostly lies, and consumers need a full list to render
+//! anyway. So the contract is deliberately minimal: on each item, re-enumerate.
+//!
+//! # Usage
+//!
+//! [`Watcher`] emits nothing on a schedule of its own, and events can be missed
+//! across suspend/resume or a dropped connection. Pair it with a slow fallback
+//! timer, and fall back to polling if construction fails:
+//!
+//! ```no_run
+//! # async fn example() {
+//! use futures_util::StreamExt;
+//!
+//! match bb_destination_watcher::Watcher::new().await {
+//!     Ok(mut watcher) => {
+//!         while watcher.next().await.is_some() {
+//!             // re-enumerate destinations
+//!         }
+//!     }
+//!     Err(e) => {
+//!         tracing::info!("no destination watcher ({e}), falling back to polling");
+//!     }
+//! }
+//! # }
+//! ```
+
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+mod pal;
+
+/// Reasons a [`Watcher`] could not be started.
+///
+/// Callers are not expected to distinguish these beyond logging: every variant
+/// means the same thing operationally, which is to fall back to polling.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum Error {
+    /// This platform has no watcher implementation.
+    #[error("destination watching is unsupported on this platform")]
+    Unsupported,
+    /// The platform API exists but could not be started.
+    #[error("failed to start destination watcher: {0}")]
+    Backend(String),
+}
+
+/// A stream of hints that the set of attached storage destinations may have
+/// changed.
+///
+/// Each item means "re-enumerate"; there is no payload. See the [crate docs](crate)
+/// for why, and for the fallback timer this should be paired with.
+///
+/// Stops watching when dropped.
+pub struct Watcher(pal::Watcher);
+
+impl Watcher {
+    /// Start watching for storage device changes.
+    ///
+    /// Any error means the caller should poll instead.
+    pub async fn new() -> Result<Self, Error> {
+        pal::Watcher::start().await.map(Self)
+    }
+}
+
+impl futures_core::Stream for Watcher {
+    type Item = ();
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        // Every platform backend is `Unpin`: they hold either a boxed stream or
+        // an mpsc receiver.
+        Pin::new(&mut self.get_mut().0).poll_next(cx)
+    }
+}
+
+impl std::fmt::Debug for Watcher {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Watcher").finish_non_exhaustive()
+    }
+}

--- a/bb-destination-watcher/src/pal/linux.rs
+++ b/bb-destination-watcher/src/pal/linux.rs
@@ -1,0 +1,153 @@
+//! Linux backend, built on udisks2's D-Bus signals.
+//!
+//! udisks2 is used rather than libudev or raw netlink because the GUI already
+//! depends on it — `bb-flasher-sd` needs it to open and eject a card — so this
+//! introduces no new runtime requirement. zbus exposes the signals as native
+//! async streams, so no thread or channel is needed here.
+
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures_util::{StreamExt, stream::BoxStream};
+use zbus::{MatchRule, MessageStream, message};
+
+use crate::Error;
+
+/// Interfaces whose arrival or departure means the destination list changed.
+///
+/// udisks2 also emits `InterfacesAdded`/`InterfacesRemoved` for jobs and other
+/// bookkeeping objects — every `udisksctl` invocation produces a pair. Without
+/// this filter, routine disk activity would trigger a re-enumeration.
+const WATCHED: [&str; 2] = [
+    "org.freedesktop.UDisks2.Block",
+    "org.freedesktop.UDisks2.Drive",
+];
+
+/// Restricts the property-change subscription to block objects.
+const BLOCK_PATHS: &str = "/org/freedesktop/UDisks2/block_devices";
+const BLOCK_INTERFACE: &str = "org.freedesktop.UDisks2.Block";
+
+pub(crate) struct Watcher {
+    /// Held for its lifetime: dropping the client would tear down the D-Bus
+    /// connection the signal streams are reading from.
+    _client: udisks2::Client,
+    events: BoxStream<'static, ()>,
+}
+
+impl Watcher {
+    pub(crate) async fn start() -> Result<Self, Error> {
+        let client = udisks2::Client::new().await.map_err(backend)?;
+        let object_manager = client.object_manager();
+
+        // Devices appearing and disappearing outright.
+        let added = object_manager
+            .receive_interfaces_added()
+            .await
+            .map_err(backend)?
+            .filter_map(|signal| async move {
+                let args = signal.args().inspect_err(parse_failed).ok()?;
+                let interfaces = args.interfaces_and_properties.keys().map(|i| i.as_str());
+                log_signal(
+                    "InterfacesAdded",
+                    args.object_path.as_str(),
+                    interfaces.clone(),
+                );
+                is_watched(interfaces).then_some(())
+            });
+
+        let removed = object_manager
+            .receive_interfaces_removed()
+            .await
+            .map_err(backend)?
+            .filter_map(|signal| async move {
+                let args = signal.args().inspect_err(parse_failed).ok()?;
+                let interfaces = args.interfaces.iter().map(|i| i.as_str());
+                log_signal(
+                    "InterfacesRemoved",
+                    args.object_path.as_str(),
+                    interfaces.clone(),
+                );
+                is_watched(interfaces).then_some(())
+            });
+
+        // Inserting a card into a reader that is already attached does not
+        // create an object: the block device persists and only its properties
+        // change (notably `Size`, 0 -> the card's size). `InterfacesAdded`
+        // alone would therefore miss this application's most common action, so
+        // property changes on block objects also count as a reason to
+        // re-enumerate.
+        //
+        // The match rule filters server-side on the object path namespace and
+        // on the interface, so unrelated udisks2 chatter is never delivered.
+        let rule = MatchRule::builder()
+            .msg_type(message::Type::Signal)
+            .interface("org.freedesktop.DBus.Properties")
+            .map_err(backend)?
+            .member("PropertiesChanged")
+            .map_err(backend)?
+            .path_namespace(BLOCK_PATHS)
+            .map_err(backend)?
+            .arg(0, BLOCK_INTERFACE)
+            .map_err(backend)?
+            .build();
+
+        let properties =
+            MessageStream::for_match_rule(rule, object_manager.inner().connection(), None)
+                .await
+                .map_err(backend)?
+                .filter_map(|msg| async move {
+                    let msg = msg.ok()?;
+                    log_signal(
+                        "PropertiesChanged",
+                        msg.header().path()?.as_str(),
+                        std::iter::once(BLOCK_INTERFACE),
+                    );
+                    Some(())
+                });
+
+        let events =
+            futures_util::stream::select(futures_util::stream::select(added, removed), properties)
+                .boxed();
+
+        Ok(Self {
+            _client: client,
+            events,
+        })
+    }
+}
+
+fn backend(e: impl std::fmt::Display) -> Error {
+    Error::Backend(e.to_string())
+}
+
+/// A signal we subscribed to but could not decode is a hole in the watcher, so
+/// it is worth surfacing rather than dropping silently.
+fn parse_failed(e: &zbus::Error) {
+    tracing::warn!("Ignoring undecodable udisks2 signal: {e}");
+}
+
+/// Every signal seen, before filtering.
+///
+/// udisks2 is chatty and the interface names are the whole basis of the filter,
+/// so seeing what actually arrived is the fastest way to diagnose either missed
+/// changes or needless re-enumeration.
+fn log_signal<'a>(signal: &str, path: &str, interfaces: impl Iterator<Item = &'a str>) {
+    if tracing::enabled!(tracing::Level::DEBUG) {
+        tracing::debug!(
+            "{signal} {path} [{}]",
+            interfaces.collect::<Vec<_>>().join(", ")
+        );
+    }
+}
+
+fn is_watched<'a>(mut interfaces: impl Iterator<Item = &'a str>) -> bool {
+    interfaces.any(|i| WATCHED.contains(&i))
+}
+
+impl futures_core::Stream for Watcher {
+    type Item = ();
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.events.as_mut().poll_next(cx)
+    }
+}

--- a/bb-destination-watcher/src/pal/macos.rs
+++ b/bb-destination-watcher/src/pal/macos.rs
@@ -1,0 +1,158 @@
+//! macOS backend, built on DiskArbitration.
+//!
+//! # Why a dedicated thread
+//!
+//! `CFRetained<T>` is only `Send` when `T: Send + Sync`, which `DASession` is
+//! not. Holding the session inside [`Watcher`] would therefore make the whole
+//! watcher `!Send`, and it has to cross threads to be driven by an async
+//! executor. So the session, its callbacks and its run loop all stay on one
+//! owned thread, and the only thing shared with the outside world is an mpsc
+//! receiver.
+//!
+//! This also keeps to the run-loop API that `bb-drivelist`'s macOS enumerator
+//! already uses successfully, rather than `DASessionSetDispatchQueue`, which
+//! would drag in `dispatch2` and re-introduce the `Send` question.
+
+use std::ffi::c_void;
+use std::pin::Pin;
+use std::ptr::NonNull;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use futures_channel::mpsc;
+use objc2_core_foundation::{CFRunLoop, kCFRunLoopDefaultMode};
+use objc2_disk_arbitration::{
+    DADisk, DARegisterDiskAppearedCallback, DARegisterDiskDisappearedCallback, DASession,
+    DAUnregisterCallback,
+};
+
+use crate::Error;
+
+/// How long each run-loop turn blocks before the stop flag is re-checked. Also
+/// the worst-case delay between dropping the watcher and the thread exiting.
+const RUN_LOOP_TURN_SECS: f64 = 0.25;
+
+/// How long `start` waits for the thread to report that registration succeeded.
+const STARTUP_TIMEOUT: Duration = Duration::from_secs(2);
+
+pub(crate) struct Watcher {
+    rx: mpsc::UnboundedReceiver<()>,
+    stop: Arc<AtomicBool>,
+}
+
+impl Watcher {
+    pub(crate) async fn start() -> Result<Self, Error> {
+        let (tx, rx) = mpsc::unbounded();
+        let stop = Arc::new(AtomicBool::new(false));
+        let (ready_tx, ready_rx) = std::sync::mpsc::sync_channel(1);
+
+        let stop_thread = Arc::clone(&stop);
+        std::thread::Builder::new()
+            .name("bb-destination-watcher".to_owned())
+            .spawn(move || run(&tx, &stop_thread, &ready_tx))
+            .map_err(|e| Error::Backend(format!("could not spawn watcher thread: {e}")))?;
+
+        // Brief and bounded: the thread only has to create a session and
+        // register two callbacks before reporting back.
+        match ready_rx.recv_timeout(STARTUP_TIMEOUT) {
+            Ok(Ok(())) => Ok(Self { rx, stop }),
+            Ok(Err(e)) => Err(e),
+            Err(e) => Err(Error::Backend(format!("watcher thread did not start: {e}"))),
+        }
+    }
+}
+
+/// Owns every DiskArbitration object; never leaves this thread.
+fn run(
+    tx: &mpsc::UnboundedSender<()>,
+    stop: &AtomicBool,
+    ready: &std::sync::mpsc::SyncSender<Result<(), Error>>,
+) {
+    let fail = |ready: &std::sync::mpsc::SyncSender<_>, msg: &str| {
+        let _ = ready.send(Err(Error::Backend(msg.to_owned())));
+    };
+
+    // `None` selects the default allocator.
+    let Some(session) = (unsafe { DASession::new(None) }) else {
+        fail(ready, "DASessionCreate returned null");
+        return;
+    };
+    let Some(run_loop) = CFRunLoop::current() else {
+        fail(ready, "no current run loop on watcher thread");
+        return;
+    };
+    let Some(mode) = (unsafe { kCFRunLoopDefaultMode }) else {
+        fail(ready, "kCFRunLoopDefaultMode unavailable");
+        return;
+    };
+
+    // Safety: `tx` outlives the scheduled session — it is dropped at the end of
+    // this function, after the callbacks have been unregistered below.
+    let context = std::ptr::from_ref(tx).cast::<c_void>().cast_mut();
+
+    unsafe {
+        // Registered separately rather than sharing one function, so each
+        // (callback, context) pair is distinct and can be unregistered on its own.
+        DARegisterDiskAppearedCallback(&session, None, Some(disk_appeared), context);
+        DARegisterDiskDisappearedCallback(&session, None, Some(disk_disappeared), context);
+        session.schedule_with_run_loop(&run_loop, mode);
+    }
+
+    let _ = ready.send(Ok(()));
+
+    while !stop.load(Ordering::Relaxed) {
+        CFRunLoop::run_in_mode(unsafe { kCFRunLoopDefaultMode }, RUN_LOOP_TURN_SECS, false);
+    }
+
+    unsafe {
+        session.unschedule_from_run_loop(&run_loop, mode);
+        DAUnregisterCallback(&session, fn_ptr(disk_appeared), context);
+        DAUnregisterCallback(&session, fn_ptr(disk_disappeared), context);
+    }
+}
+
+type DiskCallback = unsafe extern "C-unwind" fn(NonNull<DADisk>, *mut c_void);
+
+fn fn_ptr(f: DiskCallback) -> NonNull<c_void> {
+    NonNull::new((f as *const ()).cast_mut().cast::<c_void>())
+        .expect("function pointers are never null")
+}
+
+unsafe extern "C-unwind" fn disk_appeared(_disk: NonNull<DADisk>, context: *mut c_void) {
+    notify(context);
+}
+
+unsafe extern "C-unwind" fn disk_disappeared(_disk: NonNull<DADisk>, context: *mut c_void) {
+    notify(context);
+}
+
+/// Appearance and disappearance mean the same thing to a consumer: re-enumerate.
+fn notify(context: *mut c_void) {
+    if context.is_null() {
+        return;
+    }
+
+    // Safety: `context` is the address of the `UnboundedSender` owned by `run`,
+    // which unregisters these callbacks before returning.
+    let tx = unsafe { &*context.cast::<mpsc::UnboundedSender<()>>() };
+    // A closed receiver just means the watcher was dropped.
+    let _ = tx.unbounded_send(());
+}
+
+impl Drop for Watcher {
+    fn drop(&mut self) {
+        // Deliberately does not join: the thread notices within one run-loop
+        // turn and tears itself down, and `Drop` may run on the UI thread.
+        self.stop.store(true, Ordering::Relaxed);
+    }
+}
+
+impl futures_core::Stream for Watcher {
+    type Item = ();
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.rx).poll_next(cx)
+    }
+}

--- a/bb-destination-watcher/src/pal/mod.rs
+++ b/bb-destination-watcher/src/pal/mod.rs
@@ -1,0 +1,32 @@
+//! Platform backends.
+//!
+//! Each provides the same private contract, which is the entire per-OS surface:
+//!
+//! ```ignore
+//! pub(crate) struct Watcher { /* .. */ }
+//! impl Watcher { pub(crate) async fn start() -> Result<Self, crate::Error>; }
+//! impl futures_core::Stream for Watcher { type Item = (); }
+//! impl Drop for Watcher { /* unregister */ }
+//! ```
+//!
+//! `Watcher` must be `Unpin`.
+
+#[cfg(target_os = "linux")]
+mod linux;
+#[cfg(target_os = "linux")]
+pub(crate) use linux::Watcher;
+
+#[cfg(target_os = "macos")]
+mod macos;
+#[cfg(target_os = "macos")]
+pub(crate) use macos::Watcher;
+
+#[cfg(windows)]
+mod windows;
+#[cfg(windows)]
+pub(crate) use windows::Watcher;
+
+#[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
+mod unsupported;
+#[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
+pub(crate) use unsupported::Watcher;

--- a/bb-destination-watcher/src/pal/unsupported.rs
+++ b/bb-destination-watcher/src/pal/unsupported.rs
@@ -1,0 +1,27 @@
+//! Fallback for platforms with no backend.
+//!
+//! This exists so "no watcher available" is an ordinary runtime outcome the
+//! caller already handles rather than a build failure, and so `pal/mod.rs`
+//! needs a single `cfg` block instead of one per item.
+
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use crate::Error;
+
+pub(crate) struct Watcher(std::convert::Infallible);
+
+impl Watcher {
+    pub(crate) async fn start() -> Result<Self, Error> {
+        Err(Error::Unsupported)
+    }
+}
+
+impl futures_core::Stream for Watcher {
+    type Item = ();
+
+    fn poll_next(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        // Unconstructible, so this is unreachable.
+        match self.0 {}
+    }
+}

--- a/bb-destination-watcher/src/pal/windows.rs
+++ b/bb-destination-watcher/src/pal/windows.rs
@@ -1,0 +1,106 @@
+//! Windows backend, built on `CM_Register_Notification` (cfgmgr32).
+//!
+//! The textbook mechanism is `WM_DEVICECHANGE` with `DBT_DEVICEARRIVAL`, but
+//! that needs a window procedure, and in a winit-based application the window
+//! proc belongs to winit and raw messages are not exposed. `CM_Register_Notification`
+//! (Windows 10 1709+) is callback-based, needs no `HWND`, and can be registered
+//! from any thread.
+
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures_channel::mpsc;
+use windows::Win32::Devices::DeviceAndDriverInstallation::{
+    CM_NOTIFY_ACTION, CM_NOTIFY_EVENT_DATA, CM_NOTIFY_FILTER, CM_NOTIFY_FILTER_TYPE_DEVICEINTERFACE,
+    CM_Register_Notification, CM_Unregister_Notification, CR_SUCCESS, HCMNOTIFICATION,
+};
+use windows::Win32::Foundation::ERROR_SUCCESS;
+use windows::Win32::System::Ioctl::GUID_DEVINTERFACE_DISK;
+
+use crate::Error;
+
+pub(crate) struct Watcher {
+    rx: mpsc::UnboundedReceiver<()>,
+    notification: HCMNOTIFICATION,
+    /// Owns the sender the callback borrows. Declared after `notification` only
+    /// for clarity; the explicit `Drop` below controls the actual ordering.
+    _sender: Box<mpsc::UnboundedSender<()>>,
+}
+
+impl Watcher {
+    pub(crate) async fn start() -> Result<Self, Error> {
+        let (tx, rx) = mpsc::unbounded();
+
+        // Boxed so the address handed to the callback stays valid while this
+        // `Watcher` lives, and is freed only after the notification is
+        // unregistered in `Drop`.
+        let sender = Box::new(tx);
+        let context = (&raw const *sender).cast::<std::ffi::c_void>();
+
+        let mut filter = CM_NOTIFY_FILTER {
+            cbSize: std::mem::size_of::<CM_NOTIFY_FILTER>() as u32,
+            FilterType: CM_NOTIFY_FILTER_TYPE_DEVICEINTERFACE,
+            ..Default::default()
+        };
+        filter.u.DeviceInterface.ClassGuid = GUID_DEVINTERFACE_DISK;
+
+        let mut notification = HCMNOTIFICATION::default();
+        let ret = unsafe {
+            CM_Register_Notification(&filter, Some(context), Some(callback), &mut notification)
+        };
+
+        if ret != CR_SUCCESS {
+            return Err(Error::Backend(format!(
+                "CM_Register_Notification failed: CONFIGRET {}",
+                ret.0
+            )));
+        }
+
+        Ok(Self {
+            rx,
+            notification,
+            _sender: sender,
+        })
+    }
+}
+
+/// Invoked by the configuration manager on one of its own threads.
+///
+/// Must return promptly, and must never call `CM_Unregister_Notification` on
+/// its own registration — that deadlocks. So this only sends and returns.
+unsafe extern "system" fn callback(
+    _notify: HCMNOTIFICATION,
+    context: *const std::ffi::c_void,
+    _action: CM_NOTIFY_ACTION,
+    _event_data: *const CM_NOTIFY_EVENT_DATA,
+    _event_data_size: u32,
+) -> u32 {
+    if !context.is_null() {
+        // Safety: `context` is the address of the `Box<UnboundedSender>` owned by
+        // the live `Watcher`; `Drop` unregisters before the box is freed.
+        let tx = unsafe { &*context.cast::<mpsc::UnboundedSender<()>>() };
+        // Both arrival and removal mean the same thing: re-enumerate. A closed
+        // receiver just means nobody is listening any more.
+        let _ = tx.unbounded_send(());
+    }
+
+    ERROR_SUCCESS.0
+}
+
+impl Drop for Watcher {
+    fn drop(&mut self) {
+        if !self.notification.is_invalid() {
+            // Blocks until in-flight callbacks return, after which the boxed
+            // sender is safe to free.
+            let _ = unsafe { CM_Unregister_Notification(self.notification) };
+        }
+    }
+}
+
+impl futures_core::Stream for Watcher {
+    type Item = ();
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.rx).poll_next(cx)
+    }
+}

--- a/bb-destination-watcher/tests/watch.rs
+++ b/bb-destination-watcher/tests/watch.rs
@@ -1,0 +1,29 @@
+//! Exercises the real platform backend.
+//!
+//! Skips rather than fails where the platform service is unavailable — CI
+//! containers frequently have no udisks2, and a headless macOS runner may have
+//! no DiskArbitration session. The point is to catch a backend that is wired up
+//! wrongly, not to assert what the environment provides.
+
+use std::time::Duration;
+
+use futures_util::StreamExt;
+
+/// Nothing is being plugged in while this runs, so an event here means the
+/// backend is reporting unrelated churn. On Linux that is usually a missing
+/// interface filter letting mount/unmount or job objects through, which would
+/// put the GUI back to re-enumerating constantly.
+#[tokio::test]
+async fn stays_quiet_when_no_devices_change() {
+    let Ok(mut watcher) = bb_destination_watcher::Watcher::new().await else {
+        eprintln!("skipping: no destination watcher available in this environment");
+        return;
+    };
+
+    let event = tokio::time::timeout(Duration::from_millis(750), watcher.next()).await;
+
+    assert!(
+        event.is_err(),
+        "watcher produced {event:?} without any device change"
+    );
+}

--- a/bb-imager-gui/Cargo.toml
+++ b/bb-imager-gui/Cargo.toml
@@ -36,6 +36,10 @@ rusqlite = { version = "0.40", features = ["url", "chrono"] }
 chrono = "0.4"
 chrono-tz = { version = "0.10", features = ["serde"] }
 bb-iced-widgets = { path = "../bb-iced-widgets" }
+bb-destination-watcher = { path = "../bb-destination-watcher" }
+
+[dev-dependencies]
+tokio = { version = "1.52", features = ["macros", "rt", "time", "test-util"] }
 
 [build-dependencies]
 embed-resource = "3.0"

--- a/bb-imager-gui/src/helpers.rs
+++ b/bb-imager-gui/src/helpers.rs
@@ -638,6 +638,20 @@ pub(crate) fn destinations(
     }
 }
 
+/// Whether changes to this flasher's destinations arrive as OS notifications.
+///
+/// Only storage devices are watched. The other backends enumerate in-process
+/// (`serialport` walks `/sys/class/tty`, `hidapi` walks `hidraw`, mspm0-i2c
+/// reads `/dev`) at a fraction of the cost of forking `lsblk`, so polling them
+/// is not worth a watcher.
+pub(crate) const fn is_watchable(flasher: config::Flasher) -> bool {
+    match flasher {
+        #[cfg(feature = "sd")]
+        config::Flasher::SdCard | config::Flasher::SdCardBootfs => true,
+        _ => false,
+    }
+}
+
 pub(crate) fn file_filter(flasher: config::Flasher) -> &'static [&'static str] {
     match flasher {
         #[cfg(feature = "sd")]

--- a/bb-imager-gui/src/main.rs
+++ b/bb-imager-gui/src/main.rs
@@ -1,9 +1,12 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+use std::time::Duration;
+
+use bb_config::config;
 use constants::PACKAGE_QUALIFIER;
+use iced::futures::{FutureExt, StreamExt};
 use iced::{Subscription, Task, futures::SinkExt, widget};
 use message::BBImagerMessage;
-use tokio::time::interval;
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
@@ -215,8 +218,6 @@ impl BBImager {
     }
 
     fn subscription(&self) -> Subscription<BBImagerMessage> {
-        const INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
-
         match self {
             Self::ChooseDest(x) => Subscription::run_with(
                 (
@@ -225,23 +226,7 @@ impl BBImager {
                     x.search_text.to_lowercase(),
                 ),
                 |(flasher, filter, search_text)| {
-                    let mut interval = interval(INTERVAL);
-                    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-
-                    iced::futures::stream::unfold(
-                        (*flasher, *filter, search_text.clone(), interval),
-                        async move |(flasher, filter, search_text, mut interval)| {
-                            interval.tick().await;
-                            let search = search_text.clone();
-                            let dest = blocking_future(move || {
-                                helpers::destinations(flasher, filter, search)
-                            })
-                            .await;
-
-                            let msg = BBImagerMessage::Destinations(dest);
-                            Some((msg, (flasher, filter, search_text, interval)))
-                        },
-                    )
+                    destination_stream(*flasher, *filter, search_text.clone())
                 },
             ),
             _ => Subscription::none(),
@@ -489,5 +474,173 @@ impl BBImager {
             },
             _ => self.scroll_reset(),
         }
+    }
+}
+
+/// Settle time after a device change before re-enumerating. A card reader emits
+/// several events while it comes up; this collapses them into one refresh.
+const DEBOUNCE: Duration = Duration::from_millis(250);
+
+/// Safety net for changes the OS never reported — a missed event, resume from
+/// suspend, a dropped D-Bus connection. Only used while a watcher is active.
+const FALLBACK_INTERVAL: Duration = Duration::from_secs(10);
+
+/// Refresh rate when no watcher is available. Matches the old behaviour.
+const POLL_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Destination list for the currently selected flasher.
+///
+/// Enumeration is driven by OS hotplug notifications where they are available,
+/// because on Linux each pass forks `lsblk` — milliseconds and thousands of
+/// syscalls that used to be paid every second for as long as this page was open.
+/// Anything that prevents watching (unsupported platform, a flasher whose
+/// devices are not watched, a backend that failed to start) falls back to the
+/// original poll, so this is never worse than before.
+fn destination_stream(
+    flasher: config::Flasher,
+    filter: bool,
+    search: String,
+) -> impl iced::futures::Stream<Item = BBImagerMessage> {
+    iced::stream::channel(1, async move |mut out| {
+        // The page should not sit empty while the watcher starts up.
+        emit_destinations(&mut out, flasher, filter, &search).await;
+
+        let mut watcher = if helpers::is_watchable(flasher) {
+            match bb_destination_watcher::Watcher::new().await {
+                Ok(w) => Some(w),
+                Err(e) => {
+                    tracing::info!("No destination watcher ({e}); polling instead");
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+        loop {
+            wait_for_refresh(&mut watcher).await;
+            emit_destinations(&mut out, flasher, filter, &search).await;
+        }
+    })
+}
+
+/// Blocks until the destination list should be re-enumerated.
+///
+/// Takes `watcher` by `&mut Option<_>` so that a backend which stops producing
+/// can be dropped here, degrading this and every later call to a plain poll
+/// rather than going silent for the rest of the session.
+async fn wait_for_refresh<S>(watcher: &mut Option<S>)
+where
+    S: iced::futures::Stream<Item = ()> + Unpin,
+{
+    let Some(w) = watcher.as_mut() else {
+        tokio::time::sleep(POLL_INTERVAL).await;
+        return;
+    };
+
+    match tokio::time::timeout(FALLBACK_INTERVAL, w.next()).await {
+        // A change: let the burst settle, then drop whatever queued up behind
+        // it so the whole burst costs one enumeration.
+        Ok(Some(())) => {
+            tokio::time::sleep(DEBOUNCE).await;
+            while w.next().now_or_never().flatten().is_some() {}
+        }
+        Ok(None) => {
+            tracing::warn!("Destination watcher ended; falling back to polling");
+            *watcher = None;
+        }
+        // Fallback deadline with no events; re-enumerate anyway in case one was
+        // missed.
+        Err(_) => {}
+    }
+}
+
+async fn emit_destinations(
+    out: &mut iced::futures::channel::mpsc::Sender<BBImagerMessage>,
+    flasher: config::Flasher,
+    filter: bool,
+    search: &str,
+) {
+    let search = search.to_owned();
+    let dest = blocking_future(move || helpers::destinations(flasher, filter, search)).await;
+    let _ = out.send(BBImagerMessage::Destinations(dest)).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use iced::futures::channel::mpsc;
+
+    /// Number of refreshes `wait_for_refresh` completes within `budget`.
+    ///
+    /// Time is paused, so this measures logical scheduling rather than
+    /// wall-clock and runs instantly.
+    async fn refreshes_within<S>(watcher: &mut Option<S>, budget: Duration) -> usize
+    where
+        S: iced::futures::Stream<Item = ()> + Unpin,
+    {
+        let deadline = tokio::time::Instant::now() + budget;
+        let mut count = 0;
+        while tokio::time::timeout_at(deadline, wait_for_refresh(watcher))
+            .await
+            .is_ok()
+        {
+            count += 1;
+        }
+        count
+    }
+
+    /// A burst while a reader settles must cost one enumeration, not one each.
+    #[tokio::test(start_paused = true)]
+    async fn burst_of_hints_debounces_to_one_refresh() {
+        let (tx, rx) = mpsc::unbounded::<()>();
+        for _ in 0..5 {
+            tx.unbounded_send(()).unwrap();
+        }
+        let mut watcher = Some(rx);
+
+        // Long enough to debounce, far short of the fallback deadline.
+        let count = refreshes_within(&mut watcher, DEBOUNCE * 3).await;
+
+        assert_eq!(count, 1, "a burst should collapse into a single refresh");
+        assert!(watcher.is_some(), "watcher should still be live");
+    }
+
+    /// With a live but silent watcher, the fallback still forces a refresh so a
+    /// missed event cannot leave the list stale forever.
+    #[tokio::test(start_paused = true)]
+    async fn silent_watcher_still_refreshes_on_fallback() {
+        let (_tx, rx) = mpsc::unbounded::<()>();
+        let mut watcher = Some(rx);
+
+        let count = refreshes_within(&mut watcher, FALLBACK_INTERVAL * 2 + DEBOUNCE).await;
+
+        assert_eq!(count, 2, "fallback should fire once per interval");
+    }
+
+    /// A backend that ends must degrade to polling, not go silent.
+    #[tokio::test(start_paused = true)]
+    async fn ended_watcher_degrades_to_polling() {
+        let (tx, rx) = mpsc::unbounded::<()>();
+        drop(tx);
+        let mut watcher = Some(rx);
+
+        wait_for_refresh(&mut watcher).await;
+        assert!(watcher.is_none(), "a dead watcher should be dropped");
+
+        // And the poll cadence takes over.
+        let count = refreshes_within(&mut watcher, POLL_INTERVAL * 3 + POLL_INTERVAL / 2).await;
+        assert_eq!(count, 3);
+    }
+
+    /// No watcher at all (unsupported platform, or a flasher we do not watch)
+    /// keeps the original poll behaviour.
+    #[tokio::test(start_paused = true)]
+    async fn no_watcher_polls_at_the_old_interval() {
+        let mut watcher: Option<mpsc::UnboundedReceiver<()>> = None;
+
+        let count = refreshes_within(&mut watcher, POLL_INTERVAL * 3 + POLL_INTERVAL / 2).await;
+
+        assert_eq!(count, 3);
     }
 }


### PR DESCRIPTION
Instead of polling every 1s, watch for insertion/removal of block devices to update destination list.