### PR TITLE
bb-imager-gui: Copy real config entries to the clipboard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,7 +682,6 @@ dependencies = [
  "bb-iced-widgets",
  "chrono",
  "chrono-tz",
- "const-hex",
  "directories",
  "embed-resource",
  "iana-time-zone",

--- a/bb-imager-gui/Cargo.toml
+++ b/bb-imager-gui/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 [dependencies]
 iced = { version = "0.14.0", features = ["image", "svg", "tokio", "advanced"] }
 rfd = { version = "0.17.2", features = ["file-handle-inner"] }
-bb-flasher = { path = "../bb-flasher", features = ["serde", "piped_image"] }
+bb-flasher = { path = "../bb-flasher", features = ["piped_image"] }
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 tracing = "0.1.44"
 iced_aw = { version = "0.14.1", default-features = false, features = ["spinner"] }
@@ -30,7 +30,6 @@ bb-helper = { path = "../bb-helper", features = ["file_stream", "cancel"] }
 semver = "1.0.28"
 anyhow = "1.0"
 tempfile = "3.26"
-const-hex = { version = "1.19", features = ["serde"] }
 tokio-util = { version = "0.7", features = ["rt"] }
 rusqlite = { version = "0.40", features = ["url", "chrono"] }
 chrono = "0.4"

--- a/bb-imager-gui/src/db/mod.rs
+++ b/bb-imager-gui/src/db/mod.rs
@@ -32,7 +32,7 @@ impl BoardListItem {
     }
 }
 
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone)]
 pub(crate) struct Board {
     pub(crate) id: i64,
     pub(crate) name: String,
@@ -99,7 +99,7 @@ impl OsSublistListItem {
     }
 }
 
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone)]
 pub(crate) struct OsImage {
     pub(crate) id: i64,
     pub(crate) name: String,
@@ -765,5 +765,89 @@ impl Db {
             .collect();
 
         Ok(res)
+    }
+
+    /// Reconstruct the [`config::Device`] entry for a board, as it was inserted from the config.
+    ///
+    /// Statements here are not cached: this only runs when the user copies a board to the
+    /// clipboard, so a cache slot would be wasted on it.
+    pub(crate) fn os_board_json_by_id(&self, id: i64) -> rusqlite::Result<config::Device> {
+        let db = self.db.lock().unwrap();
+
+        let mut stmt = db.prepare("SELECT tag FROM board_tags WHERE board_id = $1")?;
+        let tags = stmt
+            .query_map([id], |r| r.get(0))?
+            .collect::<rusqlite::Result<_>>()?;
+
+        let mut stmt = db.prepare(
+            r#"
+            SELECT name, description, icon, flasher, instructions, oshw, specification, documentation
+            FROM boards WHERE id = $1"#)?;
+
+        stmt.query_one([id], |value| {
+            let spec: Vec<u8> = value.get("specification")?;
+
+            Ok(config::Device {
+                name: value.get("name")?,
+                description: value.get("description")?,
+                icon: value.get("icon")?,
+                flasher: value.get("flasher")?,
+                instructions: value.get("instructions")?,
+                specification: serde_json::from_slice(&spec).unwrap(),
+                documentation: value.get("documentation")?,
+                oshw: value.get("oshw")?,
+                tags,
+            })
+        })
+    }
+
+    /// Reconstruct the [`config::OsImage`] entry for an image, as it was inserted from the config.
+    ///
+    /// Image tags are not stored, and `devices` is recovered from the boards the image ended up
+    /// linked to, so it can contain more tags than the original config entry listed.
+    ///
+    /// Statements here are not cached, for the same reason as
+    /// [`Self::os_board_json_by_id`].
+    pub(crate) fn os_image_json_by_id(&self, id: i64) -> rusqlite::Result<config::OsImage> {
+        let db = self.db.lock().unwrap();
+
+        let mut stmt = db.prepare(
+            r#"
+            SELECT DISTINCT bt.tag
+            FROM os_image_boards oib
+            JOIN board_tags bt ON bt.board_id = oib.board_id
+            WHERE oib.image_id = $1"#,
+        )?;
+        let devices = stmt
+            .query_map([id], |r| r.get(0))?
+            .collect::<rusqlite::Result<_>>()?;
+
+        let mut stmt = db.prepare(
+            r#"
+            SELECT name, description, icon, url, image_download_size, image_download_sha256,
+                extract_size, release_date, init_format, bmap, info_text, support
+            FROM os_images WHERE id = $1"#,
+        )?;
+
+        stmt.query_one([id], |value| {
+            let image_download_size: Option<i64> = value.get("image_download_size")?;
+            let extract_size: i64 = value.get("extract_size")?;
+
+            Ok(config::OsImage {
+                name: value.get("name")?,
+                description: value.get("description")?,
+                icon: value.get("icon")?,
+                url: value.get("url")?,
+                image_download_size: image_download_size.map(|x| x as u64),
+                image_download_sha256: value.get("image_download_sha256")?,
+                extract_size: extract_size as u64,
+                release_date: value.get("release_date")?,
+                init_format: value.get("init_format")?,
+                bmap: value.get("bmap")?,
+                info_text: value.get("info_text")?,
+                support: value.get("support")?,
+                devices,
+            })
+        })
     }
 }

--- a/bb-imager-gui/src/db/tests.rs
+++ b/bb-imager-gui/src/db/tests.rs
@@ -1080,3 +1080,422 @@ fn board_list_search_filters_boards_case_insensitive() {
     assert!(results.iter().any(|b| b.name == "Test Board 2"));
     assert!(results.iter().any(|b| b.name == "Test Board 3"));
 }
+
+/// Insert a single board and return its id.
+fn insert_board_helper(db: &Db, board: bb_config::config::Device) -> i64 {
+    let name = board.name.clone();
+
+    db.add_config(
+        Config {
+            imager: bb_config::config::Imager {
+                remote_configs: Default::default(),
+                devices: vec![board],
+            },
+            os_list: vec![],
+        },
+        None,
+    )
+    .expect("add_config should succeed");
+
+    db.board_list("")
+        .expect("Fetching board list should succeed")
+        .iter()
+        .find(|b| b.name == name)
+        .expect("Inserted board should exist")
+        .id
+}
+
+/// This test verifies that os_board_json_by_id() reconstructs the exact
+/// [`bb_config::config::Device`] that was inserted through add_config().
+///
+/// What this test checks:
+/// 1. A device with every field populated is inserted.
+/// 2. os_board_json_by_id() returns a Device equal to the original.
+/// 3. Multi-entry tags and ordered specification pairs survive the round trip.
+///
+/// Why this matters:
+/// - The device is stored across two tables (boards + board_tags) and the
+///   specification is stored as a serialized blob, so a round trip is the only
+///   way to catch a column being dropped or serialized in the wrong shape.
+/// - The reconstructed Device is handed back to the flashing code, so any
+///   missing field would silently change flashing behaviour.
+#[test]
+fn os_board_json_by_id_round_trips_device() {
+    let db = Db::new().expect("Failed to create DB");
+    db.init().expect("DB init should succeed");
+
+    let board = bb_config::config::Device {
+        name: "Test Board".to_string(),
+        description: "Test description".to_string(),
+        icon: Some("https://example.com/icon.png".try_into().unwrap()),
+        flasher: bb_config::config::Flasher::SdCard,
+        instructions: Some("Hold the boot button".to_string()),
+        oshw: Some("us000000".to_string()),
+        specification: vec![
+            ("CPU".to_string(), "Test CPU".to_string()),
+            ("RAM".to_string(), "1GB".to_string()),
+        ],
+        documentation: Some("https://example.com/docs".try_into().unwrap()),
+        tags: ["test-board".into(), "test-board-alt".into()].into(),
+    };
+
+    let id = insert_board_helper(&db, board.clone());
+
+    let res = db
+        .os_board_json_by_id(id)
+        .expect("Fetching board json should succeed");
+
+    assert_eq!(res, board);
+}
+
+/// This test verifies that os_board_json_by_id() works for a board with no
+/// optional fields, no tags and an empty specification.
+///
+/// What this test checks:
+/// 1. A device with all optional columns NULL is inserted.
+/// 2. os_board_json_by_id() returns it without error.
+/// 3. Tags and specification come back empty instead of failing.
+///
+/// Why this matters:
+/// - icon, instructions, oshw and documentation are nullable columns; reading
+///   them into non-Option types would panic only for such minimal boards.
+/// - A board without tags produces zero rows in board_tags, which must not be
+///   treated as a missing board.
+#[test]
+fn os_board_json_by_id_handles_board_without_optional_fields() {
+    let db = Db::new().expect("Failed to create DB");
+    db.init().expect("DB init should succeed");
+
+    let board = bb_config::config::Device {
+        name: "Minimal Board".to_string(),
+        description: "Minimal".to_string(),
+        icon: None,
+        flasher: bb_config::config::Flasher::SdCard,
+        instructions: None,
+        oshw: None,
+        specification: vec![],
+        documentation: None,
+        tags: Box::default(),
+    };
+
+    let id = insert_board_helper(&db, board.clone());
+
+    let res = db
+        .os_board_json_by_id(id)
+        .expect("Fetching board json should succeed");
+
+    assert_eq!(res, board);
+}
+
+/// This test verifies that os_board_json_by_id() reflects an updated board
+/// instead of mixing old and new data.
+///
+/// What this test checks:
+/// 1. A board is inserted and then re-inserted with the same name.
+/// 2. os_board_json_by_id() returns the updated fields.
+/// 3. Tags from the first insertion are gone, not merged with the new ones.
+///
+/// Why this matters:
+/// - insert_board() upserts on name and deletes the old tags; a regression
+///   there would leave stale tags attached to the board.
+/// - Stale tags would also link the board to OS images it no longer supports.
+#[test]
+fn os_board_json_by_id_reflects_updated_board() {
+    let db = Db::new().expect("Failed to create DB");
+    db.init().expect("DB init should succeed");
+
+    let board_v1 = bb_config::config::Device {
+        name: "Test Board".to_string(),
+        description: "Old description".to_string(),
+        icon: None,
+        flasher: bb_config::config::Flasher::SdCard,
+        instructions: None,
+        oshw: None,
+        specification: vec![],
+        documentation: None,
+        tags: ["old-tag".into()].into(),
+    };
+
+    let id = insert_board_helper(&db, board_v1);
+
+    let board_v2 = bb_config::config::Device {
+        name: "Test Board".to_string(),
+        description: "New description".to_string(),
+        icon: None,
+        flasher: bb_config::config::Flasher::SdCard,
+        instructions: Some("New instructions".to_string()),
+        oshw: Some("us000000".to_string()),
+        specification: vec![("CPU".to_string(), "Test CPU".to_string())],
+        documentation: None,
+        tags: ["new-tag".into()].into(),
+    };
+
+    assert_eq!(
+        insert_board_helper(&db, board_v2.clone()),
+        id,
+        "Re-inserting the same board name should update the same row"
+    );
+
+    let res = db
+        .os_board_json_by_id(id)
+        .expect("Fetching board json should succeed");
+
+    assert_eq!(res, board_v2);
+}
+
+/// Insert a board along with an OS image and return the id of the inserted image.
+fn insert_image_helper(
+    db: &Db,
+    board: bb_config::config::Device,
+    image: bb_config::config::OsImage,
+) -> i64 {
+    let name = image.name.clone();
+
+    db.add_config(
+        Config {
+            imager: bb_config::config::Imager {
+                remote_configs: Default::default(),
+                devices: vec![board.clone()],
+            },
+            os_list: vec![bb_config::config::OsListItem::Image(image)],
+        },
+        None,
+    )
+    .expect("add_config should succeed");
+
+    let board_id = db
+        .board_list("")
+        .expect("Fetching board list should succeed")
+        .iter()
+        .find(|b| b.name == board.name)
+        .expect("Inserted board should exist")
+        .id;
+
+    let items = db
+        .os_image_items(board_id, None)
+        .expect("os_image_items should succeed");
+
+    let crate::helpers::OsImageId::OsImage(image_id) = items
+        .iter()
+        .find(|x| x.label.as_ref() == name.as_str())
+        .expect("Inserted image should exist")
+        .id
+    else {
+        panic!("Incorrect ID");
+    };
+
+    image_id
+}
+
+/// This test verifies that os_image_json_by_id() reconstructs the exact
+/// [`bb_config::config::OsImage`] that was inserted through add_config().
+///
+/// What this test checks:
+/// 1. An image with every field populated is inserted for a board with one tag.
+/// 2. os_image_json_by_id() returns an OsImage equal to the original.
+/// 3. sha256, sizes, release date, urls and devices survive the round trip.
+///
+/// Why this matters:
+/// - Sizes are stored as signed integers and the sha256 as a blob, so a wrong
+///   cast or column would only show up on a full round trip.
+/// - The reconstructed OsImage describes what is actually being flashed, so a
+///   missing field would misreport the flashing job.
+#[test]
+fn os_image_json_by_id_round_trips_image() {
+    let db = Db::new().expect("Failed to create DB");
+    db.init().expect("DB init should succeed");
+
+    let board = bb_config::config::Device {
+        name: "Test Board".to_string(),
+        description: "Test Board description".to_string(),
+        icon: None,
+        flasher: bb_config::config::Flasher::SdCard,
+        instructions: None,
+        oshw: None,
+        specification: vec![],
+        documentation: None,
+        tags: ["test_board".into()].into(),
+    };
+
+    let image = bb_config::config::OsImage {
+        name: "Test OS".to_string(),
+        description: "Test OS description".to_string(),
+        icon: "https://example.com/icon.png".try_into().unwrap(),
+        url: "https://example.com/os.img.xz".try_into().unwrap(),
+        image_download_size: Some(1024),
+        image_download_sha256: [7; 32],
+        extract_size: 4096,
+        release_date: chrono::NaiveDate::from_ymd_opt(2024, 5, 10).unwrap(),
+        devices: ["test_board".into()].into(),
+        init_format: bb_config::config::InitFormat::Sysconf,
+        bmap: Some("https://example.com/os.bmap".try_into().unwrap()),
+        info_text: Some("Test info".to_string()),
+        support: Some(
+            "https://github.com/beagleboard/bb-imager-rs"
+                .try_into()
+                .unwrap(),
+        ),
+    };
+
+    let id = insert_image_helper(&db, board, image.clone());
+
+    let res = db
+        .os_image_json_by_id(id)
+        .expect("Fetching image json should succeed");
+
+    assert_eq!(res, image);
+}
+
+/// This test verifies that os_image_json_by_id() works for an image with none
+/// of the optional fields set.
+///
+/// What this test checks:
+/// 1. An image without download size, bmap, info text and support url is inserted.
+/// 2. os_image_json_by_id() returns it without error.
+///
+/// Why this matters:
+/// - Those columns are nullable; reading them into non-Option types would only
+///   fail for images that omit them.
+#[test]
+fn os_image_json_by_id_handles_image_without_optional_fields() {
+    let db = Db::new().expect("Failed to create DB");
+    db.init().expect("DB init should succeed");
+
+    let board = bb_config::config::Device {
+        name: "Test Board".to_string(),
+        description: "Test Board description".to_string(),
+        icon: None,
+        flasher: bb_config::config::Flasher::SdCard,
+        instructions: None,
+        oshw: None,
+        specification: vec![],
+        documentation: None,
+        tags: ["test_board".into()].into(),
+    };
+
+    let image = bb_config::config::OsImage {
+        name: "Minimal OS".to_string(),
+        description: "Minimal OS description".to_string(),
+        icon: "https://example.com/icon.png".try_into().unwrap(),
+        url: "https://example.com/os.img.xz".try_into().unwrap(),
+        image_download_size: None,
+        image_download_sha256: [0; 32],
+        extract_size: 1,
+        release_date: chrono::NaiveDate::from_ymd_opt(2024, 5, 10).unwrap(),
+        devices: ["test_board".into()].into(),
+        init_format: bb_config::config::InitFormat::None,
+        bmap: None,
+        info_text: None,
+        support: None,
+    };
+
+    let id = insert_image_helper(&db, board, image.clone());
+
+    let res = db
+        .os_image_json_by_id(id)
+        .expect("Fetching image json should succeed");
+
+    assert_eq!(res, image);
+}
+
+/// This test pins the known lossiness of os_image_json_by_id(): the returned
+/// `devices` comes from the boards the image is linked to, not from the config.
+///
+/// What this test checks:
+/// 1. A board carrying two tags is inserted.
+/// 2. An image referencing only one of those tags is inserted.
+/// 3. os_image_json_by_id() reports both tags in `devices`.
+///
+/// Why this matters:
+/// - The original device list is not stored; only the board links are. Callers
+///   must treat `devices` as "tags of the boards this image matched", and this
+///   test documents that instead of leaving it to be discovered later.
+#[test]
+fn os_image_json_by_id_devices_come_from_linked_boards() {
+    let db = Db::new().expect("Failed to create DB");
+    db.init().expect("DB init should succeed");
+
+    let board = bb_config::config::Device {
+        name: "Test Board".to_string(),
+        description: "Test Board description".to_string(),
+        icon: None,
+        flasher: bb_config::config::Flasher::SdCard,
+        instructions: None,
+        oshw: None,
+        specification: vec![],
+        documentation: None,
+        tags: ["test_board".into(), "test_board_alt".into()].into(),
+    };
+
+    let image = bb_config::config::OsImage {
+        name: "Test OS".to_string(),
+        description: "Test OS description".to_string(),
+        icon: "https://example.com/icon.png".try_into().unwrap(),
+        url: "https://example.com/os.img.xz".try_into().unwrap(),
+        image_download_size: None,
+        image_download_sha256: [1; 32],
+        extract_size: 1,
+        release_date: chrono::NaiveDate::from_ymd_opt(2024, 5, 10).unwrap(),
+        devices: ["test_board".into()].into(),
+        init_format: bb_config::config::InitFormat::None,
+        bmap: None,
+        info_text: None,
+        support: None,
+    };
+
+    let id = insert_image_helper(&db, board, image);
+
+    let res = db
+        .os_image_json_by_id(id)
+        .expect("Fetching image json should succeed");
+
+    // `devices` is now an ordered slice, but the query has no ORDER BY, so
+    // compare without depending on the row order.
+    let mut devices: Vec<&str> = res.devices.iter().map(AsRef::as_ref).collect();
+    devices.sort_unstable();
+    assert_eq!(devices, ["test_board", "test_board_alt"]);
+}
+
+/// This test verifies that os_image_json_by_id() fails for an unknown image id.
+///
+/// What this test checks:
+/// 1. An id that does not exist is queried.
+/// 2. The call returns QueryReturnedNoRows instead of a default image.
+///
+/// Why this matters:
+/// - Returning a bogus image instead of an error would report the wrong image
+///   for a flashing job.
+#[test]
+fn os_image_json_by_id_unknown_id_returns_no_rows() {
+    let db = Db::new().expect("Failed to create DB");
+    db.init().expect("DB init should succeed");
+
+    let res = db.os_image_json_by_id(i64::MAX);
+
+    assert!(
+        matches!(res, Err(rusqlite::Error::QueryReturnedNoRows)),
+        "Unknown image id should return QueryReturnedNoRows, got {res:?}"
+    );
+}
+
+/// This test verifies that os_board_json_by_id() fails for an unknown board id.
+///
+/// What this test checks:
+/// 1. An id that does not exist is queried.
+/// 2. The call returns QueryReturnedNoRows instead of a default board.
+///
+/// Why this matters:
+/// - Callers pass board ids kept in UI state; returning a bogus board instead
+///   of an error would flash a device with the wrong configuration.
+#[test]
+fn os_board_json_by_id_unknown_id_returns_no_rows() {
+    let db = Db::new().expect("Failed to create DB");
+    db.init().expect("DB init should succeed");
+
+    let res = db.os_board_json_by_id(i64::MAX);
+
+    assert!(
+        matches!(res, Err(rusqlite::Error::QueryReturnedNoRows)),
+        "Unknown board id should return QueryReturnedNoRows, got {res:?}"
+    );
+}

--- a/bb-imager-gui/src/helpers.rs
+++ b/bb-imager-gui/src/helpers.rs
@@ -12,14 +12,14 @@ use std::sync::mpsc;
 use tokio_util::task::AbortOnDropHandle;
 use url::Url;
 
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone)]
 pub(crate) enum BoardImageIcon {
     Remote(url::Url),
     Local,
     Format,
 }
 
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone)]
 #[allow(clippy::large_enum_variant)]
 pub(crate) enum BoardImage {
     SdFormat {
@@ -235,14 +235,12 @@ pub(crate) fn system_keymap() -> &'static str {
     (*SYSTEM_KEYMAP).unwrap_or("us")
 }
 
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone)]
 pub(crate) struct RemoteImage {
     name: Box<str>,
     url: Box<url::Url>,
-    #[serde(with = "const_hex")]
     extract_sha256: [u8; 32],
     extract_size: u64,
-    #[serde(skip)]
     downloader: bb_downloader::Downloader,
 }
 
