### PR TITLE
bb-imager-gui: Gate bmap behind the sd feature

### DIFF
--- a/bb-imager-gui/src/helpers.rs
+++ b/bb-imager-gui/src/helpers.rs
@@ -29,6 +29,9 @@ pub(crate) enum BoardImage {
         flasher: config::Flasher,
         init_format: config::InitFormat,
         img: SelectedImage,
+        // Only the SD flasher consumes a bmap; without that backend the field,
+        // `Bmap` and its downloader are dead weight.
+        #[cfg(feature = "sd")]
         bmap: Option<Bmap>,
         info_text: Option<String>,
         description: Option<String>,
@@ -48,6 +51,7 @@ impl BoardImage {
 
         Self::Image {
             img: bb_flasher::LocalImage::new(path.into()).into(),
+            #[cfg(feature = "sd")]
             bmap: None,
             flasher,
             // Do not try to apply customization for local images
@@ -83,6 +87,7 @@ impl BoardImage {
                 downloader.clone(),
             )
             .into(),
+            #[cfg(feature = "sd")]
             bmap: image.bmap.map(|url| Bmap {
                 url: Box::new(url),
                 downloader,
@@ -344,12 +349,14 @@ impl std::fmt::Display for RemoteImage {
     }
 }
 
+#[cfg(feature = "sd")]
 #[derive(Debug, Clone)]
 pub(crate) struct Bmap {
     url: Box<Url>,
     downloader: bb_downloader::Downloader,
 }
 
+#[cfg(feature = "sd")]
 impl Bmap {
     fn into_fn(self) -> impl FnOnce() -> io::Result<Box<str>> {
         let rt = tokio::runtime::Handle::current();


### PR DESCRIPTION
A bmap only ever reaches bb_flasher::sd::Flasher, so a build without the sd backend carries the field, the Bmap struct, its downloader handle and its into_fn for nothing. That also means the compiler has been reporting three dead-code warnings for a build that is otherwise clean.


Claude-Session: https://claude.ai/code/session_01YRkEsJHsbTNJVZtgmtYjPV