### PR TITLE
Add basic Accessibility support

### DIFF
--- a/bb-imager-gui/Cargo.toml
+++ b/bb-imager-gui/Cargo.toml
@@ -47,7 +47,7 @@ ashpd = { version = "0.13", features = ["notification"] }
 bb-flasher = { path = "../bb-flasher", features = ["sd_macos_authopen"] }
 
 [features]
-default = ["static"]
+default = ["static", "sd"]
 sd = ["bb-flasher/sd"]
 bcf_cc1352p7 = ["bb-flasher/bcf"]
 # GUI requires the base board support for any sub soc firmware

--- a/bb-imager-gui/src/constants.rs
+++ b/bb-imager-gui/src/constants.rs
@@ -42,7 +42,8 @@ pub(crate) const FONT_BOLD: iced::Font = {
 };
 
 // Base Fonts
-pub(crate) const FONT_NORMAL_BYTES: &[u8] = include_bytes!("../assets/fonts/Nunito-Regular-subset.ttf");
+pub(crate) const FONT_NORMAL_BYTES: &[u8] =
+    include_bytes!("../assets/fonts/Nunito-Regular-subset.ttf");
 pub(crate) const FONT_BOLD_BYTES: &[u8] = include_bytes!("../assets/fonts/Nunito-Bold-subset.ttf");
 
 // Theme
@@ -52,6 +53,33 @@ pub(crate) const HAIR_LIGHT_BROWN: iced::Color = color!(171, 131, 60);
 pub(crate) const BACKGROUND: iced::Color = color!(30, 30, 30);
 pub(crate) const CARD: iced::Color = color!(45, 45, 45);
 pub(crate) const DANGER: iced::Color = color!(255, 0, 0);
