### PR TITLE
bb-imager-gui: Fall back to a usable default username

### DIFF
--- a/bb-imager-gui/src/helpers.rs
+++ b/bb-imager-gui/src/helpers.rs
@@ -235,6 +235,20 @@ pub(crate) fn system_keymap() -> &'static str {
     (*SYSTEM_KEYMAP).unwrap_or("us")
 }
 
+/// Username to pre-fill the customization page with.
+///
+/// Falls back to "beagle" rather than an empty name: an empty username is not a
+/// valid account, and nothing downstream rejects one, so it would be written to
+/// the image as-is.
+pub(crate) fn default_user() -> &'static str {
+    static USER: LazyLock<Option<String>> = LazyLock::new(|| whoami::username().ok());
+
+    match &*USER {
+        Some(x) => x,
+        None => "beagle",
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct RemoteImage {
     name: Box<str>,
@@ -1320,6 +1334,11 @@ mod tests {
             OsImageId::OsSublist((7, config::Flasher::SdCard))
         );
         assert!(sublist.is_sublist());
+    }
+
+    #[test]
+    fn default_user_is_never_empty() {
+        assert!(!default_user().is_empty());
     }
 
     #[test]

--- a/bb-imager-gui/src/persistance.rs
+++ b/bb-imager-gui/src/persistance.rs
@@ -200,7 +200,7 @@ impl SdCustomizationUser {
 
 impl Default for SdCustomizationUser {
     fn default() -> Self {
-        Self::new(whoami::username().unwrap_or_default(), String::new())
+        Self::new(crate::helpers::default_user().to_owned(), String::new())
     }
 }
 


### PR DESCRIPTION
`whoami::username().unwrap_or_default()` yields an empty string when the lookup fails. Nothing rejects an empty username: `validate_username` only checks for "root", so the customization page would offer it, accept it, and write an account with no name to the image.

Fall back to "beagle" instead, and resolve the name once rather than on every construction of the default customization.


Claude-Session: https://claude.ai/code/session_01YRkEsJHsbTNJVZtgmtYjPV