### PR TITLE
Create common MockArchive

### DIFF
--- a/bb-flasher-sd/src/bootfs_update.rs
+++ b/bb-flasher-sd/src/bootfs_update.rs
@@ -66,77 +66,36 @@ where
 
 #[cfg(test)]
 mod test {
-    use crate::mock_sd::MockSd;
+    use crate::mock_sd::{MockArchive, MockContent, MockSd};
     use std::io;
 
     use super::*;
 
-    #[derive(Debug, Clone)]
-    struct MockArchive(Vec<(Box<str>, Option<Vec<u8>>)>);
-
-    impl Default for MockArchive {
-        fn default() -> Self {
-            Self(vec![
-                ("config".into(), None),
-                ("config/cmdline.txt".into(), Some(b"console=ttyS0".to_vec())),
-            ])
-        }
-    }
-
-    impl IntoIterator for MockArchive {
-        type Item = (Box<str>, ContentType<'static>);
-        type IntoIter = Box<dyn Iterator<Item = Self::Item>>;
-
-        fn into_iter(self) -> Self::IntoIter {
-            Box::new(
-                self.0
-                    .iter()
-                    .map(|(p, f)| match f {
-                        Some(x) => (
-                            p.clone(),
-                            ContentType::Reader(Box::new(io::Cursor::new(x.clone()))),
-                        ),
-                        None => (p.clone(), ContentType::Dir),
-                    })
-                    .collect::<Vec<Self::Item>>()
-                    .into_iter(),
-            )
-        }
-    }
-
-    impl<'b> IntoIterator for &'b mut MockArchive {
-        type Item = (Box<str>, ContentType<'b>);
-        type IntoIter = Box<dyn Iterator<Item = Self::Item> + 'b>;
-
-        fn into_iter(self) -> Self::IntoIter {
-            Box::new(
-                self.0
-                    .iter()
-                    .map(|(p, f)| match f {
-                        Some(x) => (
-                            p.clone(),
-                            ContentType::Reader(Box::new(io::Cursor::new(x.clone()))),
-                        ),
-                        None => (p.clone(), ContentType::Dir),
-                    })
-                    .collect::<Vec<Self::Item>>()
-                    .into_iter(),
-            )
-        }
+    /// The BOOT entries these tests flash: a directory and one file under it.
+    fn archive() -> MockArchive {
+        MockArchive::from_entries(vec![
+            ("config".into(), MockContent::Dir),
+            (
+                "config/cmdline.txt".into(),
+                MockContent::Reader("console=ttyS0".as_bytes().into()),
+            ),
+        ])
     }
 
     #[test]
     fn basic() {
-        let iter = MockArchive::default();
         let mut sd = MockSd::new();
+        let archive = archive();
 
-        internal(iter.clone().into_iter(), &mut sd, None).unwrap();
+        internal((&archive).into_iter(), &mut sd, None).unwrap();
         sd.rewind().unwrap();
 
         let boot_part = crate::customization::ParitionType::Boot.open(sd).unwrap();
         let root = boot_part.root_dir();
 
-        for (path, f) in iter {
+        let mut checked = 0;
+        for (path, f) in &archive {
+            checked += 1;
             match f {
                 ContentType::Dir => {
                     root.open_dir(&path).unwrap();
@@ -154,6 +113,10 @@ mod test {
                 _ => unreachable!(),
             }
         }
+        assert_eq!(
+            checked, 2,
+            "expected the default archive to yield 2 entries"
+        );
     }
 
     #[test]
@@ -161,10 +124,10 @@ mod test {
         let cancel = CancellationToken::default();
         drop(cancel.drop_guard());
 
-        let iter = MockArchive::default();
+        let iter = archive();
         let mut sd = MockSd::new();
 
-        let result = internal(iter.into_iter(), &mut sd, Some(cancel));
+        let result = internal((&iter).into_iter(), &mut sd, Some(cancel));
         assert!(
             matches!(result.unwrap_err(), crate::Error::Aborted),
             "Expected flashing to fail due to cancellation"
@@ -187,13 +150,13 @@ mod test {
 
     #[test]
     fn test_immediate_storage_failure() {
-        let mut iter = MockArchive::default();
+        let iter = archive();
         let mut sd = MockSd::new();
 
         // Break the device immediately before passing it in
         drop(sd.fail_token().drop_guard());
 
-        let result = internal((&mut iter).into_iter(), &mut sd, None);
+        let result = internal((&iter).into_iter(), &mut sd, None);
 
         assert!(
             result.is_err(),
@@ -205,7 +168,7 @@ mod test {
     fn test_mid_flight_storage_failure() {
         let mut sd = MockSd::new();
         let fail_handle = sd.fail_token().drop_guard();
-        let mut archive = MockArchive::default();
+        let archive = archive();
 
         // Two-way synchronization channels just to orchestrate the steps
         let (signal_tx, signal_rx) = std::sync::mpsc::channel::<()>();
@@ -225,7 +188,7 @@ mod test {
 
             // We wrap the iterator on the MAIN thread. No Send bounds broken!
             let mut step = 0;
-            let triggering_iter = (&mut archive).into_iter().inspect(move |_| {
+            let triggering_iter = (&archive).into_iter().inspect(move |_| {
                 if step == 1 {
                     // Signal the background thread to kill the drive
                     let _ = signal_tx.send(());

--- a/bb-flasher-sd/src/mock_sd.rs
+++ b/bb-flasher-sd/src/mock_sd.rs
@@ -5,6 +5,8 @@ use mbrman::{CHS, MBR, MBRPartitionEntry};
 
 use bb_helper::cancel::CancellationToken;
 
+use crate::ContentType;
+
 const DISK_SIZE: u64 = 128 * 1024 * 1024; // 128 MiB
 const SECTOR_SIZE: u32 = 512;
 const FIRST_LBA: u32 = 2048;
@@ -129,5 +131,57 @@ impl Read for MockSd {
 impl crate::helpers::Eject for MockSd {
     fn eject(self) -> io::Result<()> {
         self.as_file().sync_all()
+    }
+}
+
+/// Replayable description of one archive entry.
+///
+/// Mirrors [`ContentType`], but stores reader contents as bytes so the same entry
+/// can be handed out again on every iteration.
+pub enum MockContent {
+    Dir,
+    Reader(Box<[u8]>),
+    File(Box<std::path::Path>),
+    DataAppend(Box<[u8]>),
+}
+
+impl MockContent {
+    fn as_content_type(&self) -> ContentType<'_> {
+        match self {
+            Self::Dir => ContentType::Dir,
+            Self::Reader(data) => ContentType::Reader(Box::new(data.as_ref())),
+            Self::File(path) => ContentType::File(path.clone()),
+            Self::DataAppend(data) => ContentType::DataAppend(data.clone()),
+        }
+    }
+}
+
+pub struct MockArchive(Vec<(Box<str>, MockContent)>);
+
+impl MockArchive {
+    pub fn from_entries(entries: Vec<(Box<str>, MockContent)>) -> Self {
+        Self(entries)
+    }
+}
+
+impl<'a> IntoIterator for &'a MockArchive {
+    type Item = (Box<str>, ContentType<'a>);
+    type IntoIter = Box<dyn Iterator<Item = Self::Item> + 'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        Box::new(
+            self.0
+                .iter()
+                .map(|(path, content)| (path.clone(), content.as_content_type())),
+        )
+    }
+}
+
+impl<'a> IntoIterator for &'a mut MockArchive {
+    type Item = (Box<str>, ContentType<'a>);
+    type IntoIter = Box<dyn Iterator<Item = Self::Item> + 'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        (&*self).into_iter()
     }
 }

--- a/bb-flasher-sd/tests/bootfs_update.rs
+++ b/bb-flasher-sd/tests/bootfs_update.rs
@@ -1,49 +1,13 @@
 #![cfg(feature = "mock_sd")]
 
+use bb_flasher_sd::Destination;
 use bb_flasher_sd::bootfs_update::flash;
-use bb_flasher_sd::{ContentType, Destination};
-use std::io::{self, Read, Write};
-use std::path::Path;
+use bb_flasher_sd::mock_sd::{MockArchive, MockContent};
+use std::io::{Read, Write};
 use tempfile::NamedTempFile;
 
-struct MockArchive {
-    file_path: Box<Path>,
-}
-
-impl MockArchive {
-    const READER_CONTENTS: &'static str = "reader";
-    const APPEND_CONTENTS: &'static str = "append";
-
-    fn new(file_path: Box<Path>) -> Self {
-        Self { file_path }
-    }
-}
-
-impl<'b> IntoIterator for &'b mut MockArchive {
-    type Item = (Box<str>, ContentType<'b>);
-    type IntoIter = Box<dyn Iterator<Item = Self::Item> + 'b>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        Box::new(
-            vec![
-                ("config_dir".into(), ContentType::Dir),
-                (
-                    "config_dir/reader.txt".into(),
-                    ContentType::Reader(Box::new(io::Cursor::new(MockArchive::READER_CONTENTS))),
-                ),
-                (
-                    "config_dir/file.txt".into(),
-                    ContentType::File(self.file_path.clone()),
-                ),
-                (
-                    "config_dir/reader.txt".into(),
-                    ContentType::DataAppend(MockArchive::APPEND_CONTENTS.as_bytes().into()),
-                ),
-            ]
-            .into_iter(),
-        )
-    }
-}
+const READER_CONTENTS: &str = "reader";
+const APPEND_CONTENTS: &str = "append";
 
 #[test]
 fn test_flash_workflow_with_helper_inspection() {
@@ -55,7 +19,23 @@ fn test_flash_workflow_with_helper_inspection() {
     temp_file.write_all(temp_file_data.as_bytes()).unwrap();
 
     // 2. Setup archive and closure
-    let archive = MockArchive::new(temp_file.path().into());
+    let archive = MockArchive::from_entries(vec![
+        ("config_dir".into(), MockContent::Dir),
+        (
+            "config_dir/reader.txt".into(),
+            MockContent::Reader(READER_CONTENTS.as_bytes().into()),
+        ),
+        (
+            "config_dir/file.txt".into(),
+            MockContent::File(temp_file.path().into()),
+        ),
+        // Same path as the reader above on purpose: appends onto the entry
+        // created earlier in this same archive.
+        (
+            "config_dir/reader.txt".into(),
+            MockContent::DataAppend(APPEND_CONTENTS.as_bytes().into()),
+        ),
+    ]);
     let img_closure = move || Ok(archive);
 
     // 3. Execute the public API over the MockSD's path
@@ -85,10 +65,7 @@ fn test_flash_workflow_with_helper_inspection() {
         .read_to_string(&mut actual_contents)
         .unwrap();
 
-    assert_eq!(
-        actual_contents,
-        [MockArchive::READER_CONTENTS, MockArchive::APPEND_CONTENTS].join("")
-    );
+    assert_eq!(actual_contents, [READER_CONTENTS, APPEND_CONTENTS].join(""));
 
     actual_contents.clear();
     root_dir


### PR DESCRIPTION
- Had 2 different versions of same thing defined.
- The upcoming fedora image changes will add a new callsite as well, so introduce it now.