### PR TITLE
bb-imager-gui: Drop the Skip Verification toggle

### DIFF
--- a/bb-imager-gui/src/helpers.rs
+++ b/bb-imager-gui/src/helpers.rs
@@ -498,16 +498,11 @@ pub(crate) async fn flash(
         #[cfg(feature = "bcf_cc1352p7")]
         (
             BoardImage::Image { img, .. },
-            FlashingCustomization::Bcf(customization),
+            FlashingCustomization::Bcf,
             Destination::BeagleConnectFreedom(t),
         ) => tokio::task::spawn_blocking(move || {
-            bb_flasher::bcf::cc1352p7::Flasher::new(
-                img.into_image_fn(),
-                t,
-                customization.verify,
-                Some(cancel_sync),
-            )
-            .flash(Some(chan))
+            bb_flasher::bcf::cc1352p7::Flasher::new(img.into_image_fn(), t, true, Some(cancel_sync))
+                .flash(Some(chan))
         })
         .await
         .unwrap(),
@@ -520,21 +515,14 @@ pub(crate) async fn flash(
             .unwrap()
         }
         #[cfg(any(feature = "zepto_uart", feature = "zepto_i2c"))]
-        (
-            BoardImage::Image { img, .. },
-            FlashingCustomization::Zepto(customization),
-            Destination::Mspm0(t),
-        ) => tokio::task::spawn_blocking(move || {
-            bb_flasher::mspm0::Flasher::no_prep(
-                img.into_image_fn(),
-                t,
-                customization.verify,
-                Some(cancel_sync),
-            )
-            .flash(Some(chan))
-        })
-        .await
-        .unwrap(),
+        (BoardImage::Image { img, .. }, FlashingCustomization::Zepto, Destination::Mspm0(t)) => {
+            tokio::task::spawn_blocking(move || {
+                bb_flasher::mspm0::Flasher::no_prep(img.into_image_fn(), t, true, Some(cancel_sync))
+                    .flash(Some(chan))
+            })
+            .await
+            .unwrap()
+        }
         _ => unimplemented!(),
     }
 }
@@ -673,9 +661,9 @@ pub(crate) enum FlashingCustomization {
     NoneSd,
     LinuxSdSysconfig(crate::persistance::SdSysconfCustomization),
     LinuxSdCloudInit(crate::persistance::SdSysconfCustomization),
-    Bcf(crate::persistance::BcfCustomization),
+    Bcf,
     Msp430,
-    Zepto(crate::persistance::BcfCustomization),
+    Zepto,
 }
 
 impl FlashingCustomization {
@@ -704,30 +692,17 @@ impl FlashingCustomization {
                 )
             }
             config::Flasher::SdCard | config::Flasher::SdCardBootfs => Self::NoneSd,
-            config::Flasher::BeagleConnectFreedom => {
-                Self::Bcf(app_config.bcf_customization.clone().unwrap_or_default())
-            }
+            config::Flasher::BeagleConnectFreedom => Self::Bcf,
             config::Flasher::Msp430Usb => Self::Msp430,
-            config::Flasher::Mspm0 => {
-                Self::Zepto(app_config.zepto_customization.clone().unwrap_or_default())
-            }
+            config::Flasher::Mspm0 => Self::Zepto,
             _ => unimplemented!(),
         }
     }
 
     pub(crate) fn reset(&mut self) {
-        match self {
-            Self::LinuxSdSysconfig(_) => {
-                *self = Self::LinuxSdSysconfig(Default::default());
-            }
-            Self::Bcf(_) => {
-                *self = Self::Bcf(Default::default());
-            }
-            Self::Zepto(_) => {
-                *self = Self::Zepto(Default::default());
-            }
-            _ => {}
-        };
+        if let Self::LinuxSdSysconfig(_) = self {
+            *self = Self::LinuxSdSysconfig(Default::default());
+        }
     }
 
     pub(crate) fn validate(&self) -> bool {
@@ -745,9 +720,9 @@ impl FlashingCustomization {
             FlashingCustomization::LinuxSdSysconfig(c) => c.sysconfig(),
             FlashingCustomization::LinuxSdCloudInit(c) => c.cloudinit(),
             FlashingCustomization::NoneSd => bb_flasher::sd::FlashingSdLinuxConfig::none(),
-            FlashingCustomization::Bcf(_)
+            FlashingCustomization::Bcf
             | FlashingCustomization::Msp430
-            | FlashingCustomization::Zepto(_) => unreachable!(),
+            | FlashingCustomization::Zepto => unreachable!(),
         }
     }
 }
@@ -843,6 +818,8 @@ pub(crate) fn no_customization(
             Some(FlashingCustomization::NoneSd)
         }
         config::Flasher::Msp430Usb => Some(FlashingCustomization::Msp430),
+        config::Flasher::BeagleConnectFreedom => Some(FlashingCustomization::Bcf),
+        config::Flasher::Mspm0 => Some(FlashingCustomization::Zepto),
         _ => None,
     }
 }
