### PR TITLE
bb-imager-gui: Carry the flashing choices in one struct

### DIFF
--- a/bb-imager-gui/src/main.rs
+++ b/bb-imager-gui/src/main.rs
@@ -251,19 +251,19 @@ impl BBImager {
     }
 
     fn start_flashing(&mut self) -> Task<BBImagerMessage> {
-        let state = match std::mem::take(self) {
-            Self::Review(inner) => inner,
-            Self::FlashingFail(inner) => inner.into(),
+        // Retrying from the failure page re-runs with the same choices.
+        let (common, ctx) = match std::mem::take(self) {
+            Self::Review(inner) => (inner.common, inner.ctx),
+            Self::FlashingFail(inner) => (inner.common, inner.ctx),
             _ => panic!("Unexpected page"),
         };
 
-        let is_download = state.is_download();
-        let customization = state.customization.clone();
-        let img = state.selected_image.1.clone();
-        let dst = state.selected_dest.clone();
+        let customization = ctx.customization.clone();
+        let img = ctx.selected_image.1.clone();
+        let dst = ctx.selected_dest.clone();
 
         tracing::info!("Starting Flashing Process");
-        tracing::info!("Selected Board: {:#?}", state.selected_board);
+        tracing::info!("Selected Board: {:#?}", ctx.selected_board);
         tracing::info!("Selected Image: {:#?}", img);
         tracing::info!("Selected Destination: {:#?}", dst);
         tracing::info!("Selected Customization: {:#?}", customization);
@@ -307,15 +307,11 @@ impl BBImager {
         let (t, h) = Task::stream(s).abortable();
 
         *self = Self::Flashing(state::FlashingState {
-            is_download,
-            common: state.common,
-            selected_board: state.selected_board,
+            common,
+            ctx,
             cancel_flashing: h,
             progress: bb_flasher::DownloadFlashingStatus::Preparing,
             start_timestamp: None,
-            selected_image: state.selected_image,
-            selected_dest: state.selected_dest,
-            customization: state.customization,
         });
 
         t
@@ -340,17 +336,12 @@ impl BBImager {
         *self = match std::mem::take(self) {
             Self::ChooseOs(inner) => Self::ChooseBoard(inner.into()),
             Self::ChooseDest(inner) => Self::ChooseOs(inner.into()),
-            Self::Customize(inner) => Self::ChooseDest(inner.into()),
+            Self::Customize(inner) => Self::ChooseDest(inner.ctx.choose_dest(inner.common)),
             Self::Review(inner) => {
-                if helpers::no_customization(
-                    inner.selected_image.1.flasher(),
-                    &inner.selected_image.1,
-                )
-                .is_none()
-                {
+                if inner.ctx.has_customization {
                     Self::Customize(inner)
                 } else {
-                    Self::ChooseDest(inner.into())
+                    Self::ChooseDest(inner.ctx.choose_dest(inner.common))
                 }
             }
             Self::AppInfo(inner) => inner.page.into(),
@@ -414,31 +405,37 @@ impl BBImager {
                     .selected_dest
                     .expect("Destination should already be selcted");
 
-                if let Some(customization) = helpers::no_customization(
-                    inner.selected_image.1.flasher(),
-                    &inner.selected_image.1,
-                ) {
-                    Self::Review(state::CustomizeState {
-                        common: inner.common,
+                let flasher = inner.selected_image.1.flasher();
+
+                // A flasher with nothing to configure skips the Customize page.
+                let (customization, has_customization) =
+                    match helpers::no_customization(flasher, &inner.selected_image.1) {
+                        Some(c) => (c, false),
+                        None => (
+                            helpers::FlashingCustomization::new(
+                                flasher,
+                                &inner.selected_image.1,
+                                &inner.common.app_config,
+                            ),
+                            true,
+                        ),
+                    };
+
+                let page = state::CustomizeState {
+                    common: inner.common,
+                    ctx: state::FlashingContext {
                         selected_board: inner.selected_board,
                         selected_image: inner.selected_image,
                         selected_dest,
                         customization,
-                    })
-                } else {
-                    let temp = helpers::FlashingCustomization::new(
-                        inner.selected_image.1.flasher(),
-                        &inner.selected_image.1,
-                        &inner.common.app_config,
-                    );
+                        has_customization,
+                    },
+                };
 
-                    Self::Customize(state::CustomizeState {
-                        common: inner.common,
-                        selected_board: inner.selected_board,
-                        selected_image: inner.selected_image,
-                        selected_dest,
-                        customization: temp,
-                    })
+                if has_customization {
+                    Self::Customize(page)
+                } else {
+                    Self::Review(page)
                 }
             }
             Self::Customize(inner) => Self::Review(inner),
@@ -463,7 +460,7 @@ impl BBImager {
                     self.scroll_reset(),
                 ])
             }
-            Self::Review(inner) => match &inner.customization {
+            Self::Review(inner) => match &inner.ctx.customization {
                 // Both variants are backed by the same `sysconf` slot, matching how
                 // `FlashingCustomization::new` loads them.
                 helpers::FlashingCustomization::LinuxSdSysconfig(c)

--- a/bb-imager-gui/src/message.rs
+++ b/bb-imager-gui/src/message.rs
@@ -350,13 +350,13 @@ pub(crate) fn update(state: &mut BBImager, message: BBImagerMessage) -> Task<BBI
         },
         BBImagerMessage::UpdateFlashConfig(x) => match state {
             BBImager::Customize(inner) => {
-                inner.customization = x;
+                inner.ctx.customization = x;
             }
             _ => panic!("Unexpected message"),
         },
         BBImagerMessage::ResetFlashingConfig => match state {
             BBImager::Customize(inner) => {
-                inner.customization.reset();
+                inner.ctx.customization.reset();
             }
             _ => panic!("Unexpected message"),
         },
@@ -367,7 +367,7 @@ pub(crate) fn update(state: &mut BBImager, message: BBImagerMessage) -> Task<BBI
                 BBImager::Flashing(inner) => {
                     inner.cancel_flashing.abort();
 
-                    if inner.is_download {
+                    if inner.ctx.is_download() {
                         msg = "Download cancelled by user";
                     }
                     BBImager::FlashingCancel(inner.into())
@@ -376,7 +376,7 @@ pub(crate) fn update(state: &mut BBImager, message: BBImagerMessage) -> Task<BBI
                     OverlayData::Flashing(flashing_state) => {
                         flashing_state.cancel_flashing.abort();
 
-                        if flashing_state.is_download {
+                        if flashing_state.ctx.is_download() {
                             msg = "Download cancelled by user";
                         }
 
@@ -404,41 +404,29 @@ pub(crate) fn update(state: &mut BBImager, message: BBImagerMessage) -> Task<BBI
 
             *state = match std::mem::take(state) {
                 BBImager::Flashing(inner) => {
-                    if inner.is_download {
+                    if inner.ctx.is_download() {
                         msg = "Download failed";
                     }
 
-                    BBImager::FlashingFail(crate::state::FlashingFailState {
-                        common: inner.common,
-                        err,
-                        logs,
-                        selected_board: inner.selected_board,
-                        selected_image: inner.selected_image,
-                        selected_dest: inner.selected_dest,
-                        customization: inner.customization,
-                    })
+                    BBImager::FlashingFail(crate::state::FlashingFailState::new(inner, err, logs))
                 }
-                BBImager::AppInfo(inner) => match inner.page {
-                    OverlayData::Flashing(flashing_state) => {
-                        if flashing_state.is_download {
-                            msg = "Download failed";
-                        }
+                BBImager::AppInfo(inner) => {
+                    match inner.page {
+                        OverlayData::Flashing(flashing_state) => {
+                            if flashing_state.ctx.is_download() {
+                                msg = "Download failed";
+                            }
 
-                        BBImager::AppInfo(OverlayState {
-                            page: OverlayData::FlashingFail(crate::state::FlashingFailState {
-                                common: flashing_state.common,
-                                err,
-                                logs,
-                                selected_board: flashing_state.selected_board,
-                                selected_image: flashing_state.selected_image,
-                                selected_dest: flashing_state.selected_dest,
-                                customization: flashing_state.customization,
-                            }),
-                            ..inner
-                        })
+                            BBImager::AppInfo(OverlayState {
+                                page: OverlayData::FlashingFail(
+                                    crate::state::FlashingFailState::new(flashing_state, err, logs),
+                                ),
+                                ..inner
+                            })
+                        }
+                        _ => panic!("Unexpected message"),
                     }
-                    _ => panic!("Unexpected message"),
-                },
+                }
                 _ => panic!("Unexpected message"),
             };
 
@@ -463,14 +451,14 @@ pub(crate) fn update(state: &mut BBImager, message: BBImagerMessage) -> Task<BBI
 
             *state = match std::mem::take(state) {
                 BBImager::Flashing(inner) => {
-                    if inner.is_download {
+                    if inner.ctx.is_download() {
                         msg = "Download finished successfully";
                     }
                     BBImager::FlashingSuccess(inner.into())
                 }
                 BBImager::AppInfo(inner) => match inner.page {
                     OverlayData::Flashing(flashing_state) => {
-                        if flashing_state.is_download {
+                        if flashing_state.ctx.is_download() {
                             msg = "Download finished successfully";
                         }
 

--- a/bb-imager-gui/src/state.rs
+++ b/bb-imager-gui/src/state.rs
@@ -194,12 +194,6 @@ impl ChooseOsState {
     }
 }
 
-impl From<CustomizeState> for ChooseOsState {
-    fn from(value: CustomizeState) -> Self {
-        ChooseDestState::from(value).into()
-    }
-}
-
 impl From<ChooseDestState> for ChooseOsState {
     fn from(value: ChooseDestState) -> Self {
         Self {
@@ -249,13 +243,43 @@ impl ChooseDestState {
     }
 }
 
-impl From<CustomizeState> for ChooseDestState {
-    fn from(value: CustomizeState) -> Self {
-        Self {
-            common: value.common,
-            selected_board: value.selected_board,
-            selected_image: value.selected_image,
-            selected_dest: Some(value.selected_dest),
+/// The choices that make up a flashing job.
+///
+/// Complete once a destination has been picked, and carried unchanged from
+/// there through Customize, Review, Flashing and the failure page.
+#[derive(Debug)]
+pub(crate) struct FlashingContext {
+    pub(crate) selected_board: Board,
+    pub(crate) selected_image: (OsImageId, helpers::BoardImage),
+    pub(crate) selected_dest: helpers::Destination,
+    pub(crate) customization: helpers::FlashingCustomization,
+    /// Whether the Customize page is part of this flow.
+    ///
+    /// Decided once, when the destination is picked, so going back from Review
+    /// does not have to ask [`helpers::no_customization`] the same question a
+    /// second time and hope it answers consistently.
+    pub(crate) has_customization: bool,
+}
+
+impl FlashingContext {
+    pub(crate) fn selected_destination(&self) -> String {
+        match self.selected_dest.size() {
+            Some(x) => format!("{} ({})", self.selected_dest, helpers::pretty_bytes(x)),
+            None => self.selected_dest.to_string(),
+        }
+    }
+
+    pub(crate) fn is_download(&self) -> bool {
+        self.selected_dest.is_download_action()
+    }
+
+    /// Rebuild the destination page this context was completed on.
+    pub(crate) fn choose_dest(self, common: BBImagerCommon) -> ChooseDestState {
+        ChooseDestState {
+            common,
+            selected_board: self.selected_board,
+            selected_image: self.selected_image,
+            selected_dest: Some(self.selected_dest),
             destinations: Box::default(),
             filter_destination: true,
             search_text: "".into(),
@@ -266,10 +290,7 @@ impl From<CustomizeState> for ChooseDestState {
 #[derive(Debug)]
 pub(crate) struct CustomizeState {
     pub(crate) common: BBImagerCommon,
-    pub(crate) selected_board: Board,
-    pub(crate) selected_image: (OsImageId, helpers::BoardImage),
-    pub(crate) selected_dest: helpers::Destination,
-    pub(crate) customization: helpers::FlashingCustomization,
+    pub(crate) ctx: FlashingContext,
 }
 
 impl CustomizeState {
@@ -282,30 +303,15 @@ impl CustomizeState {
             BBImagerMessage::Null
         }))
     }
-
-    pub(crate) fn selected_destination(&self) -> String {
-        match self.selected_dest.size() {
-            Some(x) => format!("{} ({})", self.selected_dest, helpers::pretty_bytes(x)),
-            None => self.selected_dest.to_string(),
-        }
-    }
-
-    pub(crate) fn is_download(&self) -> bool {
-        self.selected_dest.is_download_action()
-    }
 }
 
 #[derive(Debug)]
 pub(crate) struct FlashingState {
     pub(crate) common: BBImagerCommon,
-    pub(crate) selected_board: Board,
+    pub(crate) ctx: FlashingContext,
     pub(crate) cancel_flashing: iced::task::Handle,
     pub(crate) progress: bb_flasher::DownloadFlashingStatus,
     pub(crate) start_timestamp: Option<Instant>,
-    pub(crate) is_download: bool,
-    pub(crate) selected_image: (OsImageId, helpers::BoardImage),
-    pub(crate) selected_dest: helpers::Destination,
-    pub(crate) customization: helpers::FlashingCustomization,
 }
 
 impl FlashingState {
@@ -369,31 +375,31 @@ pub(crate) struct FlashingFinishState {
 impl From<FlashingState> for FlashingFinishState {
     fn from(value: FlashingState) -> Self {
         Self {
+            is_download: value.ctx.is_download(),
             common: value.common,
-            selected_board: value.selected_board,
-            is_download: value.is_download,
+            selected_board: value.ctx.selected_board,
         }
     }
 }
 
 pub(crate) struct FlashingFailState {
     pub(crate) common: BBImagerCommon,
+    pub(crate) ctx: FlashingContext,
     pub(crate) err: String,
     pub(crate) logs: widget::text_editor::Content,
-    pub(crate) selected_board: Board,
-    pub(crate) selected_image: (OsImageId, helpers::BoardImage),
-    pub(crate) selected_dest: helpers::Destination,
-    pub(crate) customization: helpers::FlashingCustomization,
 }
 
-impl From<FlashingFailState> for CustomizeState {
-    fn from(value: FlashingFailState) -> Self {
+impl FlashingFailState {
+    pub(crate) fn new(
+        state: FlashingState,
+        err: String,
+        logs: widget::text_editor::Content,
+    ) -> Self {
         Self {
-            common: value.common,
-            selected_board: value.selected_board,
-            selected_image: value.selected_image,
-            selected_dest: value.selected_dest,
-            customization: value.customization,
+            common: state.common,
+            ctx: state.ctx,
+            err,
+            logs,
         }
     }
 }

--- a/bb-imager-gui/src/ui/configuration.rs
+++ b/bb-imager-gui/src/ui/configuration.rs
@@ -22,7 +22,7 @@ pub(crate) fn view<'a>(state: &'a crate::state::CustomizeState) -> Element<'a, B
             widget::button("BACK")
                 .on_press(BBImagerMessage::Back)
                 .style(widget::button::secondary),
-            widget::button("NEXT").on_press_maybe(if state.customization.validate() {
+            widget::button("NEXT").on_press_maybe(if state.ctx.customization.validate() {
                 Some(BBImagerMessage::Next)
             } else {
                 None
@@ -32,7 +32,7 @@ pub(crate) fn view<'a>(state: &'a crate::state::CustomizeState) -> Element<'a, B
 }
 
 fn customization_pane<'a>(state: &'a crate::state::CustomizeState) -> Element<'a, BBImagerMessage> {
-    match &state.customization {
+    match &state.ctx.customization {
         FlashingCustomization::LinuxSdSysconfig(inner) => linux_sd_card_sysconfig(state, inner),
         FlashingCustomization::LinuxSdCloudInit(inner) => linux_sd_card_cloudinit(state, inner),
         _ => panic!("No customization"),

--- a/bb-imager-gui/src/ui/flash.rs
+++ b/bb-imager-gui/src/ui/flash.rs
@@ -10,7 +10,7 @@ use crate::{BBImagerMessage, state::FlashingState};
 
 pub(crate) fn view(state: &FlashingState) -> Element<'_, BBImagerMessage> {
     page_type1(
-        helpers::board_view_pane(&state.selected_board, &state.common),
+        helpers::board_view_pane(&state.ctx.selected_board, &state.common),
         progress_view(state),
         [button("Cancel")
             .style(widget::button::danger)

--- a/bb-imager-gui/src/ui/review.rs
+++ b/bb-imager-gui/src/ui/review.rs
@@ -13,7 +13,7 @@ use crate::{
 const HEADING_SIZE: u32 = 26;
 
 pub(crate) fn view<'a>(state: &'a CustomizeState) -> Element<'a, BBImagerMessage> {
-    let btn_label = if state.is_download() {
+    let btn_label = if state.ctx.is_download() {
         "DOWNLOAD"
     } else {
         "WRITE"
@@ -42,18 +42,18 @@ fn review_view<'a>(state: &'a CustomizeState) -> Element<'a, BBImagerMessage> {
             .size(HEADING_SIZE),
         widget::grid![
             text("Device"),
-            text(state.selected_board.name.as_str()),
+            text(state.ctx.selected_board.name.as_str()),
             text("Operating System"),
-            text(state.selected_image.1.to_string()),
+            text(state.ctx.selected_image.1.to_string()),
             text("Storage"),
-            text(state.selected_destination())
+            text(state.ctx.selected_destination())
         ]
         .height(iced::Length::Shrink)
         .spacing(8)
         .columns(2),
     ];
 
-    let modifications = state.customization.modifications();
+    let modifications = state.ctx.customization.modifications();
     if !modifications.is_empty() {
         col = col.extend([
             widget::rule::horizontal(2).into(),


### PR DESCRIPTION
The board, image, destination and customization that define a flashing job were declared field by field on CustomizeState, FlashingState and FlashingFailState, and shuttled between them by two From impls that existed only to copy the four across. Adding a fifth choice meant editing three structs and both conversions.

Group them into FlashingContext, built once when the destination is picked and moved from page to page unchanged.

The context also records whether the Customize page is part of this flow. Going back from Review used to re-derive that by asking no_customization about the image a second time, which only works as long as both calls agree; the answer is now taken at the point the decision is made.

is_download stops being a stored flag on FlashingState and becomes a question asked of the destination, so it cannot drift from the destination it describes.


Claude-Session: https://claude.ai/code/session_01YRkEsJHsbTNJVZtgmtYjPV