+
+const HC_BACKGROUND: iced::Color = color!(0, 0, 0);
+const HC_TEXT: iced::Color = color!(255, 255, 255);
+
+pub(crate) fn is_high_contrast_palette(palette: &iced::theme::Palette) -> bool {
+    palette.background == HC_BACKGROUND
+}
+
+/// Inner and outer focus-ring colors.
+///
+/// High contrast uses a black inner stroke plus a white outer stroke so the
+/// ring stays visible on both yellow primary buttons and dark fills. The
+/// default theme is a single white ring (inner == outer).
+pub(crate) fn focus_ring_colors(high_contrast: bool) -> (iced::Color, iced::Color) {
+    if high_contrast {
+        (HC_BACKGROUND, HC_TEXT)
+    } else {
+        (iced::Color::WHITE, iced::Color::WHITE)
+    }
+}
+
+pub(crate) fn focus_ring_width(high_contrast: bool) -> f32 {
+    if high_contrast { 4.0 } else { 3.0 }
+}
+
+/// How far the focus ring sits outside the button bounds.
+pub(crate) const FOCUS_RING_OUTSET: f32 = 3.0;
 
 pub(crate) const KEYMAP_LAYOUTS: &[&str] = &[
     "af", "al", "am", "ara", "at", "au", "az", "ba", "bd", "be", "bg", "br", "brai", "bt", "bw",

--- a/bb-imager-gui/src/constants.rs
+++ b/bb-imager-gui/src/constants.rs
@@ -47,6 +47,9 @@ pub(crate) const FONT_NORMAL_BYTES: &[u8] =
 pub(crate) const FONT_BOLD_BYTES: &[u8] = include_bytes!("../assets/fonts/Nunito-Bold-subset.ttf");
 
 // Theme
+pub(crate) const DEFAULT_THEME: &str = "Beagle";
+pub(crate) const HIGH_CONTRAST_THEME: &str = "Beagle High Contrast";
+
 pub(crate) const TONGUE_ORANGE: iced::Color = color!(242, 105, 53);
 pub(crate) const CHECK_MARK_GREEN: iced::Color = color!(142, 201, 105);
 pub(crate) const HAIR_LIGHT_BROWN: iced::Color = color!(171, 131, 60);
@@ -56,6 +59,58 @@ pub(crate) const DANGER: iced::Color = color!(255, 0, 0);
 
 const HC_BACKGROUND: iced::Color = color!(0, 0, 0);
 const HC_TEXT: iced::Color = color!(255, 255, 255);
+const HC_PRIMARY: iced::Color = color!(255, 255, 0);
+const HC_SUCCESS: iced::Color = color!(0, 255, 128);
+const HC_WARNING: iced::Color = color!(255, 200, 0);
+const HC_DANGER: iced::Color = color!(255, 80, 80);
+
+pub(crate) fn theme_palette(high_contrast: bool) -> (&'static str, iced::theme::Palette) {
+    if high_contrast {
+        (
+            HIGH_CONTRAST_THEME,
+            iced::theme::Palette {
+                background: HC_BACKGROUND,
+                text: HC_TEXT,
+                primary: HC_PRIMARY,
+                success: HC_SUCCESS,
+                warning: HC_WARNING,
+                danger: HC_DANGER,
+            },
+        )
+    } else {
+        (
+            DEFAULT_THEME,
+            iced::theme::Palette {
+                background: BACKGROUND,
+                text: iced::Color::WHITE,
+                primary: TONGUE_ORANGE,
+                success: CHECK_MARK_GREEN,
+                warning: HAIR_LIGHT_BROWN,
+                danger: DANGER,
+            },
+        )
+    }
+}
+
+pub(crate) fn progress_primary(high_contrast: bool) -> iced::Color {
+    if high_contrast {
+        HC_PRIMARY
+    } else {
+        TONGUE_ORANGE
+    }
+}
+
+pub(crate) fn progress_success(high_contrast: bool) -> iced::Color {
+    if high_contrast {
+        HC_SUCCESS
+    } else {
+        CHECK_MARK_GREEN
+    }
+}
+
+pub(crate) fn progress_danger(high_contrast: bool) -> iced::Color {
+    if high_contrast { HC_DANGER } else { DANGER }
+}
 
 pub(crate) fn is_high_contrast_palette(palette: &iced::theme::Palette) -> bool {
     palette.background == HC_BACKGROUND
@@ -136,5 +191,25 @@ mod tests {
         assert_eq!(keymap_layout(""), None);
         // Matching is exact: the table is lowercase, locale regions are not.
         assert_eq!(keymap_layout("US"), None);
+    }
+
+    #[test]
+    fn high_contrast_palette_is_distinct_and_detected() {
+        let (_, default) = super::theme_palette(false);
+        let (_, hc) = super::theme_palette(true);
+
+        assert_ne!(default.background, hc.background);
+        assert_ne!(default.primary, hc.primary);
+        assert!(super::is_high_contrast_palette(&hc));
+        assert!(!super::is_high_contrast_palette(&default));
+    }
+
+    #[test]
+    fn focus_ring_is_not_primary_fill() {
+        let (_, hc) = super::theme_palette(true);
+        let (inner, outer) = super::focus_ring_colors(true);
+        assert_ne!(inner, hc.primary);
+        assert_ne!(outer, hc.primary);
+        assert_ne!(inner, outer);
     }
 }

--- a/bb-imager-gui/src/focus_scroll.rs
+++ b/bb-imager-gui/src/focus_scroll.rs
@@ -1,0 +1,285 @@
+//! Scroll ancestor [`iced::widget::scrollable`] panes so a target widget
+//! stays visible.
+
+use iced::advanced::widget::{self, Operation};
+use iced::{Rectangle, Task, Vector};
+use widget::operation::{Focusable, Outcome, Scrollable, scrollable::AbsoluteOffset};
+
+use crate::message::BBImagerMessage;
+
+enum Phase {
+    Find,
+    Apply,
+}
+
+enum Target {
+    Focused,
+    Id(widget::Id),
+}
+
+struct ScrollIntoView {
+    target: Target,
+    phase: Phase,
+    found_bounds: Option<Rectangle>,
+}
+
+impl ScrollIntoView {
+    const fn focused() -> Self {
+        Self {
+            target: Target::Focused,
+            phase: Phase::Find,
+            found_bounds: None,
+        }
+    }
+
+    fn widget(id: widget::Id) -> Self {
+        Self {
+            target: Target::Id(id),
+            phase: Phase::Find,
+            found_bounds: None,
+        }
+    }
+}
+
+fn scroll_padding() -> f32 {
+    crate::constants::FOCUS_RING_OUTSET + 8.0
+}
+
+/// Visible slice of `viewport` in the same coordinate space as content widgets.
+///
+/// iced reports child layout bounds in unscrolled content space and passes the
+/// current scroll offset as `translation`. Adding it maps the clip rect into
+/// that space.
+fn visible_rect(viewport: Rectangle, translation: Vector) -> Rectangle {
+    Rectangle {
+        x: viewport.x + translation.x,
+        y: viewport.y + translation.y,
+        width: viewport.width,
+        height: viewport.height,
+    }
+}
+
+/// How far to scroll each axis so `focus` is visible inside `visible`.
+fn scroll_delta(visible: Rectangle, focus: Rectangle, pad: f32) -> (f32, f32) {
+    let mut delta_x = 0.0;
+    let mut delta_y = 0.0;
+
+    let focus_top = focus.y;
+    let focus_bottom = focus.y + focus.height;
+    let focus_left = focus.x;
+    let focus_right = focus.x + focus.width;
+
+    let view_top = visible.y + pad;
+    let view_bottom = visible.y + visible.height - pad;
+    let view_left = visible.x + pad;
+    let view_right = visible.x + visible.width - pad;
+
+    if focus_top < view_top {
+        delta_y = focus_top - view_top;
+    } else if focus_bottom > view_bottom {
+        delta_y = focus_bottom - view_bottom;
+    }
+
+    if focus_left < view_left {
+        delta_x = focus_left - view_left;
+    } else if focus_right > view_right {
+        delta_x = focus_right - view_right;
+    }
+
+    (delta_x, delta_y)
+}
+
+fn scroll_rect_into_view(
+    state: &mut dyn Scrollable,
+    viewport: Rectangle,
+    content_bounds: Rectangle,
+    translation: Vector,
+    focus: Rectangle,
+) {
+    // Board/OS/destination screens have two scrollables. Only move the pane
+    // that actually contains the target; otherwise the other pane jumps.
+    if !content_bounds.intersects(&focus) {
+        return;
+    }
+
+    let visible = visible_rect(viewport, translation);
+    let (delta_x, delta_y) = scroll_delta(visible, focus, scroll_padding());
+
+    if delta_x.abs() > f32::EPSILON || delta_y.abs() > f32::EPSILON {
+        state.scroll_by(
+            AbsoluteOffset {
+                x: delta_x,
+                y: delta_y,
+            },
+            viewport,
+            content_bounds,
+        );
+    }
+}
+
+impl ScrollIntoView {
+    fn consider(&mut self, id: Option<&widget::Id>, bounds: Rectangle, focused: bool) {
+        if !matches!(self.phase, Phase::Find) {
+            return;
+        }
+
+        match &self.target {
+            Target::Focused if focused => self.found_bounds = Some(bounds),
+            Target::Id(want) if id == Some(want) => self.found_bounds = Some(bounds),
+            _ => {}
+        }
+    }
+}
+
+impl Operation<()> for ScrollIntoView {
+    fn traverse(&mut self, operate: &mut dyn FnMut(&mut dyn Operation<()>)) {
+        operate(self);
+    }
+
+    fn container(&mut self, id: Option<&widget::Id>, bounds: Rectangle) {
+        self.consider(id, bounds, false);
+    }
+
+    fn focusable(&mut self, id: Option<&widget::Id>, bounds: Rectangle, state: &mut dyn Focusable) {
+        self.consider(id, bounds, state.is_focused());
+    }
+
+    fn scrollable(
+        &mut self,
+        _id: Option<&widget::Id>,
+        bounds: Rectangle,
+        content_bounds: Rectangle,
+        translation: Vector,
+        state: &mut dyn Scrollable,
+    ) {
+        if matches!(self.phase, Phase::Apply)
+            && let Some(focus) = self.found_bounds
+        {
+            scroll_rect_into_view(state, bounds, content_bounds, translation, focus);
+        }
+    }
+
+    fn finish(&self) -> Outcome<()> {
+        if matches!(self.phase, Phase::Find) && self.found_bounds.is_some() {
+            return Outcome::Chain(Box::new(Self {
+                phase: Phase::Apply,
+                found_bounds: self.found_bounds,
+                target: match &self.target {
+                    Target::Focused => Target::Focused,
+                    Target::Id(id) => Target::Id(id.clone()),
+                },
+            }));
+        }
+
+        Outcome::None
+    }
+}
+
+pub(crate) fn scroll_focused_into_view() -> Task<BBImagerMessage> {
+    iced::advanced::widget::operate(ScrollIntoView::focused()).map(|()| BBImagerMessage::Null)
+}
+
+pub(crate) fn scroll_widget_into_view(id: widget::Id) -> Task<BBImagerMessage> {
+    iced::advanced::widget::operate(ScrollIntoView::widget(id)).map(|()| BBImagerMessage::Null)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scrolls_up_when_focus_is_above_viewport() {
+        let visible = Rectangle {
+            x: 0.0,
+            y: 100.0,
+            width: 200.0,
+            height: 300.0,
+        };
+        let focus = Rectangle {
+            x: 10.0,
+            y: 50.0,
+            width: 80.0,
+            height: 24.0,
+        };
+
+        let (_, delta_y) = scroll_delta(visible, focus, 8.0);
+        assert!(delta_y < 0.0);
+    }
+
+    #[test]
+    fn scrolls_down_when_focus_is_below_viewport() {
+        let visible = Rectangle {
+            x: 0.0,
+            y: 0.0,
+            width: 200.0,
+            height: 100.0,
+        };
+        let focus = Rectangle {
+            x: 10.0,
+            y: 120.0,
+            width: 80.0,
+            height: 24.0,
+        };
+
+        let (_, delta_y) = scroll_delta(visible, focus, 8.0);
+        assert!(delta_y > 0.0);
+    }
+
+    #[test]
+    fn no_scroll_when_focus_is_fully_visible() {
+        let visible = Rectangle {
+            x: 0.0,
+            y: 0.0,
+            width: 200.0,
+            height: 200.0,
+        };
+        let focus = Rectangle {
+            x: 20.0,
+            y: 50.0,
+            width: 80.0,
+            height: 24.0,
+        };
+
+        let (delta_x, delta_y) = scroll_delta(visible, focus, 8.0);
+        assert_eq!(delta_x, 0.0);
+        assert_eq!(delta_y, 0.0);
+    }
+
+    #[test]
+    fn translation_maps_viewport_into_content_space() {
+        let viewport = Rectangle {
+            x: 0.0,
+            y: 0.0,
+            width: 200.0,
+            height: 100.0,
+        };
+        let visible = visible_rect(viewport, Vector { x: 0.0, y: 50.0 });
+        let focus = Rectangle {
+            x: 10.0,
+            y: 0.0,
+            width: 80.0,
+            height: 24.0,
+        };
+
+        let (_, delta_y) = scroll_delta(visible, focus, 8.0);
+        assert!(delta_y < 0.0, "scrolled-away top widget should scroll up");
+    }
+
+    #[test]
+    fn sibling_pane_content_does_not_intersect_focus() {
+        let left_content = Rectangle {
+            x: 0.0,
+            y: 0.0,
+            width: 200.0,
+            height: 800.0,
+        };
+        let focus_in_right = Rectangle {
+            x: 250.0,
+            y: 40.0,
+            width: 80.0,
+            height: 24.0,
+        };
+
+        assert!(!left_content.intersects(&focus_in_right));
+    }
+}

--- a/bb-imager-gui/src/helpers.rs
+++ b/bb-imager-gui/src/helpers.rs
@@ -984,7 +984,9 @@ impl<'a> DestinationItem<'a> {
 
     pub(crate) fn is_selected(&'a self, dst: &'a Destination) -> bool {
         match self {
-            DestinationItem::SaveToFile(_) => false,
+            // After the file picker, the selection is a `LocalFile` path; this
+            // list row is the action that produced it, so match by variant.
+            DestinationItem::SaveToFile(_) => matches!(dst, Destination::LocalFile(_)),
             DestinationItem::Destination(d) => dst.eq(d),
         }
     }
@@ -1409,10 +1411,10 @@ mod tests {
     #[test]
     fn destination_item_save_to_file() {
         let item = DestinationItem::SaveToFile("os.img.xz".to_string());
-        let other = Destination::LocalFile(PathBuf::from("/tmp/x"));
+        let selected = Destination::LocalFile(PathBuf::from("/tmp/x"));
 
         assert_eq!(item.to_string(), "Save To File");
-        assert!(!item.is_selected(&other));
+        assert!(item.is_selected(&selected));
         assert!(item.subtitle().is_none());
         match item.msg() {
             BBImagerMessage::SelectFileDest(name) => assert_eq!(name, "os.img"),

--- a/bb-imager-gui/src/keyboard.rs
+++ b/bb-imager-gui/src/keyboard.rs
@@ -1,0 +1,133 @@
+//! Global keyboard shortcuts for the GUI.
+//!
+//! List navigation and Escape are handled even when the runtime marks an event
+//! as captured (macOS often does this while no widget is focused). Tab and
+//! Enter defer to widgets when captured so text fields keep working.
+
+use iced::Subscription;
+use iced::event::{self, Status};
+use iced::keyboard::{self, Key, key::Named};
+
+use crate::message::BBImagerMessage;
+
+pub(crate) fn subscription() -> Subscription<BBImagerMessage> {
+    event::listen_with(key_message)
+}
+
+fn key_message(
+    event: iced::Event,
+    status: Status,
+    _window: iced::window::Id,
+) -> Option<BBImagerMessage> {
+    let iced::Event::Keyboard(keyboard::Event::KeyPressed { key, modifiers, .. }) = event else {
+        return None;
+    };
+
+    if (modifiers.control() || modifiers.command())
+        && matches!(key, Key::Character(ref c) if c.as_str() == "f")
+    {
+        return Some(BBImagerMessage::FocusSearch);
+    }
+
+    match key {
+        Key::Named(Named::ArrowUp) => Some(BBImagerMessage::KeyboardListPrevious),
+        Key::Named(Named::ArrowDown) => Some(BBImagerMessage::KeyboardListNext),
+        Key::Named(Named::Escape) => Some(BBImagerMessage::KeyboardEscape),
+        Key::Named(Named::Enter) if status == Status::Ignored => {
+            Some(BBImagerMessage::KeyboardEnter)
+        }
+        Key::Named(Named::Tab) if status == Status::Ignored => Some(BBImagerMessage::KeyboardTab {
+            shift: modifiers.shift(),
+        }),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key_press(key: Key, modifiers: keyboard::Modifiers) -> iced::Event {
+        iced::Event::Keyboard(keyboard::Event::KeyPressed {
+            key: key.clone(),
+            modified_key: key,
+            physical_key: keyboard::key::Physical::Unidentified(
+                keyboard::key::NativeCode::Unidentified,
+            ),
+            location: keyboard::Location::Standard,
+            modifiers,
+            text: None,
+            repeat: false,
+        })
+    }
+
+    #[test]
+    fn focus_search_shortcut() {
+        let msg = key_message(
+            key_press(Key::Character("f".into()), keyboard::Modifiers::COMMAND),
+            Status::Captured,
+            iced::window::Id::unique(),
+        );
+        assert!(matches!(msg, Some(BBImagerMessage::FocusSearch)));
+    }
+
+    #[test]
+    fn arrow_keys_work_when_captured() {
+        assert!(matches!(
+            key_message(
+                key_press(Key::Named(Named::ArrowDown), keyboard::Modifiers::empty()),
+                Status::Captured,
+                iced::window::Id::unique(),
+            ),
+            Some(BBImagerMessage::KeyboardListNext)
+        ));
+    }
+
+    #[test]
+    fn enter_ignored_when_captured() {
+        assert!(
+            key_message(
+                key_press(Key::Named(Named::Enter), keyboard::Modifiers::empty()),
+                Status::Captured,
+                iced::window::Id::unique(),
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn enter_when_ignored() {
+        assert!(matches!(
+            key_message(
+                key_press(Key::Named(Named::Enter), keyboard::Modifiers::empty()),
+                Status::Ignored,
+                iced::window::Id::unique(),
+            ),
+            Some(BBImagerMessage::KeyboardEnter)
+        ));
+    }
+
+    #[test]
+    fn shift_tab_when_ignored() {
+        assert!(matches!(
+            key_message(
+                key_press(Key::Named(Named::Tab), keyboard::Modifiers::SHIFT),
+                Status::Ignored,
+                iced::window::Id::unique(),
+            ),
+            Some(BBImagerMessage::KeyboardTab { shift: true })
+        ));
+    }
+
+    #[test]
+    fn escape_is_delivered_even_when_captured() {
+        assert!(matches!(
+            key_message(
+                key_press(Key::Named(Named::Escape), keyboard::Modifiers::empty()),
+                Status::Captured,
+                iced::window::Id::unique(),
+            ),
+            Some(BBImagerMessage::KeyboardEscape)
+        ));
+    }
+}

--- a/bb-imager-gui/src/main.rs
+++ b/bb-imager-gui/src/main.rs
@@ -153,17 +153,9 @@ impl BBImager {
     }
 
     fn theme(&self) -> iced::Theme {
-        iced::Theme::custom(
-            "Beagle",
-            iced::theme::Palette {
-                background: constants::BACKGROUND,
-                text: iced::Color::WHITE,
-                primary: constants::TONGUE_ORANGE,
-                success: constants::CHECK_MARK_GREEN,
-                warning: constants::HAIR_LIGHT_BROWN,
-                danger: constants::DANGER,
-            },
-        )
+        let high_contrast = self.common().app_config.high_contrast;
+        let (name, palette) = constants::theme_palette(high_contrast);
+        iced::Theme::custom(name, palette)
     }
 
     fn scroll_selection(&self) -> Task<BBImagerMessage> {

--- a/bb-imager-gui/src/main.rs
+++ b/bb-imager-gui/src/main.rs
@@ -13,7 +13,9 @@ use crate::{helpers::blocking_future, state::BBImagerCommon};
 
 mod constants;
 mod db;
+mod focus_scroll;
 mod helpers;
+mod keyboard;
 mod message;
 mod persistance;
 mod state;
@@ -52,11 +54,11 @@ fn main() -> iced::Result {
         Some(image::ImageFormat::Png),
     )
     .ok();
-    assert!(icon.is_some());
-
-    #[cfg(target_os = "macos")]
-    // HACK: mac_notification_sys set application name (not an option in notify-rust)
-    let _ = notify_rust::set_application("org.beagleboard.imagingutility");
+    if icon.is_none() {
+        tracing::warn!(
+            "Window icon could not be loaded (is git-lfs installed and have you run `git lfs pull`?)"
+        );
+    }
 
     let settings = iced::window::Settings {
         min_size: Some(constants::WINDOW_SIZE),
@@ -64,6 +66,10 @@ fn main() -> iced::Result {
         icon,
         ..Default::default()
     };
+
+    #[cfg(all(target_os = "macos", feature = "notify-rust"))]
+    // HACK: mac_notification_sys set application name (not an option in notify-rust)
+    let _ = notify_rust::set_application("org.beagleboard.imagingutility");
 
     iced::application(BBImager::new, message::update, ui::view)
         .title(helpers::app_title)
@@ -129,6 +135,8 @@ impl BBImager {
             img_handle_cache: bb_iced_widgets::cached_icon::Cache::default(),
 
             scroll_id: widget::Id::unique(),
+            search_id: widget::Id::unique(),
+            list_selection_id: widget::Id::unique(),
             db: db.clone(),
         };
 
@@ -156,6 +164,74 @@ impl BBImager {
                 danger: constants::DANGER,
             },
         )
+    }
+
+    fn scroll_selection(&self) -> Task<BBImagerMessage> {
+        crate::focus_scroll::scroll_widget_into_view(self.common().list_selection_id.clone())
+    }
+
+    fn focus_search(&self) -> Task<BBImagerMessage> {
+        match self {
+            Self::ChooseBoard(_) | Self::ChooseOs(_) | Self::ChooseDest(_) => {
+                widget::operation::focus(self.common().search_id.clone())
+                    .chain(focus_scroll::scroll_focused_into_view())
+            }
+            _ => Task::none(),
+        }
+    }
+
+    fn keyboard_tab(&self, shift: bool) -> Task<BBImagerMessage> {
+        let focus = if shift {
+            widget::operation::focus_previous()
+        } else {
+            widget::operation::focus_next()
+        };
+
+        focus.chain(focus_scroll::scroll_focused_into_view())
+    }
+
+    fn keyboard_escape_message(&self) -> Option<BBImagerMessage> {
+        match self {
+            Self::ChooseBoard(x) if !x.search_text.is_empty() => {
+                Some(BBImagerMessage::UpdateSearchText("".into()))
+            }
+            Self::ChooseOs(x) if !x.search_text.is_empty() => {
+                Some(BBImagerMessage::UpdateSearchText("".into()))
+            }
+            Self::ChooseOs(x) if x.pos.is_some() => Some(BBImagerMessage::GotoOsListParent),
+            Self::ChooseDest(x) if !x.search_text.is_empty() => {
+                Some(BBImagerMessage::UpdateSearchText("".into()))
+            }
+            Self::ChooseBoard(_) | Self::Flashing(_) => None,
+            Self::AppInfo(_)
+            | Self::ChooseOs(_)
+            | Self::ChooseDest(_)
+            | Self::Customize(_)
+            | Self::Review(_) => Some(BBImagerMessage::Back),
+            _ => None,
+        }
+    }
+
+    fn keyboard_enter_message(&self) -> Option<BBImagerMessage> {
+        match self {
+            Self::ChooseBoard(x) if x.selected_board.is_some() => Some(BBImagerMessage::Next),
+            Self::ChooseOs(x) if x.selected_image.is_some() => Some(BBImagerMessage::Next),
+            Self::ChooseDest(x) if x.selected_dest.is_some() => Some(BBImagerMessage::Next),
+            Self::Customize(x) if x.ctx.customization.validate() => Some(BBImagerMessage::Next),
+            Self::Review(_) => Some(BBImagerMessage::FlashStart),
+            Self::FlashingFail(_) => Some(BBImagerMessage::Retry),
+            Self::FlashingCancel(_) | Self::FlashingSuccess(_) => Some(BBImagerMessage::Restart),
+            _ => None,
+        }
+    }
+
+    fn keyboard_list_message(&self, delta: i32) -> Option<BBImagerMessage> {
+        match self {
+            Self::ChooseBoard(x) => x.list_select_relative(delta),
+            Self::ChooseOs(x) => x.list_select_relative(delta),
+            Self::ChooseDest(x) => x.list_select_relative(delta),
+            _ => None,
+        }
     }
 
     fn common_mut(&mut self) -> &mut BBImagerCommon {
@@ -219,7 +295,9 @@ impl BBImager {
     fn subscription(&self) -> Subscription<BBImagerMessage> {
         const INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
 
-        match self {
+        let keyboard = crate::keyboard::subscription();
+
+        let destinations = match self {
             Self::ChooseDest(x) => Subscription::run_with(
                 (
                     x.selected_image.1.flasher(),
@@ -247,7 +325,9 @@ impl BBImager {
                 },
             ),
             _ => Subscription::none(),
-        }
+        };
+
+        Subscription::batch([keyboard, destinations])
     }
 
     fn start_flashing(&mut self) -> Task<BBImagerMessage> {

--- a/bb-imager-gui/src/message.rs
+++ b/bb-imager-gui/src/message.rs
@@ -105,6 +105,9 @@ pub(crate) enum BBImagerMessage {
     },
     KeyboardListPrevious,
     KeyboardListNext,
+
+    /// High-contrast theme toggle (App Info)
+    SetHighContrast(bool),
 }
 
 pub(crate) fn update(state: &mut BBImager, message: BBImagerMessage) -> Task<BBImagerMessage> {
@@ -614,6 +617,16 @@ pub(crate) fn update(state: &mut BBImager, message: BBImagerMessage) -> Task<BBI
             if let Some(msg) = state.keyboard_list_message(1) {
                 return update(state, msg);
             }
+        }
+        BBImagerMessage::SetHighContrast(enabled) => {
+            state.common_mut().app_config.high_contrast = enabled;
+            let config = state.common().app_config.clone();
+            return Task::future(blocking_future(move || {
+                if let Err(e) = config.save() {
+                    tracing::error!("Failed to save config: {e}");
+                }
+                BBImagerMessage::Null
+            }));
         }
         BBImagerMessage::Null => {}
     }

--- a/bb-imager-gui/src/message.rs
+++ b/bb-imager-gui/src/message.rs
@@ -95,6 +95,16 @@ pub(crate) enum BBImagerMessage {
 
     /// Search
     UpdateSearchText(Arc<str>),
+
+    /// Keyboard navigation
+    FocusSearch,
+    KeyboardEscape,
+    KeyboardEnter,
+    KeyboardTab {
+        shift: bool,
+    },
+    KeyboardListPrevious,
+    KeyboardListNext,
 }
 
 pub(crate) fn update(state: &mut BBImager, message: BBImagerMessage) -> Task<BBImagerMessage> {
@@ -120,17 +130,20 @@ pub(crate) fn update(state: &mut BBImager, message: BBImagerMessage) -> Task<BBI
                 _ => {}
             }
         }
-        BBImagerMessage::SelectBoard(b) => match state {
-            BBImager::ChooseBoard(inner) => {
-                inner.selected_board = Some(b);
-            }
-            BBImager::AppInfo(overlay_state) => {
-                if let OverlayData::ChooseBoard(inner) = &mut overlay_state.page {
-                    inner.selected_board = Some(b)
+        BBImagerMessage::SelectBoard(b) => {
+            match state {
+                BBImager::ChooseBoard(inner) => {
+                    inner.selected_board = Some(b);
                 }
+                BBImager::AppInfo(overlay_state) => {
+                    if let OverlayData::ChooseBoard(inner) = &mut overlay_state.page {
+                        inner.selected_board = Some(b)
+                    }
+                }
+                _ => {}
             }
-            _ => {}
-        },
+            return state.scroll_selection();
+        }
         BBImagerMessage::UpdateOsList((imgs, pos)) => {
             match state {
                 BBImager::ChooseOs(inner) => inner.update_images(imgs, pos),
@@ -145,7 +158,9 @@ pub(crate) fn update(state: &mut BBImager, message: BBImagerMessage) -> Task<BBI
         BBImagerMessage::SelectOs(id) => match state {
             BBImager::ChooseOs(inner) => match id {
                 helpers::OsImageId::Format => {
-                    inner.selected_image = Some((id, helpers::BoardImage::format()))
+                    let scroll = inner.common.list_selection_id.clone();
+                    inner.selected_image = Some((id, helpers::BoardImage::format()));
+                    return crate::focus_scroll::scroll_widget_into_view(scroll);
                 }
                 helpers::OsImageId::Local(flasher) => {
                     let extensions = helpers::file_filter(flasher);
@@ -190,15 +205,9 @@ pub(crate) fn update(state: &mut BBImager, message: BBImagerMessage) -> Task<BBI
             },
             _ => panic!("Unexpected message"),
         },
-        BBImagerMessage::SelectRemoteOs((image, flasher)) => match state {
-            BBImager::ChooseOs(inner) => {
-                inner.selected_image = Some((
-                    helpers::OsImageId::OsImage(image.id),
-                    helpers::BoardImage::remote(image, flasher, inner.common.downloader.clone()),
-                ));
-            }
-            BBImager::AppInfo(overlay_state) => {
-                if let OverlayData::ChooseOs(inner) = &mut overlay_state.page {
+        BBImagerMessage::SelectRemoteOs((image, flasher)) => {
+            match state {
+                BBImager::ChooseOs(inner) => {
                     inner.selected_image = Some((
                         helpers::OsImageId::OsImage(image.id),
                         helpers::BoardImage::remote(
@@ -208,9 +217,22 @@ pub(crate) fn update(state: &mut BBImager, message: BBImagerMessage) -> Task<BBI
                         ),
                     ));
                 }
+                BBImager::AppInfo(overlay_state) => {
+                    if let OverlayData::ChooseOs(inner) = &mut overlay_state.page {
+                        inner.selected_image = Some((
+                            helpers::OsImageId::OsImage(image.id),
+                            helpers::BoardImage::remote(
+                                image,
+                                flasher,
+                                inner.common.downloader.clone(),
+                            ),
+                        ));
+                    }
+                }
+                _ => {}
             }
-            _ => {}
-        },
+            return state.scroll_selection();
+        }
         BBImagerMessage::SelectLocalOs(image) => match state {
             BBImager::ChooseOs(inner) => {
                 inner.selected_image = Some((helpers::OsImageId::Local(image.flasher()), image))
@@ -321,12 +343,13 @@ pub(crate) fn update(state: &mut BBImager, message: BBImagerMessage) -> Task<BBI
                 inner.destinations = x;
             }
         }
-        BBImagerMessage::SelectDest(x) => match state {
-            BBImager::ChooseDest(inner) => {
-                inner.selected_dest = Some(x);
+        BBImagerMessage::SelectDest(x) => {
+            match state {
+                BBImager::ChooseDest(inner) => inner.selected_dest = Some(x),
+                _ => panic!("Unexpected message"),
             }
-            _ => panic!("Unexpected message"),
-        },
+            return state.scroll_selection();
+        }
         BBImagerMessage::SelectFileDest(x) => {
             return Task::perform(
                 async move {
@@ -568,6 +591,28 @@ pub(crate) fn update(state: &mut BBImager, message: BBImagerMessage) -> Task<BBI
                 && let Some((_, img)) = &mut inner.selected_image
             {
                 img.update_init_format(f);
+            }
+        }
+        BBImagerMessage::FocusSearch => return state.focus_search(),
+        BBImagerMessage::KeyboardEscape => {
+            if let Some(msg) = state.keyboard_escape_message() {
+                return update(state, msg);
+            }
+        }
+        BBImagerMessage::KeyboardEnter => {
+            if let Some(msg) = state.keyboard_enter_message() {
+                return update(state, msg);
+            }
+        }
+        BBImagerMessage::KeyboardTab { shift } => return state.keyboard_tab(shift),
+        BBImagerMessage::KeyboardListPrevious => {
+            if let Some(msg) = state.keyboard_list_message(-1) {
+                return update(state, msg);
+            }
+        }
+        BBImagerMessage::KeyboardListNext => {
+            if let Some(msg) = state.keyboard_list_message(1) {
+                return update(state, msg);
             }
         }
         BBImagerMessage::Null => {}

--- a/bb-imager-gui/src/persistance.rs
+++ b/bb-imager-gui/src/persistance.rs
@@ -5,9 +5,15 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
+fn skip_false(v: &bool) -> bool {
+    !*v
+}
+
 /// Configuration for GUI that should be presisted
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct GuiConfiguration {
+    #[serde(default, skip_serializing_if = "skip_false")]
+    pub(crate) high_contrast: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) sd_customization: Option<SdCustomization>,
 }
@@ -323,6 +329,15 @@ mod tests {
         gui.update_sd_customization(SdCustomization::default());
 
         assert!(gui.sd_customization.is_some());
+    }
+
+    #[test]
+    fn high_contrast_defaults_false_and_omits_from_json() {
+        let json = serde_json::to_string(&GuiConfiguration::default()).unwrap();
+        assert_eq!(json, "{}");
+
+        let back: GuiConfiguration = serde_json::from_str(r#"{"high_contrast":true}"#).unwrap();
+        assert!(back.high_contrast);
     }
 
     #[test]

--- a/bb-imager-gui/src/state.rs
+++ b/bb-imager-gui/src/state.rs
@@ -22,6 +22,8 @@ pub(crate) struct BBImagerCommon {
     pub(crate) img_handle_cache: bb_iced_widgets::cached_icon::Cache<std::sync::Arc<url::Url>>,
 
     pub(crate) scroll_id: widget::Id,
+    pub(crate) search_id: widget::Id,
+    pub(crate) list_selection_id: widget::Id,
     pub(crate) db: db::Db,
 }
 
@@ -79,6 +81,22 @@ impl ChooseBoardState {
     pub(crate) fn update_search(&mut self, search: Arc<str>) -> Task<BBImagerMessage> {
         self.search_text = search;
         self.refresh_board_list()
+    }
+
+    pub(crate) fn list_select_relative(&self, delta: i32) -> Option<BBImagerMessage> {
+        if self.boards.is_empty() {
+            return None;
+        }
+
+        let next = list_relative_index(
+            self.selected_board
+                .as_ref()
+                .and_then(|b| self.boards.iter().position(|x| x.id == b.id)),
+            self.boards.len(),
+            delta,
+        );
+
+        Some(BBImagerMessage::SelectBoardById(self.boards[next].id))
     }
 }
 
@@ -192,6 +210,22 @@ impl ChooseOsState {
         self.flasher = flasher;
         self.refresh_image_list()
     }
+
+    pub(crate) fn list_select_relative(&self, delta: i32) -> Option<BBImagerMessage> {
+        if self.images.is_empty() {
+            return None;
+        }
+
+        let next = list_relative_index(
+            self.selected_image
+                .as_ref()
+                .and_then(|(id, _)| self.images.iter().position(|x| x.id == *id)),
+            self.images.len(),
+            delta,
+        );
+
+        Some(BBImagerMessage::SelectOs(self.images[next].id))
+    }
 }
 
 impl From<ChooseDestState> for ChooseOsState {
@@ -240,6 +274,21 @@ impl ChooseDestState {
 
     pub(crate) fn update_search(&mut self, search: Arc<str>) {
         self.search_text = search;
+    }
+
+    pub(crate) fn list_select_relative(&self, delta: i32) -> Option<BBImagerMessage> {
+        let items: Vec<BBImagerMessage> = self.destinations().map(|d| d.msg()).collect();
+        if items.is_empty() {
+            return None;
+        }
+
+        let current = self
+            .selected_dest
+            .as_ref()
+            .and_then(|sel| self.destinations().position(|d| d.is_selected(sel)));
+
+        let next = list_relative_index(current, items.len(), delta);
+        Some(items[next].clone())
     }
 }
 
@@ -517,9 +566,16 @@ impl OverlayState {
     }
 }
 
+fn list_relative_index(current: Option<usize>, len: usize, delta: i32) -> usize {
+    debug_assert!(len > 0);
+
+    let current = current.unwrap_or(if delta >= 0 { len.saturating_sub(1) } else { 0 });
+    ((current as i32 + delta).rem_euclid(len as i32)) as usize
+}
+
 #[cfg(test)]
 mod tests {
-    use super::time_remaining_from;
+    use super::{list_relative_index, time_remaining_from};
     use bb_flasher::DownloadFlashingStatus;
     use std::time::Duration;
 
@@ -564,6 +620,17 @@ mod tests {
             ),
             None
         );
+    }
+
+    #[test]
+    fn list_relative_index_wraps_forward() {
+        assert_eq!(list_relative_index(Some(2), 5, 1), 3);
+        assert_eq!(list_relative_index(Some(4), 5, 1), 0);
+    }
+
+    #[test]
+    fn list_relative_index_wraps_backward() {
+        assert_eq!(list_relative_index(Some(0), 5, -1), 4);
     }
 
     #[test]

--- a/bb-imager-gui/src/ui/app_info.rs
+++ b/bb-imager-gui/src/ui/app_info.rs
@@ -3,7 +3,9 @@ use iced::{Element, widget};
 use crate::{
     message::BBImagerMessage,
     state::OverlayState,
-    ui::helpers::{VIEW_COL_PADDING, WINDOW_ICON, element_with_label, page_type3, selectable_text},
+    ui::helpers::{
+        self, VIEW_COL_PADDING, WINDOW_ICON, element_with_label, page_type3, selectable_text,
+    },
 };
 
 const INP_BOX_WIDTH: u32 = 420;
@@ -11,7 +13,7 @@ const INP_BOX_WIDTH: u32 = 420;
 pub(crate) fn view<'a>(state: &'a OverlayState) -> Element<'a, BBImagerMessage> {
     page_type3(
         review_view(state),
-        [widget::button("BACK")
+        [helpers::action_button("BACK")
             .on_press(BBImagerMessage::Back)
             .style(widget::button::secondary)],
     )

--- a/bb-imager-gui/src/ui/app_info.rs
+++ b/bb-imager-gui/src/ui/app_info.rs
@@ -20,11 +20,19 @@ pub(crate) fn view<'a>(state: &'a OverlayState) -> Element<'a, BBImagerMessage> 
 }
 
 fn review_view<'a>(state: &'a OverlayState) -> Element<'a, BBImagerMessage> {
+    let high_contrast = state.common().app_config.high_contrast;
+
     let col = widget::column![
         widget::image(WINDOW_ICON.clone()),
         crate::constants::APP_NAME,
         crate::constants::APP_RELEASE,
         crate::constants::APP_DESC,
+        widget::rule::horizontal(2),
+        helpers::focusable_toggler(
+            high_contrast,
+            "High contrast theme",
+            BBImagerMessage::SetHighContrast,
+        ),
         widget::rule::horizontal(2),
         element_with_label(
             "Cache Directory",

--- a/bb-imager-gui/src/ui/board_selection.rs
+++ b/bb-imager-gui/src/ui/board_selection.rs
@@ -1,4 +1,4 @@
-use iced::{Element, widget};
+use iced::Element;
 
 use crate::{BBImagerMessage, state::ChooseBoardState, ui::helpers};
 
@@ -8,37 +8,40 @@ pub(crate) fn view<'a>(state: &'a ChooseBoardState) -> Element<'a, BBImagerMessa
     helpers::page_type1(
         board_list_pane(state),
         board_view_pane(state),
-        [widget::button("NEXT")
+        [helpers::action_button("NEXT")
             .on_press_maybe(state.selected_board.as_ref().map(|_| BBImagerMessage::Next))],
     )
 }
 
 fn board_list_pane<'a>(state: &'a ChooseBoardState) -> Element<'a, BBImagerMessage> {
-    let items = state
-        .boards
-        .iter()
-        .map(|dev| {
-            let is_selected = state
-                .selected_board
-                .as_ref()
-                .map(|x| x.id == dev.id)
-                .unwrap_or(false);
-            let img = helpers::network_image_or_default(
-                &state.common.img_handle_cache,
-                dev.icon.as_ref(),
-                helpers::BOARD_ICON.clone(),
-                ICON_WIDTH,
-                iced::Shrink,
-            );
-            helpers::list_item(
-                [img, helpers::list_label(&dev.name).into()],
-                is_selected,
-                BBImagerMessage::SelectBoardById(dev.id),
-            )
-        })
-        .map(Into::into);
+    let items = state.boards.iter().map(|dev| {
+        let is_selected = state
+            .selected_board
+            .as_ref()
+            .map(|x| x.id == dev.id)
+            .unwrap_or(false);
+        let img = helpers::network_image_or_default(
+            &state.common.img_handle_cache,
+            dev.icon.as_ref(),
+            helpers::BOARD_ICON.clone(),
+            ICON_WIDTH,
+            iced::Shrink,
+        );
+        helpers::list_item(
+            [img, helpers::list_label(&dev.name).into()],
+            is_selected,
+            BBImagerMessage::SelectBoardById(dev.id),
+            &state.common.list_selection_id,
+        )
+    });
 
-    helpers::list_pane(&state.search_text, &state.common.scroll_id, [], items)
+    helpers::list_pane(
+        &state.search_text,
+        &state.common.scroll_id,
+        &state.common.search_id,
+        [],
+        items,
+    )
 }
 
 fn board_view_pane<'a>(state: &'a ChooseBoardState) -> Element<'a, BBImagerMessage> {

--- a/bb-imager-gui/src/ui/configuration.rs
+++ b/bb-imager-gui/src/ui/configuration.rs
@@ -7,7 +7,10 @@ use crate::{
     BBImagerMessage,
     helpers::{self, FlashingCustomization},
     persistance,
-    ui::helpers::{detail_pane, element_with_element, element_with_label, page_type2},
+    ui::helpers::{
+        action_button, detail_pane, element_with_element, element_with_label, focusable_toggler,
+        page_type2,
+    },
 };
 
 const INPUT_WIDTH: u32 = 200;
@@ -16,13 +19,13 @@ pub(crate) fn view<'a>(state: &'a crate::state::CustomizeState) -> Element<'a, B
     page_type2(
         customization_pane(state),
         [
-            widget::button("RESET")
+            action_button("RESET")
                 .style(widget::button::danger)
                 .on_press(BBImagerMessage::ResetFlashingConfig),
-            widget::button("BACK")
+            action_button("BACK")
                 .on_press(BBImagerMessage::Back)
                 .style(widget::button::secondary),
-            widget::button("NEXT").on_press_maybe(if state.ctx.customization.validate() {
+            action_button("NEXT").on_press_maybe(if state.ctx.customization.validate() {
                 Some(BBImagerMessage::Next)
             } else {
                 None
@@ -47,14 +50,14 @@ fn linux_sd_card_common<'a>(
     let mut col = widget::column([]);
 
     // Username and Password
-    col = col.push(
-        widget::toggler(config.user.is_some())
-            .label("Configure Username and Password")
-            .on_toggle(move |t| {
-                let c = if t { Some(Default::default()) } else { None };
-                BBImagerMessage::UpdateFlashConfig(wrap(config.clone().update_user(c)))
-            }),
-    );
+    col = col.push(focusable_toggler(
+        config.user.is_some(),
+        "Configure Username and Password",
+        move |t| {
+            let c = if t { Some(Default::default()) } else { None };
+            BBImagerMessage::UpdateFlashConfig(wrap(config.clone().update_user(c)))
+        },
+    ));
     if let Some(usr) = config.user.as_ref() {
         col = col.extend([
             input_with_label(
@@ -91,14 +94,14 @@ fn linux_sd_card_common<'a>(
     col = col.push(widget::rule::horizontal(2));
 
     // Wifi
-    col = col.push(
-        widget::toggler(config.wifi.is_some())
-            .label("Configure Wireless LAN")
-            .on_toggle(move |t| {
-                let c = if t { Some(Default::default()) } else { None };
-                BBImagerMessage::UpdateFlashConfig(wrap(config.clone().update_wifi(c)))
-            }),
-    );
+    col = col.push(focusable_toggler(
+        config.wifi.is_some(),
+        "Configure Wireless LAN",
+        move |t| {
+            let c = if t { Some(Default::default()) } else { None };
+            BBImagerMessage::UpdateFlashConfig(wrap(config.clone().update_wifi(c)))
+        },
+    ));
     if let Some(wifi) = config.wifi.as_ref() {
         col = col.extend([
             input_with_label(
@@ -135,19 +138,17 @@ fn linux_sd_card_common<'a>(
     col = col.push(widget::rule::horizontal(2));
 
     // Timezone
-    let toggle = widget::toggler(config.timezone.is_some())
-        .label("Set Timezone")
-        .on_toggle(move |t| {
-            let tz = if t { helpers::system_timezone() } else { None };
-            BBImagerMessage::UpdateFlashConfig(wrap(config.clone().update_timezone(tz)))
-        });
+    let toggle = focusable_toggler(config.timezone.is_some(), "Set Timezone", move |t| {
+        let tz = if t { helpers::system_timezone() } else { None };
+        BBImagerMessage::UpdateFlashConfig(wrap(config.clone().update_timezone(tz)))
+    });
     col = match config.timezone.as_ref() {
         Some(tz) => {
             let xc = config.clone();
             // The configuration stores the zone as a string, so it has to be resolved
             // back to a `Tz` for the combo box to show it as the current selection.
             col.push(element_with_element(
-                toggle.into(),
+                toggle,
                 widget::combo_box(&state.common.timezones, "Timezone", Some(tz), move |t| {
                     BBImagerMessage::UpdateFlashConfig(wrap(xc.clone().update_timezone(Some(t))))
                 })
@@ -161,15 +162,13 @@ fn linux_sd_card_common<'a>(
     col = col.push(widget::rule::horizontal(2));
 
     // Hostname
-    let toggle = widget::toggler(config.hostname.is_some())
-        .label("Set Hostname")
-        .on_toggle(move |t| {
-            let hostname = if t { Some(String::new()) } else { None };
-            BBImagerMessage::UpdateFlashConfig(wrap(config.clone().update_hostname(hostname)))
-        });
+    let toggle = focusable_toggler(config.hostname.is_some(), "Set Hostname", move |t| {
+        let hostname = if t { Some(String::new()) } else { None };
+        BBImagerMessage::UpdateFlashConfig(wrap(config.clone().update_hostname(hostname)))
+    });
     col = match config.hostname.as_ref() {
         Some(hostname) => col.push(element_with_element(
-            toggle.into(),
+            toggle,
             widget::text_input("beagle", hostname)
                 .on_input(move |inp| {
                     BBImagerMessage::UpdateFlashConfig(wrap(
@@ -185,16 +184,14 @@ fn linux_sd_card_common<'a>(
     col = col.push(widget::rule::horizontal(2));
 
     // Keymap
-    let toggle = widget::toggler(config.keymap.is_some())
-        .label("Set Keymap")
-        .on_toggle(move |t| {
-            let keymap = if t {
-                Some(helpers::system_keymap().to_string())
-            } else {
-                None
-            };
-            BBImagerMessage::UpdateFlashConfig(wrap(config.clone().update_keymap(keymap)))
-        });
+    let toggle = focusable_toggler(config.keymap.is_some(), "Set Keymap", move |t| {
+        let keymap = if t {
+            Some(helpers::system_keymap().to_string())
+        } else {
+            None
+        };
+        BBImagerMessage::UpdateFlashConfig(wrap(config.clone().update_keymap(keymap)))
+    });
     col = match config.keymap.as_ref() {
         Some(keymap) => {
             let xc = config.clone();
@@ -204,7 +201,7 @@ fn linux_sd_card_common<'a>(
             let selection = crate::constants::keymap_layout(keymap);
 
             col.push(element_with_element(
-                toggle.into(),
+                toggle,
                 widget::combo_box(
                     &state.common.keymaps,
                     "Keymap",
@@ -259,15 +256,15 @@ fn linux_sd_card_sysconfig<'a>(
 
     col = col.push(widget::rule::horizontal(2));
     // Enable USB DHCP
-    col = col.push(
-        widget::toggler(config.usb_enable_dhcp == Some(true))
-            .label("Enable USB DHCP")
-            .on_toggle(|x| {
-                BBImagerMessage::UpdateFlashConfig(FlashingCustomization::LinuxSdSysconfig(
-                    config.clone().update_usb_enable_dhcp(Some(x)),
-                ))
-            }),
-    );
+    col = col.push(focusable_toggler(
+        config.usb_enable_dhcp == Some(true),
+        "Enable USB DHCP",
+        |x| {
+            BBImagerMessage::UpdateFlashConfig(FlashingCustomization::LinuxSdSysconfig(
+                config.clone().update_usb_enable_dhcp(Some(x)),
+            ))
+        },
+    ));
 
     detail_pane(col, &state.common.scroll_id)
 }

--- a/bb-imager-gui/src/ui/destination_selection.rs
+++ b/bb-imager-gui/src/ui/destination_selection.rs
@@ -17,55 +17,58 @@ pub(crate) fn view<'a>(state: &'a ChooseDestState) -> Element<'a, BBImagerMessag
         dest_list_pane(state),
         dest_view_pane(state),
         [
-            widget::button("BACK")
+            helpers::action_button("BACK")
                 .on_press(BBImagerMessage::Back)
                 .style(widget::button::secondary),
-            widget::button("NEXT")
+            helpers::action_button("NEXT")
                 .on_press_maybe(state.selected_dest.as_ref().map(|_| BBImagerMessage::Next)),
         ],
     )
 }
 
 fn dest_list_pane<'a>(state: &'a ChooseDestState) -> Element<'a, BBImagerMessage> {
-    let items = state
-        .destinations()
-        .map(|dest| {
-            let is_selected = state
-                .selected_dest
-                .as_ref()
-                .map(|x| dest.is_selected(x))
-                .unwrap_or(false);
+    let items = state.destinations().map(|dest| {
+        let is_selected = state
+            .selected_dest
+            .as_ref()
+            .map(|x| dest.is_selected(x))
+            .unwrap_or(false);
 
-            let icon: Element<BBImagerMessage> = match dest {
-                DestinationItem::SaveToFile(_) => widget::svg(helpers::FILE_SAVE_ICON.clone()),
-                DestinationItem::Destination(_) => widget::svg(helpers::USB_ICON.clone()),
-            }
-            .height(ICON_WIDTH)
-            .width(ICON_WIDTH)
-            .style(svg_icon_style)
-            .into();
+        let icon: Element<BBImagerMessage> = match dest {
+            DestinationItem::SaveToFile(_) => widget::svg(helpers::FILE_SAVE_ICON.clone()),
+            DestinationItem::Destination(_) => widget::svg(helpers::USB_ICON.clone()),
+        }
+        .height(ICON_WIDTH)
+        .width(ICON_WIDTH)
+        .style(svg_icon_style)
+        .into();
 
-            let label: Element<'_, _> = match dest.subtitle() {
-                Some(x) => widget::column![text(dest.to_string()).size(18), text(x)]
-                    .width(iced::Length::Fill)
-                    .into(),
-                None => helpers::list_label(dest.to_string()).into(),
-            };
+        let label: Element<'_, _> = match dest.subtitle() {
+            Some(x) => widget::column![text(dest.to_string()).size(18), text(x)]
+                .width(iced::Length::Fill)
+                .into(),
+            None => helpers::list_label(dest.to_string()).into(),
+        };
 
-            helpers::list_item([icon, label], is_selected, dest.msg())
-        })
-        .map(Into::into);
+        helpers::list_item(
+            [icon, label],
+            is_selected,
+            dest.msg(),
+            &state.common.list_selection_id,
+        )
+    });
 
-    let filter_toggle = widget::container(
-        widget::toggler(!state.filter_destination)
-            .label("Show all destinations")
-            .on_toggle(|x| BBImagerMessage::DestinationFilter(!x)),
-    )
+    let filter_toggle = widget::container(helpers::focusable_toggler(
+        !state.filter_destination,
+        "Show all destinations",
+        |x| BBImagerMessage::DestinationFilter(!x),
+    ))
     .padding(16);
 
     helpers::list_pane(
         &state.search_text,
         &state.common.scroll_id,
+        &state.common.search_id,
         [filter_toggle.into(), helpers::list_separator()],
         items,
     )

--- a/bb-imager-gui/src/ui/flash.rs
+++ b/bb-imager-gui/src/ui/flash.rs
@@ -16,6 +16,7 @@ pub(crate) fn view(state: &FlashingState) -> Element<'_, BBImagerMessage> {
 }
 
 fn progress_view(state: &FlashingState) -> Element<'_, BBImagerMessage> {
+    let high_contrast = state.common.app_config.high_contrast;
     let (prog, label) = match state.progress {
         bb_flasher::DownloadFlashingStatus::Preparing => (0.0, "Preparing ..."),
         bb_flasher::DownloadFlashingStatus::DownloadingProgress(x) => (x, "Downloading ..."),
@@ -24,7 +25,12 @@ fn progress_view(state: &FlashingState) -> Element<'_, BBImagerMessage> {
         bb_flasher::DownloadFlashingStatus::Customizing => (0.99, "Customizing ..."),
     };
 
-    let progress = progress_circle(prog, 10.0f32, crate::constants::TONGUE_ORANGE, FONT_BOLD);
+    let progress = progress_circle(
+        prog,
+        10.0f32,
+        crate::constants::progress_primary(high_contrast),
+        FONT_BOLD,
+    );
 
     let mut col = widget::column![progress, widget::text(label)];
     if let Some(x) = state.time_remaining() {

--- a/bb-imager-gui/src/ui/flash.rs
+++ b/bb-imager-gui/src/ui/flash.rs
@@ -1,10 +1,7 @@
 use bb_iced_widgets::progress_circle;
-use iced::{
-    Element,
-    widget::{self, button},
-};
+use iced::{Element, widget};
 
-use crate::constants::{FONT_BOLD, TONGUE_ORANGE};
+use crate::constants::FONT_BOLD;
 use crate::ui::helpers::{self, VIEW_COL_PADDING, detail_entry, page_type1};
 use crate::{BBImagerMessage, state::FlashingState};
 
@@ -12,7 +9,7 @@ pub(crate) fn view(state: &FlashingState) -> Element<'_, BBImagerMessage> {
     page_type1(
         helpers::board_view_pane(&state.ctx.selected_board, &state.common),
         progress_view(state),
-        [button("Cancel")
+        [helpers::action_button("Cancel")
             .style(widget::button::danger)
             .on_press(BBImagerMessage::FlashCancel)],
     )
@@ -27,7 +24,7 @@ fn progress_view(state: &FlashingState) -> Element<'_, BBImagerMessage> {
         bb_flasher::DownloadFlashingStatus::Customizing => (0.99, "Customizing ..."),
     };
 
-    let progress = progress_circle(prog, 10.0f32, TONGUE_ORANGE, FONT_BOLD);
+    let progress = progress_circle(prog, 10.0f32, crate::constants::TONGUE_ORANGE, FONT_BOLD);
 
     let mut col = widget::column![progress, widget::text(label)];
     if let Some(x) = state.time_remaining() {

--- a/bb-imager-gui/src/ui/flash_finish.rs
+++ b/bb-imager-gui/src/ui/flash_finish.rs
@@ -1,8 +1,10 @@
 use iced::Element;
-use iced::widget::{self, button};
+use iced::widget;
 
 use crate::state::{FlashingFailState, FlashingFinishState};
-use crate::ui::helpers::{board_view_pane, page_type1, progress_finish_view, selectable_text};
+use crate::ui::helpers::{
+    action_button, board_view_pane, page_type1, progress_finish_view, selectable_text,
+};
 use crate::{BBImagerMessage, constants};
 
 pub(crate) fn fail(state: &FlashingFailState) -> Element<'_, BBImagerMessage> {
@@ -10,10 +12,10 @@ pub(crate) fn fail(state: &FlashingFailState) -> Element<'_, BBImagerMessage> {
         info_view(state),
         progress_finish_view("Failed", constants::DANGER, &state.err),
         [
-            button("Flash New")
+            action_button("Flash New")
                 .style(widget::button::danger)
                 .on_press(BBImagerMessage::Restart),
-            button("Retry")
+            action_button("Retry")
                 .style(widget::button::primary)
                 .on_press(BBImagerMessage::Retry),
         ],
@@ -39,7 +41,7 @@ pub(crate) fn cancel(state: &FlashingFinishState) -> Element<'_, BBImagerMessage
             constants::DANGER,
             "Flashing Cancelled by the user",
         ),
-        [button("Restart")
+        [action_button("Restart")
             .style(widget::button::danger)
             .on_press(BBImagerMessage::Restart)],
     )
@@ -55,7 +57,7 @@ pub(crate) fn success(state: &FlashingFinishState) -> Element<'_, BBImagerMessag
     page_type1(
         board_view_pane(&state.selected_board, &state.common),
         progress_finish_view("100%", constants::CHECK_MARK_GREEN, msg),
-        [button("Flash Another")
+        [action_button("Flash Another")
             .style(widget::button::primary)
             .on_press(BBImagerMessage::Restart)],
     )

--- a/bb-imager-gui/src/ui/flash_finish.rs
+++ b/bb-imager-gui/src/ui/flash_finish.rs
@@ -8,9 +8,14 @@ use crate::ui::helpers::{
 use crate::{BBImagerMessage, constants};
 
 pub(crate) fn fail(state: &FlashingFailState) -> Element<'_, BBImagerMessage> {
+    let high_contrast = state.common.app_config.high_contrast;
     page_type1(
         info_view(state),
-        progress_finish_view("Failed", constants::DANGER, &state.err),
+        progress_finish_view(
+            "Failed",
+            constants::progress_danger(high_contrast),
+            &state.err,
+        ),
         [
             action_button("Flash New")
                 .style(widget::button::danger)
@@ -34,11 +39,12 @@ pub(crate) fn info_view(state: &FlashingFailState) -> Element<'_, BBImagerMessag
 }
 
 pub(crate) fn cancel(state: &FlashingFinishState) -> Element<'_, BBImagerMessage> {
+    let high_contrast = state.common.app_config.high_contrast;
     page_type1(
         board_view_pane(&state.selected_board, &state.common),
         progress_finish_view(
             "Cancelled",
-            constants::DANGER,
+            constants::progress_danger(high_contrast),
             "Flashing Cancelled by the user",
         ),
         [action_button("Restart")
@@ -48,6 +54,7 @@ pub(crate) fn cancel(state: &FlashingFinishState) -> Element<'_, BBImagerMessage
 }
 
 pub(crate) fn success(state: &FlashingFinishState) -> Element<'_, BBImagerMessage> {
+    let high_contrast = state.common.app_config.high_contrast;
     let msg = if state.is_download {
         "Successfully Downloaded Image"
     } else {
@@ -56,7 +63,7 @@ pub(crate) fn success(state: &FlashingFinishState) -> Element<'_, BBImagerMessag
 
     page_type1(
         board_view_pane(&state.selected_board, &state.common),
-        progress_finish_view("100%", constants::CHECK_MARK_GREEN, msg),
+        progress_finish_view("100%", constants::progress_success(high_contrast), msg),
         [action_button("Flash Another")
             .style(widget::button::primary)
             .on_press(BBImagerMessage::Restart)],

--- a/bb-imager-gui/src/ui/focusable.rs
+++ b/bb-imager-gui/src/ui/focusable.rs
@@ -1,0 +1,326 @@
+//! Widgets that participate in Tab focus order (iced 0.14 [`widget::button`]
+//! and [`widget::toggler`] do not).
+
+use iced::advanced::Renderer as _;
+use iced::advanced::layout::{self, Layout};
+use iced::advanced::renderer;
+use iced::advanced::widget::operation::Focusable as FocusableOp;
+use iced::advanced::widget::tree::{self, Tree};
+use iced::advanced::widget::{Operation, Widget};
+use iced::advanced::{Clipboard, Shell};
+use iced::keyboard;
+use iced::mouse;
+use iced::widget::button as iced_button;
+use iced::{Border, Color, Element, Event, Length, Rectangle, Size, Theme};
+
+use crate::message::BBImagerMessage;
+
+#[derive(Debug, Default)]
+struct State {
+    focused: bool,
+}
+
+impl FocusableOp for State {
+    fn is_focused(&self) -> bool {
+        self.focused
+    }
+
+    fn focus(&mut self) {
+        self.focused = true;
+    }
+
+    fn unfocus(&mut self) {
+        self.focused = false;
+    }
+}
+
+/// Builder for a focusable [`iced_button`].
+pub(crate) struct FocusableButtonBuilder<'a> {
+    content: Element<'a, BBImagerMessage>,
+    on_press: Option<BBImagerMessage>,
+    width: Length,
+    height: Length,
+    style: Option<iced_button::StyleFn<'a, Theme>>,
+}
+
+impl<'a> FocusableButtonBuilder<'a> {
+    pub(crate) fn new(content: impl Into<Element<'a, BBImagerMessage>>) -> Self {
+        Self {
+            content: content.into(),
+            on_press: None,
+            width: Length::Shrink,
+            height: Length::Shrink,
+            style: None,
+        }
+    }
+
+    pub(crate) fn on_press(mut self, message: BBImagerMessage) -> Self {
+        self.on_press = Some(message);
+        self
+    }
+
+    pub(crate) fn on_press_maybe(mut self, message: Option<BBImagerMessage>) -> Self {
+        self.on_press = message;
+        self
+    }
+
+    pub(crate) fn style(
+        mut self,
+        style: impl Fn(&Theme, iced_button::Status) -> iced_button::Style + 'a,
+    ) -> Self {
+        self.style = Some(Box::new(style));
+        self
+    }
+
+    pub(crate) fn width(mut self, width: impl Into<Length>) -> Self {
+        self.width = width.into();
+        self
+    }
+
+    pub(crate) fn height(mut self, height: impl Into<Length>) -> Self {
+        self.height = height.into();
+        self
+    }
+
+    fn into_focusable(self) -> Focusable<'a> {
+        let mut button = iced_button(self.content)
+            .width(self.width)
+            .height(self.height);
+
+        if let Some(style) = self.style {
+            button = button.style(style);
+        }
+
+        button = button.on_press_maybe(self.on_press.clone());
+
+        Focusable::new(button.into(), self.on_press)
+    }
+}
+
+/// Wraps any widget so it joins iced's Tab cycle and activates on Enter or Space.
+pub(crate) struct Focusable<'a> {
+    inner: Element<'a, BBImagerMessage>,
+    on_press: Option<BBImagerMessage>,
+}
+
+impl<'a> Focusable<'a> {
+    fn new(inner: Element<'a, BBImagerMessage>, on_press: Option<BBImagerMessage>) -> Self {
+        Self { inner, on_press }
+    }
+}
+
+impl<'a> Widget<BBImagerMessage, Theme, iced::Renderer> for Focusable<'a> {
+    fn tag(&self) -> tree::Tag {
+        tree::Tag::of::<State>()
+    }
+
+    fn state(&self) -> tree::State {
+        tree::State::new(State::default())
+    }
+
+    fn children(&self) -> Vec<Tree> {
+        vec![Tree::new(&self.inner)]
+    }
+
+    fn diff(&self, tree: &mut Tree) {
+        tree.diff_children(std::slice::from_ref(&self.inner));
+    }
+
+    fn size(&self) -> Size<Length> {
+        self.inner.as_widget().size()
+    }
+
+    fn layout(
+        &mut self,
+        tree: &mut Tree,
+        renderer: &iced::Renderer,
+        limits: &layout::Limits,
+    ) -> layout::Node {
+        self.inner
+            .as_widget_mut()
+            .layout(&mut tree.children[0], renderer, limits)
+    }
+
+    fn operate(
+        &mut self,
+        tree: &mut Tree,
+        layout: Layout<'_>,
+        renderer: &iced::Renderer,
+        operation: &mut dyn Operation,
+    ) {
+        let state = tree.state.downcast_mut::<State>();
+        if self.on_press.is_some() {
+            // `None` keeps us in Tab order by tree position. A fresh
+            // `Id::unique()` every `view()` would be wasted work and would
+            // break `focus(id)` if anything ever targeted these widgets.
+            operation.focusable(None, layout.bounds(), state);
+        } else {
+            state.unfocus();
+        }
+
+        self.inner
+            .as_widget_mut()
+            .operate(&mut tree.children[0], layout, renderer, operation);
+    }
+
+    fn update(
+        &mut self,
+        tree: &mut Tree,
+        event: &Event,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        renderer: &iced::Renderer,
+        clipboard: &mut dyn Clipboard,
+        shell: &mut Shell<'_, BBImagerMessage>,
+        viewport: &Rectangle,
+    ) {
+        let state = tree.state.downcast_mut::<State>();
+        let over = cursor.is_over(layout.bounds());
+
+        if let Event::Keyboard(keyboard::Event::KeyPressed { key, .. }) = event
+            && state.focused
+            && matches!(
+                key,
+                keyboard::Key::Named(keyboard::key::Named::Enter)
+                    | keyboard::Key::Named(keyboard::key::Named::Space)
+            )
+            && let Some(on_press) = &self.on_press
+        {
+            shell.publish(on_press.clone());
+            shell.capture_event();
+            return;
+        }
+
+        // Same exclusive-focus pattern as iced's `text_input`: every focusable
+        // sees the press, so the one under the cursor takes focus and the rest
+        // drop it. Column/row still visit siblings after a capture.
+        if matches!(
+            event,
+            Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))
+                | Event::Touch(iced::touch::Event::FingerPressed { .. })
+        ) {
+            if over && self.on_press.is_some() {
+                state.focus();
+            } else {
+                state.unfocus();
+            }
+        }
+
+        self.inner.as_widget_mut().update(
+            &mut tree.children[0],
+            event,
+            layout,
+            cursor,
+            renderer,
+            clipboard,
+            shell,
+            viewport,
+        );
+    }
+
+    fn draw(
+        &self,
+        tree: &Tree,
+        renderer: &mut iced::Renderer,
+        theme: &Theme,
+        defaults: &renderer::Style,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+    ) {
+        self.inner.as_widget().draw(
+            &tree.children[0],
+            renderer,
+            theme,
+            defaults,
+            layout,
+            cursor,
+            viewport,
+        );
+
+        let state = tree.state.downcast_ref::<State>();
+        if state.focused {
+            draw_focus_ring(renderer, layout.bounds(), theme);
+        }
+    }
+
+    fn mouse_interaction(
+        &self,
+        tree: &Tree,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+        renderer: &iced::Renderer,
+    ) -> mouse::Interaction {
+        self.inner.as_widget().mouse_interaction(
+            &tree.children[0],
+            layout,
+            cursor,
+            viewport,
+            renderer,
+        )
+    }
+}
+
+fn draw_focus_ring(renderer: &mut iced::Renderer, bounds: Rectangle, theme: &Theme) {
+    let high_contrast = crate::constants::is_high_contrast_palette(&theme.palette());
+    let width = crate::constants::focus_ring_width(high_contrast);
+    let radius = 5.0 + crate::constants::FOCUS_RING_OUTSET;
+    let (inner_color, outer_color) = crate::constants::focus_ring_colors(high_contrast);
+
+    let mut stroke = |expand: f32, color: Color| {
+        renderer.fill_quad(
+            renderer::Quad {
+                bounds: bounds.expand(expand),
+                border: Border {
+                    width,
+                    radius: (radius + expand - crate::constants::FOCUS_RING_OUTSET).into(),
+                    color,
+                },
+                ..Default::default()
+            },
+            Color::TRANSPARENT,
+        );
+    };
+
+    if high_contrast {
+        // White outer + black inner so the ring stays visible on both yellow
+        // primary buttons and dark secondary fills.
+        stroke(crate::constants::FOCUS_RING_OUTSET + width, outer_color);
+        stroke(crate::constants::FOCUS_RING_OUTSET, inner_color);
+    } else {
+        stroke(crate::constants::FOCUS_RING_OUTSET, inner_color);
+    }
+}
+
+impl<'a> From<FocusableButtonBuilder<'a>> for Focusable<'a> {
+    fn from(builder: FocusableButtonBuilder<'a>) -> Self {
+        builder.into_focusable()
+    }
+}
+
+impl<'a> From<FocusableButtonBuilder<'a>> for Element<'a, BBImagerMessage> {
+    fn from(builder: FocusableButtonBuilder<'a>) -> Self {
+        Focusable::from(builder).into()
+    }
+}
+
+impl<'a> From<Focusable<'a>> for Element<'a, BBImagerMessage> {
+    fn from(focusable: Focusable<'a>) -> Self {
+        Element::new(focusable)
+    }
+}
+
+pub(crate) fn button<'a>(
+    content: impl Into<Element<'a, BBImagerMessage>>,
+) -> FocusableButtonBuilder<'a> {
+    FocusableButtonBuilder::new(content)
+}
+
+/// Wrap `content` so Tab can reach it and Enter/Space publishes `on_activate`.
+pub(crate) fn activate<'a>(
+    content: impl Into<Element<'a, BBImagerMessage>>,
+    on_activate: BBImagerMessage,
+) -> Element<'a, BBImagerMessage> {
+    Focusable::new(content.into(), Some(on_activate)).into()
+}

--- a/bb-imager-gui/src/ui/helpers.rs
+++ b/bb-imager-gui/src/ui/helpers.rs
@@ -33,9 +33,13 @@ pub(crate) static SEARCH_ICON: LazyLock<svg::Handle> =
 
 pub(crate) const VIEW_COL_PADDING: u16 = 16;
 pub(crate) const LIST_COL_PADDING: iced::Padding = iced::Padding {
+    top: 4.0,
     right: 16.0,
-    ..iced::Padding::ZERO
+    bottom: 8.0,
+    left: 4.0,
 };
+pub(crate) const LIST_ITEM_INSET: f32 = 4.0;
+pub(crate) const CARD_INSET: u16 = 4;
 
 pub(crate) fn card_btn_style(
     theme: &iced::Theme,
@@ -47,7 +51,12 @@ pub(crate) fn card_btn_style(
         ..Default::default()
     };
 
-    if is_selected || matches!(status, widget::button::Status::Hovered) {
+    if is_selected
+        || matches!(
+            status,
+            widget::button::Status::Hovered | widget::button::Status::Pressed
+        )
+    {
         style.border = iced::Border::default()
             .color(theme.palette().primary)
             .width(3)
@@ -73,7 +82,7 @@ pub(crate) fn svg_icon_style(theme: &iced::Theme, _: svg::Status) -> svg::Style 
 pub(crate) fn page_type1<'a>(
     col1: Element<'a, BBImagerMessage>,
     col2: Element<'a, BBImagerMessage>,
-    btns: impl IntoIterator<Item = widget::Button<'a, BBImagerMessage>>,
+    btns: impl IntoIterator<Item = impl Into<Element<'a, BBImagerMessage>>>,
 ) -> Element<'a, BBImagerMessage> {
     let row2 = widget::row(
         [
@@ -116,7 +125,7 @@ pub(crate) fn page_type1<'a>(
 /// |--------|
 pub(crate) fn page_type2<'a>(
     row1: Element<'a, BBImagerMessage>,
-    btns: impl IntoIterator<Item = widget::Button<'a, BBImagerMessage>>,
+    btns: impl IntoIterator<Item = impl Into<Element<'a, BBImagerMessage>>>,
 ) -> Element<'a, BBImagerMessage> {
     let row2 = widget::row(
         [
@@ -145,7 +154,7 @@ pub(crate) fn page_type2<'a>(
 /// |--------|
 pub(crate) fn page_type3<'a>(
     row1: Element<'a, BBImagerMessage>,
-    btns: impl IntoIterator<Item = widget::Button<'a, BBImagerMessage>>,
+    btns: impl IntoIterator<Item = impl Into<Element<'a, BBImagerMessage>>>,
 ) -> Element<'a, BBImagerMessage> {
     let row2 = widget::row(
         [widget::space::horizontal().into()]
@@ -174,7 +183,9 @@ pub(crate) fn board_view_pane<'a>(
         iced::Shrink,
     );
 
-    let copy_btn = copy_btn(COPY_ICON.clone()).on_press(BBImagerMessage::CopyBoardConfig(dev.id));
+    let copy_btn = super::focusable::button(svg(COPY_ICON.clone()))
+        .style(widget::button::secondary)
+        .on_press(BBImagerMessage::CopyBoardConfig(dev.id));
 
     let cols = widget::column![
         img,
@@ -199,7 +210,7 @@ pub(crate) fn board_view_pane<'a>(
 
     if let Some(x) = &dev.documentation {
         btns.push(
-            widget::button(widget::text("DOCUMENTATION"))
+            super::focusable::button(widget::text("DOCUMENTATION"))
                 .on_press(BBImagerMessage::OpenUrl(x.clone()))
                 .into(),
         );
@@ -209,7 +220,7 @@ pub(crate) fn board_view_pane<'a>(
         && let Ok(u) = url::Url::parse(&format!("{}/{}.html", constants::OSHW_BASE_URL, x))
     {
         btns.push(
-            widget::button(widget::text("OSHW"))
+            super::focusable::button(widget::text("OSHW"))
                 .on_press(BBImagerMessage::OpenUrl(u))
                 .into(),
         );
@@ -257,24 +268,49 @@ pub(crate) fn selectable_text(
 fn card_box<'a>(
     content: impl Into<Element<'a, BBImagerMessage>>,
 ) -> widget::Container<'a, BBImagerMessage> {
-    widget::container(content).style(|_| {
-        widget::container::Style::default()
-            .background(constants::CARD)
-            .border(iced::border::rounded(8))
-    })
+    widget::container(content)
+        .padding(CARD_INSET)
+        .style(|_: &iced::Theme| {
+            widget::container::Style::default()
+                .background(constants::CARD)
+                .border(iced::border::rounded(8))
+        })
 }
 
-fn info_btn(handle: svg::Handle) -> widget::Button<'static, BBImagerMessage> {
-    widget::button(svg(handle))
-        .on_press(BBImagerMessage::AppInfo)
+fn info_btn(handle: svg::Handle) -> super::focusable::FocusableButtonBuilder<'static> {
+    super::focusable::button(svg(handle))
         .width(iced::Shrink)
         .height(iced::Shrink)
+        .on_press(BBImagerMessage::AppInfo)
 }
 
-pub(crate) fn copy_btn<'a>(handle: svg::Handle) -> widget::Button<'a, BBImagerMessage> {
-    widget::button(svg(handle))
+pub(crate) fn copy_btn<'a>(handle: svg::Handle) -> super::focusable::FocusableButtonBuilder<'a> {
+    super::focusable::button(svg(handle))
         .width(iced::Shrink)
         .style(widget::button::secondary)
+}
+
+pub(crate) fn action_button<'a>(
+    label: &'static str,
+) -> super::focusable::FocusableButtonBuilder<'a> {
+    super::focusable::button(label)
+}
+
+/// A toggler that is in Tab order and flips on Enter or Space.
+pub(crate) fn focusable_toggler<'a, F>(
+    is_toggled: bool,
+    label: &'static str,
+    on_toggle: F,
+) -> Element<'a, BBImagerMessage>
+where
+    F: Fn(bool) -> BBImagerMessage + Clone + 'a,
+{
+    super::focusable::activate(
+        widget::toggler(is_toggled)
+            .label(label)
+            .on_toggle(on_toggle.clone()),
+        on_toggle(!is_toggled),
+    )
 }
 
 /// Horizontal separator between rows of a list pane.
@@ -289,10 +325,11 @@ pub(crate) fn list_separator<'a>() -> Element<'a, BBImagerMessage> {
 pub(crate) fn list_pane<'a>(
     search_text: &'a str,
     scroll_id: &widget::Id,
+    search_id: &widget::Id,
     header: impl IntoIterator<Item = Element<'a, BBImagerMessage>>,
     items: impl IntoIterator<Item = Element<'a, BBImagerMessage>>,
 ) -> Element<'a, BBImagerMessage> {
-    let top = [search_box(search_text).into(), list_separator()];
+    let top = [search_box(search_text, search_id).into(), list_separator()];
 
     widget::scrollable(
         widget::column(top.into_iter().chain(header).chain(items)).padding(LIST_COL_PADDING),
@@ -303,19 +340,34 @@ pub(crate) fn list_pane<'a>(
 
 /// A selectable row of a [`list_pane`], laid out as a horizontal run of
 /// `contents` (typically a leading icon followed by a label).
+///
+/// The selected row is tagged with `selection_id` so arrow-key movement can
+/// scroll it into view.
 pub(crate) fn list_item<'a>(
     contents: impl IntoIterator<Item = Element<'a, BBImagerMessage>>,
     is_selected: bool,
     msg: BBImagerMessage,
-) -> widget::Button<'a, BBImagerMessage> {
-    widget::button(
+    selection_id: &widget::Id,
+) -> Element<'a, BBImagerMessage> {
+    let btn = widget::button(
         widget::row(contents)
             .spacing(12)
             .padding(8)
             .align_y(iced::alignment::Vertical::Center),
     )
     .on_press(msg)
-    .style(move |theme, status| card_btn_style(theme, status, is_selected))
+    .width(iced::Length::Fill)
+    .style(move |theme, status| card_btn_style(theme, status, is_selected));
+
+    let row = widget::container(btn)
+        .padding(LIST_ITEM_INSET)
+        .width(iced::Length::Fill);
+
+    if is_selected {
+        row.id(selection_id.clone()).into()
+    } else {
+        row.into()
+    }
 }
 
 /// The primary label of a [`list_item`].
@@ -349,7 +401,7 @@ pub(crate) fn placeholder_pane<'a>(label: &'a str) -> Element<'a, BBImagerMessag
         .into()
 }
 
-fn search_box<'a>(inp: &'a str) -> widget::Container<'a, BBImagerMessage> {
+fn search_box<'a>(inp: &'a str, search_id: &widget::Id) -> widget::Container<'a, BBImagerMessage> {
     widget::container(
         widget::row![
             widget::svg(SEARCH_ICON.clone())
@@ -357,6 +409,7 @@ fn search_box<'a>(inp: &'a str) -> widget::Container<'a, BBImagerMessage> {
                 .width(iced::Length::Shrink)
                 .height(18),
             widget::text_input("SEARCH", inp)
+                .id(search_id.clone())
                 .style(|theme, status| {
                     let mut temp = widget::text_input::default(theme, status);
                     temp.border.width = 0.0;

--- a/bb-imager-gui/src/ui/helpers.rs
+++ b/bb-imager-gui/src/ui/helpers.rs
@@ -270,10 +270,21 @@ fn card_box<'a>(
 ) -> widget::Container<'a, BBImagerMessage> {
     widget::container(content)
         .padding(CARD_INSET)
-        .style(|_: &iced::Theme| {
-            widget::container::Style::default()
-                .background(constants::CARD)
-                .border(iced::border::rounded(8))
+        .style(|theme: &iced::Theme| {
+            if constants::is_high_contrast_palette(&theme.palette()) {
+                widget::container::Style::default()
+                    .background(theme.palette().background)
+                    .border(
+                        iced::Border::default()
+                            .color(theme.palette().text)
+                            .width(2)
+                            .rounded(8),
+                    )
+            } else {
+                widget::container::Style::default()
+                    .background(constants::CARD)
+                    .border(iced::border::rounded(8))
+            }
         })
 }
 

--- a/bb-imager-gui/src/ui/image_selection.rs
+++ b/bb-imager-gui/src/ui/image_selection.rs
@@ -1,6 +1,6 @@
 use iced::{
     Element,
-    widget::{self, button, text},
+    widget::{self, text},
 };
 
 use crate::{
@@ -16,10 +16,10 @@ pub(crate) fn view<'a>(state: &'a crate::state::ChooseOsState) -> Element<'a, BB
         os_list_pane(state),
         os_view_pane(state),
         [
-            widget::button("BACK")
+            helpers::action_button("BACK")
                 .on_press(BBImagerMessage::Back)
                 .style(widget::button::secondary),
-            widget::button("NEXT")
+            helpers::action_button("NEXT")
                 .on_press_maybe(state.selected_image.as_ref().map(|_| BBImagerMessage::Next)),
         ],
     )
@@ -35,53 +35,53 @@ fn os_list_pane<'a>(state: &'a crate::state::ChooseOsState) -> Element<'a, BBIma
         )
         .into()
     } else {
-        let items = state
-            .images
-            .iter()
-            .map(|img| {
-                let is_selected = state
-                    .selected_image
-                    .as_ref()
-                    .map(|(x, _)| *x == img.id)
-                    .unwrap_or(false);
+        let items = state.images.iter().map(|img| {
+            let is_selected = state
+                .selected_image
+                .as_ref()
+                .map(|(x, _)| *x == img.id)
+                .unwrap_or(false);
 
-                let icon: Element<BBImagerMessage> = match img.id {
-                    crate::helpers::OsImageId::Format => widget::svg(helpers::FORMAT_ICON.clone())
-                        .height(ICON_WIDTH)
-                        .width(ICON_WIDTH)
-                        .style(svg_icon_style)
-                        .into(),
-                    crate::helpers::OsImageId::Local(_) => {
-                        widget::svg(helpers::FILE_ADD_ICON.clone())
-                            .height(ICON_WIDTH)
-                            .width(ICON_WIDTH)
-                            .style(svg_icon_style)
-                            .into()
-                    }
-                    crate::helpers::OsImageId::OsImage(_)
-                    | crate::helpers::OsImageId::OsSublist(_) => bb_iced_widgets::cached_icon(
+            let icon: Element<BBImagerMessage> = match img.id {
+                crate::helpers::OsImageId::Format => widget::svg(helpers::FORMAT_ICON.clone())
+                    .height(ICON_WIDTH)
+                    .width(ICON_WIDTH)
+                    .style(svg_icon_style)
+                    .into(),
+                crate::helpers::OsImageId::Local(_) => widget::svg(helpers::FILE_ADD_ICON.clone())
+                    .height(ICON_WIDTH)
+                    .width(ICON_WIDTH)
+                    .style(svg_icon_style)
+                    .into(),
+                crate::helpers::OsImageId::OsImage(_) | crate::helpers::OsImageId::OsSublist(_) => {
+                    bb_iced_widgets::cached_icon(
                         &state.common.img_handle_cache,
                         img.icon.as_ref().expect("Missing Os Image icon"),
                     )
                     .width(ICON_WIDTH)
                     .height(ICON_WIDTH)
-                    .into(),
-                };
-
-                let mut contents = vec![icon, helpers::list_label(img.label()).into()];
-                if img.is_sublist() {
-                    contents.push(
-                        widget::svg(helpers::ARROW_FORWARD_IOS_ICON.clone())
-                            .height(20)
-                            .width(iced::Shrink)
-                            .style(svg_icon_style)
-                            .into(),
-                    );
+                    .into()
                 }
+            };
 
-                helpers::list_item(contents, is_selected, BBImagerMessage::SelectOs(img.id))
-            })
-            .map(Into::into);
+            let mut contents = vec![icon, helpers::list_label(img.label()).into()];
+            if img.is_sublist() {
+                contents.push(
+                    widget::svg(helpers::ARROW_FORWARD_IOS_ICON.clone())
+                        .height(20)
+                        .width(iced::Shrink)
+                        .style(svg_icon_style)
+                        .into(),
+                );
+            }
+
+            helpers::list_item(
+                contents,
+                is_selected,
+                BBImagerMessage::SelectOs(img.id),
+                &state.common.list_selection_id,
+            )
+        });
 
         // Nested sublists get a row to walk back up to their parent.
         let back: Vec<Element<BBImagerMessage>> = if state.pos.is_none() {
@@ -91,17 +91,21 @@ fn os_list_pane<'a>(state: &'a crate::state::ChooseOsState) -> Element<'a, BBIma
                 .height(ICON_WIDTH)
                 .width(ICON_WIDTH)
                 .style(svg_icon_style);
-            vec![
-                helpers::list_item(
-                    [icon.into(), helpers::list_label("Back").into()],
-                    false,
-                    BBImagerMessage::GotoOsListParent,
-                )
-                .into(),
-            ]
+            vec![helpers::list_item(
+                [icon.into(), helpers::list_label("Back").into()],
+                false,
+                BBImagerMessage::GotoOsListParent,
+                &state.common.list_selection_id,
+            )]
         };
 
-        helpers::list_pane(&state.search_text, &state.common.scroll_id, back, items)
+        helpers::list_pane(
+            &state.search_text,
+            &state.common.scroll_id,
+            &state.common.search_id,
+            back,
+            items,
+        )
     }
 }
 
@@ -185,9 +189,10 @@ fn os_view_pane<'a>(state: &'a crate::state::ChooseOsState) -> Element<'a, BBIma
             }
 
             if let Some(x) = img.support() {
-                let row =
-                    widget::row![button("SUPPORT").on_press(BBImagerMessage::OpenUrl(x.clone()))]
-                        .spacing(16);
+                let row = widget::row![
+                    helpers::action_button("SUPPORT").on_press(BBImagerMessage::OpenUrl(x.clone()))
+                ]
+                .spacing(16);
                 col = col.push(widget::center(row));
             }
 

--- a/bb-imager-gui/src/ui/mod.rs
+++ b/bb-imager-gui/src/ui/mod.rs
@@ -6,6 +6,7 @@ mod configuration;
 mod destination_selection;
 mod flash;
 mod flash_finish;
+mod focusable;
 mod helpers;
 mod image_selection;
 mod review;

--- a/bb-imager-gui/src/ui/review.rs
+++ b/bb-imager-gui/src/ui/review.rs
@@ -7,7 +7,7 @@ use crate::{
     constants,
     message::BBImagerMessage,
     state::CustomizeState,
-    ui::helpers::{detail_pane, page_type2},
+    ui::helpers::{action_button, detail_pane, page_type2},
 };
 
 const HEADING_SIZE: u32 = 26;
@@ -22,10 +22,10 @@ pub(crate) fn view<'a>(state: &'a CustomizeState) -> Element<'a, BBImagerMessage
     page_type2(
         review_view(state),
         [
-            widget::button("BACK")
+            action_button("BACK")
                 .on_press(BBImagerMessage::Back)
                 .style(widget::button::secondary),
-            widget::button(btn_label).on_press(BBImagerMessage::FlashStart),
+            action_button(btn_label).on_press(BBImagerMessage::FlashStart),
         ],
     )
 }


### PR DESCRIPTION
The GUI is mouse-only. Iced 0.14 does not put button or toggler in Tab order, so there is no visible focus ring on the actions that actually advance the flashing flow (Next, Back, Flash, list confirm). Arrow keys do not move the board/OS/destination selection, Enter does not confirm it, and Escape does not go back. On macOS, key events are often marked captured even when nothing is focused, so a naive listener never sees Up/Down/Escape. That is a real barrier for keyboard users and for anyone driving the app without a pointer.

The default Beagle palette is also hard to use in bright light or with low vision: orange-on-dark cards, a white focus ring that disappears on yellow primary buttons, and list selection drawn as a 3px border that the parent scrollable clips. There is no way to switch to a high-contrast palette or keep that choice across launches.


This PR helps in solving that by introducing 

A global `event::listen_with` subscription maps keys to `BBImagerMessage`s:

| Key | Behavior |
|---|---|
| **↑ / ↓** | Move the selected list row (delivered even when iced marks the event captured, which is the macOS idle-window case) |
| **Tab / Shift+Tab** | Move iced’s focus ring, then scroll the focused widget into view |
| **Enter** | Confirm the current screen (Next / Flash / Retry) when a selection is valid |
| **Escape** | Clear search → nested OS parent → Back. No-op on the first board screen and while flashing |
| **Ctrl/Cmd+F** | Focus the search field |

Tab and Enter are ignored while a widget has already captured them, so text inputs and combo boxes keep their usual editing keys.
Because iced 0.14 buttons and togglers are not focusable, action controls are wrapped in a small `Focusable` widget (`ui/focusable.rs`): they join Tab order, draw a focus ring, activate on Enter/Space, and skip disabled (`on_press: None`) controls. List rows stay arrow-only, not Tab, so Tab does not walk every board. A two-phase widget operation (`focus_scroll.rs`) scrolls either the focused control or the tagged selected row into view, and only in the scrollable whose content actually intersects that target (so the sibling pane does not jump).


App Info gains a **High contrast theme** toggler. The flag lives on `GuiConfiguration` (`skip_serializing_if` false) and is written on change. The palette is black background, white text, yellow primary, with matching progress and finish colors. Cards use a 2px white stroke plus inset padding so the border is not covered by the child scrollable. List rows get the same inset so the 3px selection ring is not clipped. The focus ring in this theme is a black inner stroke plus a white outer stroke so it stays visible on yellow primary buttons.