@@ -1067,8 +1044,7 @@ where
 mod tests {
     use super::*;
     use crate::persistance::{
-        BcfCustomization, GuiConfiguration, SdCustomizationUser, SdCustomizationWifi,
-        SdSysconfCustomization,
+        GuiConfiguration, SdCustomizationUser, SdCustomizationWifi, SdSysconfCustomization,
     };
 
     #[test]
@@ -1156,7 +1132,15 @@ mod tests {
             no_customization(config::Flasher::Msp430Usb, &img),
             Some(FlashingCustomization::Msp430)
         ));
-        assert!(no_customization(config::Flasher::BeagleConnectFreedom, &img).is_none());
+        // BCF and MSPM0 have no customization of their own, so they skip the page.
+        assert!(matches!(
+            no_customization(config::Flasher::BeagleConnectFreedom, &img),
+            Some(FlashingCustomization::Bcf)
+        ));
+        assert!(matches!(
+            no_customization(config::Flasher::Mspm0, &img),
+            Some(FlashingCustomization::Zepto)
+        ));
     }
 
     #[test]
@@ -1171,7 +1155,7 @@ mod tests {
         ));
         assert!(matches!(
             FlashingCustomization::new(config::Flasher::BeagleConnectFreedom, &img, &cfg),
-            FlashingCustomization::Bcf(_)
+            FlashingCustomization::Bcf
         ));
         assert!(matches!(
             FlashingCustomization::new(config::Flasher::Msp430Usb, &img, &cfg),
@@ -1179,7 +1163,7 @@ mod tests {
         ));
         assert!(matches!(
             FlashingCustomization::new(config::Flasher::Mspm0, &img, &cfg),
-            FlashingCustomization::Zepto(_)
+            FlashingCustomization::Zepto
         ));
     }
 
