### PR TITLE
bb-imager-gui: Treat cloud-init as customizable everywhere

### DIFF
--- a/bb-imager-gui/src/helpers.rs
+++ b/bb-imager-gui/src/helpers.rs
@@ -700,14 +700,21 @@ impl FlashingCustomization {
     }
 
     pub(crate) fn reset(&mut self) {
-        if let Self::LinuxSdSysconfig(_) = self {
-            *self = Self::LinuxSdSysconfig(Default::default());
+        match self {
+            Self::LinuxSdSysconfig(_) => {
+                *self = Self::LinuxSdSysconfig(Default::default());
+            }
+            Self::LinuxSdCloudInit(_) => {
+                *self = Self::LinuxSdCloudInit(Default::default());
+            }
+            _ => {}
         }
     }
 
     pub(crate) fn validate(&self) -> bool {
         match self {
-            FlashingCustomization::LinuxSdSysconfig(sd_customization) => {
+            FlashingCustomization::LinuxSdSysconfig(sd_customization)
+            | FlashingCustomization::LinuxSdCloudInit(sd_customization) => {
                 sd_customization.validate_user()
             }
             _ => true,
@@ -1175,7 +1182,12 @@ mod tests {
         );
         let root = SdSysconfCustomization::default()
             .update_user(Some(SdCustomizationUser::new("root".into(), "p".into())));
-        assert!(!FlashingCustomization::LinuxSdSysconfig(root).validate());
+        assert!(!FlashingCustomization::LinuxSdSysconfig(root.clone()).validate());
+        // Cloud-init writes the same user account, so it needs the same check.
+        assert!(
+            FlashingCustomization::LinuxSdCloudInit(SdSysconfCustomization::default()).validate()
+        );
+        assert!(!FlashingCustomization::LinuxSdCloudInit(root).validate());
     }
 
     #[test]
@@ -1186,6 +1198,16 @@ mod tests {
         sysconf.reset();
         match sysconf {
             FlashingCustomization::LinuxSdSysconfig(c) => assert!(c.hostname.is_none()),
+            _ => panic!("variant should be preserved"),
+        }
+
+        // Cloud-init is just as resettable as sysconf.
+        let mut cloudinit = FlashingCustomization::LinuxSdCloudInit(
+            SdSysconfCustomization::default().update_hostname(Some("h".into())),
+        );
+        cloudinit.reset();
+        match cloudinit {
+            FlashingCustomization::LinuxSdCloudInit(c) => assert!(c.hostname.is_none()),
             _ => panic!("variant should be preserved"),
         }
 

--- a/bb-imager-gui/src/main.rs
+++ b/bb-imager-gui/src/main.rs
@@ -462,7 +462,10 @@ impl BBImager {
                 ])
             }
             Self::Review(inner) => match &inner.customization {
-                helpers::FlashingCustomization::LinuxSdSysconfig(c) => {
+                // Both variants are backed by the same `sysconf` slot, matching how
+                // `FlashingCustomization::new` loads them.
+                helpers::FlashingCustomization::LinuxSdSysconfig(c)
+                | helpers::FlashingCustomization::LinuxSdCloudInit(c) => {
                     let mut temp = inner
                         .common
                         .app_config


### PR DESCRIPTION
`FlashingCustomization::new` loads LinuxSdCloudInit from the same persisted `sysconf` slot as LinuxSdSysconfig, but three places downstream only ever matched on LinuxSdSysconfig and let cloud-init fall through to a catch-all:

  - `next` never wrote the customization back, so the hostname, user account, wifi credentials and SSH key a user entered for a cloud-init image were silently discarded and the page came back empty next launch.
  - `reset` left cloud-init untouched, so the Reset button did nothing.
  - `validate` skipped the username check, so `root` was accepted for cloud-init images while being rejected for sysconf ones.

Cloud-init and sysconf carry the same SdSysconfCustomization and write the same user account, so all three now handle the two variants together.


Claude-Session: https://claude.ai/code/session_01YRkEsJHsbTNJVZtgmtYjPV