### PR TITLE
bb-imager-gui: Do not panic on late database results

### DIFF
--- a/bb-imager-gui/src/message.rs
+++ b/bb-imager-gui/src/message.rs
@@ -106,22 +106,24 @@ pub(crate) fn update(state: &mut BBImager, message: BBImagerMessage) -> Task<BBI
                 BBImager::ChooseBoard(x) => {
                     x.boards = boards;
                 }
-                BBImager::AppInfo(overlay_state) => match &mut overlay_state.page {
-                    OverlayData::ChooseBoard(x) => x.boards = boards,
-                    _ => panic!("Unexpected message"),
-                },
-                _ => panic!("Unexpected message"),
+                BBImager::AppInfo(overlay_state) => {
+                    if let OverlayData::ChooseBoard(x) = &mut overlay_state.page {
+                        x.boards = boards
+                    }
+                }
+                _ => {}
             }
         }
         BBImagerMessage::SelectBoard(b) => match state {
             BBImager::ChooseBoard(inner) => {
                 inner.selected_board = Some(b);
             }
-            BBImager::AppInfo(overlay_state) => match &mut overlay_state.page {
-                OverlayData::ChooseBoard(inner) => inner.selected_board = Some(b),
-                _ => panic!("Unexpected message"),
-            },
-            _ => panic!("Unexpected message"),
+            BBImager::AppInfo(overlay_state) => {
+                if let OverlayData::ChooseBoard(inner) = &mut overlay_state.page {
+                    inner.selected_board = Some(b)
+                }
+            }
+            _ => {}
         },
         BBImagerMessage::UpdateOsList((imgs, pos)) => {
             match state {
@@ -189,8 +191,8 @@ pub(crate) fn update(state: &mut BBImager, message: BBImagerMessage) -> Task<BBI
                     helpers::BoardImage::remote(image, flasher, inner.common.downloader.clone()),
                 ));
             }
-            BBImager::AppInfo(overlay_state) => match &mut overlay_state.page {
-                OverlayData::ChooseOs(inner) => {
+            BBImager::AppInfo(overlay_state) => {
+                if let OverlayData::ChooseOs(inner) = &mut overlay_state.page {
                     inner.selected_image = Some((
                         helpers::OsImageId::OsImage(image.id),
                         helpers::BoardImage::remote(
@@ -200,9 +202,8 @@ pub(crate) fn update(state: &mut BBImager, message: BBImagerMessage) -> Task<BBI
                         ),
                     ));
                 }
-                _ => panic!("Unexpected message"),
-            },
-            _ => panic!("Unexpected message"),
+            }
+            _ => {}
         },
         BBImagerMessage::SelectLocalOs(image) => match state {
             BBImager::ChooseOs(inner) => {


### PR DESCRIPTION
UpdateBoardList, SelectBoard and SelectRemoteOs all carry the result of a database query dispatched as a Task. Nothing keeps the user on the page while that query runs, so a board list refresh or an image lookup can land after they have navigated away — and every one of those handlers ended in `panic!("Unexpected message")`, crashing the application.

The UpdateBoardList arm even documents the intended behaviour, "Update board list only if still on that page"; it just did not implement it.

Drop the stale result instead, matching how UpdateOsList and Destinations already handle the same race.


Claude-Session: https://claude.ai/code/session_01YRkEsJHsbTNJVZtgmtYjPV