@@ -1196,13 +1180,6 @@ mod tests {
 
     #[test]
     fn flashing_customization_reset_restores_defaults() {
-        let mut bcf = FlashingCustomization::Bcf(BcfCustomization { verify: false });
-        bcf.reset();
-        assert!(matches!(
-            bcf,
-            FlashingCustomization::Bcf(BcfCustomization { verify: true })
-        ));
-
         let mut sysconf = FlashingCustomization::LinuxSdSysconfig(
             SdSysconfCustomization::default().update_hostname(Some("h".into())),
         );
@@ -1216,6 +1193,10 @@ mod tests {
         let mut none = FlashingCustomization::NoneSd;
         none.reset();
         assert!(matches!(none, FlashingCustomization::NoneSd));
+
+        let mut bcf = FlashingCustomization::Bcf;
+        bcf.reset();
+        assert!(matches!(bcf, FlashingCustomization::Bcf));
     }
 
     #[test]

--- a/bb-imager-gui/src/main.rs
+++ b/bb-imager-gui/src/main.rs
@@ -474,17 +474,6 @@ impl BBImager {
 
                     Task::batch([inner.save_app_config(), self.scroll_reset()])
                 }
-                helpers::FlashingCustomization::Bcf(c) => {
-                    inner.common.app_config.update_bcf_customization(c.clone());
-                    Task::batch([inner.save_app_config(), self.scroll_reset()])
-                }
-                helpers::FlashingCustomization::Zepto(c) => {
-                    inner
-                        .common
-                        .app_config
-                        .update_zepto_customization(c.clone());
-                    Task::batch([inner.save_app_config(), self.scroll_reset()])
-                }
                 _ => self.scroll_reset(),
             },
             _ => self.scroll_reset(),

--- a/bb-imager-gui/src/persistance.rs
+++ b/bb-imager-gui/src/persistance.rs
@@ -10,10 +10,6 @@ use serde::{Deserialize, Serialize};
 pub(crate) struct GuiConfiguration {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) sd_customization: Option<SdCustomization>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) bcf_customization: Option<BcfCustomization>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) zepto_customization: Option<BcfCustomization>,
 }
 
 impl GuiConfiguration {
@@ -52,14 +48,6 @@ impl GuiConfiguration {
 
     pub(crate) fn update_sd_customization(&mut self, t: SdCustomization) {
         self.sd_customization = Some(t);
-    }
-
-    pub(crate) fn update_bcf_customization(&mut self, t: BcfCustomization) {
-        self.bcf_customization = Some(t)
-    }
-
-    pub(crate) fn update_zepto_customization(&mut self, t: BcfCustomization) {
-        self.zepto_customization = Some(t)
     }
 }
 
@@ -234,33 +222,9 @@ impl SdCustomizationWifi {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) struct BcfCustomization {
-    pub(crate) verify: bool,
-}
-
-impl BcfCustomization {
-    pub(crate) fn update_verify(mut self, t: bool) -> Self {
-        self.verify = t;
-        self
-    }
-}
-
-impl Default for BcfCustomization {
-    fn default() -> Self {
-        Self { verify: true }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn bcf_customization_defaults_to_verify() {
-        assert!(BcfCustomization::default().verify);
-        assert!(!BcfCustomization::default().update_verify(false).verify);
-    }
 
     #[test]
     fn sd_user_validate_rejects_root() {
@@ -352,19 +316,13 @@ mod tests {
     }
 
     #[test]
-    fn gui_configuration_updates_each_slot() {
+    fn gui_configuration_updates_sd_slot() {
         let mut gui = GuiConfiguration::default();
         assert!(gui.sd_customization.is_none());
-        assert!(gui.bcf_customization.is_none());
-        assert!(gui.zepto_customization.is_none());
 
         gui.update_sd_customization(SdCustomization::default());
-        gui.update_bcf_customization(BcfCustomization::default());
-        gui.update_zepto_customization(BcfCustomization::default().update_verify(false));
 
         assert!(gui.sd_customization.is_some());
-        assert!(gui.bcf_customization.is_some());
-        assert_eq!(gui.zepto_customization.map(|z| z.verify), Some(false));
     }
 
     #[test]
@@ -377,7 +335,6 @@ mod tests {
     #[test]
     fn gui_configuration_round_trips_through_json() {
         let mut gui = GuiConfiguration::default();
-        gui.update_bcf_customization(BcfCustomization { verify: false });
         gui.update_sd_customization({
             let mut sd = SdCustomization::default();
             sd.update_sysconfig(
@@ -389,7 +346,6 @@ mod tests {
         let json = serde_json::to_string(&gui).unwrap();
         let back: GuiConfiguration = serde_json::from_str(&json).unwrap();
 
-        assert_eq!(back.bcf_customization.map(|b| b.verify), Some(false));
         assert_eq!(
             back.sd_customization
                 .and_then(|s| s.sysconf_customization().and_then(|c| c.hostname.clone())),

--- a/bb-imager-gui/src/state.rs
+++ b/bb-imager-gui/src/state.rs
@@ -301,13 +301,6 @@ impl CustomizeState {
             helpers::FlashingCustomization::LinuxSdCloudInit(x) => {
                 helpers::sd_modifications_common(x)
             }
-            helpers::FlashingCustomization::Bcf(x) | helpers::FlashingCustomization::Zepto(x) => {
-                if !x.verify {
-                    vec!["• Skip Verification"]
-                } else {
-                    Vec::new()
-                }
-            }
             _ => Vec::new(),
         }
     }

--- a/bb-imager-gui/src/ui/configuration.rs
+++ b/bb-imager-gui/src/ui/configuration.rs
@@ -7,9 +7,7 @@ use crate::{
     BBImagerMessage,
     helpers::{self, FlashingCustomization},
     persistance,
-    ui::helpers::{
-        VIEW_COL_PADDING, detail_pane, element_with_element, element_with_label, page_type2,
-    },
+    ui::helpers::{detail_pane, element_with_element, element_with_label, page_type2},
 };
 
 const INPUT_WIDTH: u32 = 200;
@@ -37,25 +35,8 @@ fn customization_pane<'a>(state: &'a crate::state::CustomizeState) -> Element<'a
     match &state.customization {
         FlashingCustomization::LinuxSdSysconfig(inner) => linux_sd_card_sysconfig(state, inner),
         FlashingCustomization::LinuxSdCloudInit(inner) => linux_sd_card_cloudinit(state, inner),
-        FlashingCustomization::Bcf(inner) => verify_toggle(inner, FlashingCustomization::Bcf),
-        FlashingCustomization::Zepto(inner) => verify_toggle(inner, FlashingCustomization::Zepto),
         _ => panic!("No customization"),
     }
-}
-
-fn verify_toggle<'a>(
-    state: &'a persistance::BcfCustomization,
-    cb: impl Fn(persistance::BcfCustomization) -> FlashingCustomization + 'a,
-) -> Element<'a, BBImagerMessage> {
-    widget::container(
-        widget::toggler(!state.verify)
-            .label("Skip Verification")
-            .on_toggle(move |x| {
-                BBImagerMessage::UpdateFlashConfig(cb(state.clone().update_verify(!x)))
-            }),
-    )
-    .padding(VIEW_COL_PADDING)
-    .into()
 }
 
 fn linux_sd_card_common<'a>(


### PR DESCRIPTION
The BeagleConnect Freedom and MSPM0 flashers exposed a single customization option, a "Skip Verification" toggle, which was the only reason those flows visited the Customize page at all. Verification is cheap relative to the flash itself and turning it off only trades a silent corruption risk for a small time saving, so the option is not worth the page.

Hardcode verification on for both flashers and let `no_customization` report `Bcf`/`Zepto`, so those boards go straight from destination selection to review. `FlashingCustomization::Bcf`/`Zepto` lose their payload, and the persisted `bcf_customization`/`zepto_customization` config slots go with them. Existing config files still load; serde ignores the now-unknown fields.

The Reset button and `FlashingCustomization::reset` are untouched: they still apply to the SD sysconf customization.


Claude-Session: https://claude.ai/code/session_01YRkEsJHsbTNJVZtgmtYjPV