### PR TITLE
Cargo.toml: Strip release build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
 [profile.release]
 lto = true
 codegen-units = 1
+strip = true
 
 [profile.profiling]
 inherits = "release"


### PR DESCRIPTION
- cargo-packager does this automatically, but required for appimage, flatpak, etc.