@@ -332,10 +330,9 @@ impl std::fmt::Display for RemoteImage {
     }
 }
 
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone)]
 pub(crate) struct Bmap {
     url: Box<Url>,
-    #[serde(skip)]
     downloader: bb_downloader::Downloader,
 }
 
@@ -349,7 +346,7 @@ impl Bmap {
     }
 }
 
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone)]
 pub(crate) enum SelectedImage {
     LocalImage(bb_flasher::LocalImage),
     RemoteImage(RemoteImage),

--- a/bb-imager-gui/src/message.rs
+++ b/bb-imager-gui/src/message.rs
@@ -83,6 +83,10 @@ pub(crate) enum BBImagerMessage {
 
     /// Copy text to clipboard.
     CopyToClipboard(String),
+    /// Copy a board's config entry, looked up by id, to the clipboard.
+    CopyBoardConfig(i64),
+    /// Copy an OS image's config entry, looked up by id, to the clipboard.
+    CopyImageConfig(i64),
 
     /// DB Ops
     DbInitSuccess,
@@ -496,6 +500,36 @@ pub(crate) fn update(state: &mut BBImager, message: BBImagerMessage) -> Task<BBI
         }
         BBImagerMessage::CopyToClipboard(data) => {
             return iced::clipboard::write(data);
+        }
+        BBImagerMessage::CopyBoardConfig(id) => {
+            let db = state.common().db.clone();
+            return Task::perform(
+                blocking_future(move || db.os_board_json_by_id(id)),
+                |x| match x {
+                    Ok(b) => BBImagerMessage::CopyToClipboard(
+                        serde_json::to_string_pretty(&b).expect("Device is always serializable"),
+                    ),
+                    Err(e) => {
+                        tracing::error!("Failed to get board config: {e}");
+                        BBImagerMessage::Null
+                    }
+                },
+            );
+        }
+        BBImagerMessage::CopyImageConfig(id) => {
+            let db = state.common().db.clone();
+            return Task::perform(
+                blocking_future(move || db.os_image_json_by_id(id)),
+                |x| match x {
+                    Ok(i) => BBImagerMessage::CopyToClipboard(
+                        serde_json::to_string_pretty(&i).expect("OsImage is always serializable"),
+                    ),
+                    Err(e) => {
+                        tracing::error!("Failed to get image config: {e}");
+                        BBImagerMessage::Null
+                    }
+                },
+            );
         }
         BBImagerMessage::DbInitSuccess => {
             let db = state.common().db.clone();

--- a/bb-imager-gui/src/state.rs
+++ b/bb-imager-gui/src/state.rs
@@ -117,10 +117,15 @@ impl ChooseOsState {
         self.pos = pos;
     }
 
-    pub(crate) fn img_json(&self) -> Option<String> {
-        self.selected_image
-            .as_ref()
-            .map(|(_, b)| serde_json::to_string_pretty(&b).unwrap())
+    /// Id of the selected image's config entry, if it has one.
+    ///
+    /// Local images and the SD format action are not in the config, so there is
+    /// nothing to copy for them.
+    pub(crate) fn selected_image_config_id(&self) -> Option<i64> {
+        match self.selected_image.as_ref()?.0 {
+            helpers::OsImageId::OsImage(id) => Some(id),
+            _ => None,
+        }
     }
 
     pub(crate) fn resolve_remote_sublists(

--- a/bb-imager-gui/src/ui/helpers.rs
+++ b/bb-imager-gui/src/ui/helpers.rs
@@ -174,10 +174,7 @@ pub(crate) fn board_view_pane<'a>(
         iced::Shrink,
     );
 
-    let copy_btn = copy_btn(COPY_ICON.clone()).on_press_with(|| {
-        let json = serde_json::to_string_pretty(dev).expect("Invalid image");
-        BBImagerMessage::CopyToClipboard(json)
-    });
+    let copy_btn = copy_btn(COPY_ICON.clone()).on_press(BBImagerMessage::CopyBoardConfig(dev.id));
 
     let cols = widget::column![
         img,

--- a/bb-imager-gui/src/ui/image_selection.rs
+++ b/bb-imager-gui/src/ui/image_selection.rs
@@ -130,10 +130,10 @@ fn os_view_pane<'a>(state: &'a crate::state::ChooseOsState) -> Element<'a, BBIma
             let mut col = widget::column![icon];
 
             // Add button to copy image info when it makes sense.
-            if let Some(json) = state.img_json() {
+            if let Some(id) = state.selected_image_config_id() {
                 col = col.push(widget::center(
                     helpers::copy_btn(helpers::COPY_ICON.clone())
-                        .on_press(BBImagerMessage::CopyToClipboard(json)),
+                        .on_press(BBImagerMessage::CopyImageConfig(id)),
                 ));
             }
 


### PR DESCRIPTION
The copy buttons on the board and image panes serialized the GUI's own structs. db::Board carries an internal rowid and no tags; helpers::BoardImage is a GUI enum of details, icons and a downloader handle. Neither output is a bb_config entry, so what landed on the clipboard could not be pasted back into a config.json, which is the only thing anyone would want it for.

Reconstruct the original config::Device and config::OsImage from the database instead, and have the buttons carry an id so the lookup happens in update rather than in view. Both statements are uncached: this runs once per click, so it should not take a cache slot from the queries that populate the lists.

`devices` on an image is recovered from the boards the image was linked to rather than from the original config, so it can list more tags than the config entry did; that is pinned by a test rather than left to be discovered.

The copy button now only appears for images that have a config entry. Local files and the SD format action never had anything meaningful to copy.

With the GUI structs no longer serialized, their Serialize derives go, and with them the const-hex dependency and bb-flasher's serde feature.


Claude-Session: https://claude.ai/code/session_01YRkEsJHsbTNJVZtgmtYjPV