### PR TITLE
GUI: Add support for fedora like images

### DIFF
--- a/bb-config/src/config.rs
+++ b/bb-config/src/config.rs
@@ -60,6 +60,20 @@ pub struct Device {
     pub specification: Vec<(String, String)>,
     /// OSHW details for the device.
     pub oshw: Option<String>,
+    /// Url to tarball of bootfs. Should ideally only contain the minimal files that need to be
+    /// present in bootfs to load something like grub.
+    pub bootfs: Option<Bootfs>,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct Bootfs {
+    /// Os Image download URL
+    pub url: Url,
+    /// Os Image size after extraction
+    pub extract_size: u64,
+    /// Os Image sha256 (before extraction)
+    #[serde(with = "const_hex")]
+    pub image_download_sha256: [u8; 32],
 }
 
 /// Types of customization Initialization formats
@@ -220,6 +234,9 @@ pub enum Flasher {
     Pb2Mspm0,
     /// MSPM0 flasher
     Mspm0,
+    /// The image does not contain first stage bootloader (eg: uboot), which needs to be added based
+    /// on board.
+    SdCardNoBootloader,
 }
 
 impl rusqlite::ToSql for Flasher {
@@ -231,6 +248,7 @@ impl rusqlite::ToSql for Flasher {
             Flasher::Msp430Usb => 4,
             Flasher::Pb2Mspm0 => 5,
             Flasher::Mspm0 => 6,
+            Flasher::SdCardNoBootloader => 7,
         };
 
         Ok(rusqlite::types::ToSqlOutput::from(val))
@@ -246,6 +264,7 @@ impl rusqlite::types::FromSql for Flasher {
             4 => Ok(Flasher::Msp430Usb),
             5 => Ok(Flasher::Pb2Mspm0),
             6 => Ok(Flasher::Mspm0),
+            7 => Ok(Flasher::SdCardNoBootloader),
             _ => Err(rusqlite::types::FromSqlError::Other(
                 format!("Invalid Flasher discriminant: {}", val).into(),
             )),

--- a/bb-imager-gui/migrations/20260316134019_init.sql
+++ b/bb-imager-gui/migrations/20260316134019_init.sql
@@ -17,7 +17,12 @@ CREATE TABLE boards
 	instructions TEXT,
 	oshw TEXT,
 	specification BLOB,
-	documentation TEXT
+	documentation TEXT,
+	-- Bootfs tarball for images flashed with SdCardNoBootloader. All three are
+	-- set together or all NULL.
+	bootfs_url TEXT,
+	bootfs_extract_size INTEGER,
+	bootfs_sha256 BLOB
 ) STRICT;
 
 CREATE TABLE board_tags

--- a/bb-imager-gui/src/db/mod.rs
+++ b/bb-imager-gui/src/db/mod.rs
@@ -43,6 +43,24 @@ pub(crate) struct Board {
     pub(crate) oshw: Option<String>,
     pub(crate) flasher: config::Flasher,
     pub(crate) instructions: Option<Box<str>>,
+    pub(crate) bootfs: Option<config::Bootfs>,
+}
+
+/// Read the `bootfs_*` columns back into a [`config::Bootfs`].
+///
+/// The three columns are always written together, so the URL alone decides whether the board
+/// has a tarball.
+fn bootfs_from_row(value: &rusqlite::Row<'_>) -> rusqlite::Result<Option<config::Bootfs>> {
+    let Some(url) = value.get::<_, Option<Url>>("bootfs_url")? else {
+        return Ok(None);
+    };
+    let extract_size: i64 = value.get("bootfs_extract_size")?;
+
+    Ok(Some(config::Bootfs {
+        url,
+        extract_size: extract_size as u64,
+        image_download_sha256: value.get("bootfs_sha256")?,
+    }))
 }
 
 impl Board {
@@ -59,6 +77,7 @@ impl Board {
             oshw: value.get("oshw")?,
             flasher: value.get("flasher")?,
             instructions: value.get("instructions")?,
+            bootfs: bootfs_from_row(value)?,
         })
     }
 }
@@ -384,9 +403,12 @@ impl Db {
             instructions,
             oshw,
             specification,
-            documentation
+            documentation,
+            bootfs_url,
+            bootfs_extract_size,
+            bootfs_sha256
         )
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
         ON CONFLICT(name) DO UPDATE SET
             description = excluded.description,
             icon = excluded.icon,
@@ -394,7 +416,10 @@ impl Db {
             instructions = excluded.instructions,
             oshw = excluded.oshw,
             specification = excluded.specification,
-            documentation = excluded.documentation
+            documentation = excluded.documentation,
+            bootfs_url = excluded.bootfs_url,
+            bootfs_extract_size = excluded.bootfs_extract_size,
+            bootfs_sha256 = excluded.bootfs_sha256
         RETURNING id
         "#,
         )?;
@@ -407,7 +432,13 @@ impl Db {
                 board.instructions,
                 board.oshw,
                 spec,
-                board.documentation
+                board.documentation,
+                board.bootfs.as_ref().map(|x| &x.url),
+                board
+                    .bootfs
+                    .as_ref()
+                    .map(|x| i64::try_from(x.extract_size).unwrap()),
+                board.bootfs.as_ref().map(|x| x.image_download_sha256)
             ],
             |r| r.get(0),
         )?;
@@ -551,7 +582,7 @@ impl Db {
         let mut stmt = db.prepare_cached(
             r#"
         SELECT id, name, icon, description, documentation, specification, oshw, 
-            flasher, instructions
+            flasher, instructions, bootfs_url, bootfs_extract_size, bootfs_sha256
         FROM boards
         WHERE id = $1"#,
         )?;
@@ -624,16 +655,19 @@ impl Db {
             SELECT s.id, s.name, s.icon, s.flasher
             FROM os_sublists s
             JOIN os_sublist_boards sb ON sb.sublist_id = s.id
+            JOIN boards b ON b.id = sb.board_id
             WHERE sb.board_id = $1
               AND (
                     ($2 IS NULL AND s.parent_id IS NULL)
                  OR s.parent_id = $2
               )
+              -- Images without a bootloader are only flashable on boards that supply one
+              AND (s.flasher != $3 OR b.bootfs_url IS NOT NULL)
             ORDER BY s.remote_config_id NULLS LAST"#,
         )?;
         let res = stmt
             .query_map(
-                rusqlite::params![board_id, parent_id],
+                rusqlite::params![board_id, parent_id, config::Flasher::SdCardNoBootloader],
                 OsSublistListItem::from_row,
             )?
             .map(|x| x.unwrap())
@@ -653,17 +687,21 @@ impl Db {
             SELECT s.id, s.subitems_url
             FROM os_sublists s
             JOIN os_sublist_boards sb ON sb.sublist_id = s.id
+            JOIN boards b ON b.id = sb.board_id
             WHERE sb.board_id = $1
                 AND s.subitems_url IS NOT NULL
                 AND (
                     ($2 IS NULL AND s.parent_id IS NULL)
                     OR s.parent_id = $2
-                )"#,
+                )
+                -- Skip fetching subitems for sublists that are not shown. See `os_sublists`.
+                AND (s.flasher != $3 OR b.bootfs_url IS NOT NULL)"#,
         )?;
         let res = stmt
-            .query_map(rusqlite::params![board_id, parent_id], |r| {
-                Ok((r.get(0)?, r.get(1)?))
-            })?
+            .query_map(
+                rusqlite::params![board_id, parent_id, config::Flasher::SdCardNoBootloader],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )?
             .map(|x| x.unwrap())
             .collect();
 
@@ -784,7 +822,8 @@ impl Db {
 
         let mut stmt = db.prepare(
             r#"
-            SELECT name, description, icon, flasher, instructions, oshw, specification, documentation
+            SELECT name, description, icon, flasher, instructions, oshw, specification, documentation,
+                bootfs_url, bootfs_extract_size, bootfs_sha256
             FROM boards WHERE id = $1"#)?;
 
         stmt.query_one([id], |value| {
@@ -799,6 +838,7 @@ impl Db {
                 specification: serde_json::from_slice(&spec).unwrap(),
                 documentation: value.get("documentation")?,
                 oshw: value.get("oshw")?,
+                bootfs: bootfs_from_row(value)?,
                 tags,
             })
         })

--- a/bb-imager-gui/src/db/tests.rs
+++ b/bb-imager-gui/src/db/tests.rs
@@ -200,6 +200,7 @@ fn add_config_inserts_device_into_board_list() {
         instructions: None,
         specification: vec![],
         oshw: None,
+        bootfs: None,
     };
 
     let mut imager = bb_config::config::Imager::default();
@@ -261,6 +262,7 @@ fn add_config_updates_existing_device_with_same_name() {
         instructions: None,
         specification: vec![],
         oshw: None,
+        bootfs: None,
     };
 
     let mut imager = bb_config::config::Imager::default();
@@ -299,6 +301,7 @@ fn add_config_updates_existing_device_with_same_name() {
         instructions: Some("New instructions".to_string()),
         specification: vec![("CPU".to_string(), "Test CPU".to_string())],
         oshw: Some("us000000".to_string()),
+        bootfs: None,
     };
 
     let mut imager = bb_config::config::Imager::default();
@@ -371,6 +374,7 @@ fn add_config_inserts_os_image_for_board() {
         flasher: bb_config::config::Flasher::SdCard,
         instructions: None,
         oshw: None,
+        bootfs: None,
         specification: vec![],
         documentation: None,
         tags: Box::new(["test_board".into()]),
@@ -448,6 +452,7 @@ fn os_image_by_id_returns_correct_data() {
         flasher: bb_config::config::Flasher::SdCard,
         instructions: None,
         oshw: None,
+        bootfs: None,
         specification: vec![],
         documentation: None,
         tags: Box::new(["test_board".into()]),
@@ -548,6 +553,7 @@ fn add_config_inserts_os_sublist_for_board() {
         flasher: bb_config::config::Flasher::SdCard,
         instructions: None,
         oshw: None,
+        bootfs: None,
         specification: vec![],
         documentation: None,
         tags: Box::new(["test_board".into()]),
@@ -632,6 +638,7 @@ fn nested_os_sublists_propagate_board_support() {
         flasher: bb_config::config::Flasher::SdCard,
         instructions: None,
         oshw: None,
+        bootfs: None,
         specification: vec![],
         documentation: None,
         tags: Box::new(["test_board".into()]),
@@ -731,6 +738,7 @@ fn remote_os_sublist_is_returned_for_board() {
         flasher: bb_config::config::Flasher::SdCard,
         instructions: None,
         oshw: None,
+        bootfs: None,
         specification: vec![],
         documentation: None,
         tags: Box::new(["test_board".into()]),
@@ -816,6 +824,7 @@ fn remote_os_sublist_resolve_inserts_child_items_and_clears_url() {
         flasher: bb_config::config::Flasher::SdCard,
         instructions: None,
         oshw: None,
+        bootfs: None,
         specification: vec![],
         documentation: None,
         tags: Box::new(["test_board".into()]),
@@ -921,6 +930,7 @@ fn duplicate_remote_sublist_resolve_does_not_duplicate_os_items() {
         flasher: bb_config::config::Flasher::SdCard,
         instructions: None,
         oshw: None,
+        bootfs: None,
         specification: vec![],
         documentation: None,
         tags: Box::new(["test_board".into()]),
@@ -1031,6 +1041,7 @@ fn board_list_search_filters_boards_case_insensitive() {
         flasher: bb_config::config::Flasher::SdCard,
         instructions: None,
         oshw: None,
+        bootfs: None,
         specification: vec![],
         documentation: None,
         tags: Box::new(["bbb".into()]),
@@ -1043,6 +1054,7 @@ fn board_list_search_filters_boards_case_insensitive() {
         flasher: bb_config::config::Flasher::SdCard,
         instructions: None,
         oshw: None,
+        bootfs: None,
         specification: vec![],
         documentation: None,
         tags: Box::new(["beagleplay".into()]),
@@ -1055,6 +1067,7 @@ fn board_list_search_filters_boards_case_insensitive() {
         flasher: bb_config::config::Flasher::SdCard,
         instructions: None,
         oshw: None,
+        bootfs: None,
         specification: vec![],
         documentation: None,
         tags: Box::new(["rpi".into()]),
@@ -1134,6 +1147,7 @@ fn os_board_json_by_id_round_trips_device() {
         flasher: bb_config::config::Flasher::SdCard,
         instructions: Some("Hold the boot button".to_string()),
         oshw: Some("us000000".to_string()),
+        bootfs: None,
         specification: vec![
             ("CPU".to_string(), "Test CPU".to_string()),
             ("RAM".to_string(), "1GB".to_string()),
@@ -1176,6 +1190,7 @@ fn os_board_json_by_id_handles_board_without_optional_fields() {
         flasher: bb_config::config::Flasher::SdCard,
         instructions: None,
         oshw: None,
+        bootfs: None,
         specification: vec![],
         documentation: None,
         tags: Box::default(),
@@ -1214,6 +1229,7 @@ fn os_board_json_by_id_reflects_updated_board() {
         flasher: bb_config::config::Flasher::SdCard,
         instructions: None,
         oshw: None,
+        bootfs: None,
         specification: vec![],
         documentation: None,
         tags: ["old-tag".into()].into(),
@@ -1228,6 +1244,7 @@ fn os_board_json_by_id_reflects_updated_board() {
         flasher: bb_config::config::Flasher::SdCard,
         instructions: Some("New instructions".to_string()),
         oshw: Some("us000000".to_string()),
+        bootfs: None,
         specification: vec![("CPU".to_string(), "Test CPU".to_string())],
         documentation: None,
         tags: ["new-tag".into()].into(),
@@ -1315,6 +1332,7 @@ fn os_image_json_by_id_round_trips_image() {
         flasher: bb_config::config::Flasher::SdCard,
         instructions: None,
         oshw: None,
+        bootfs: None,
         specification: vec![],
         documentation: None,
         tags: ["test_board".into()].into(),
@@ -1371,6 +1389,7 @@ fn os_image_json_by_id_handles_image_without_optional_fields() {
         flasher: bb_config::config::Flasher::SdCard,
         instructions: None,
         oshw: None,
+        bootfs: None,
         specification: vec![],
         documentation: None,
         tags: ["test_board".into()].into(),
@@ -1425,6 +1444,7 @@ fn os_image_json_by_id_devices_come_from_linked_boards() {
         flasher: bb_config::config::Flasher::SdCard,
         instructions: None,
         oshw: None,
+        bootfs: None,
         specification: vec![],
         documentation: None,
         tags: ["test_board".into(), "test_board_alt".into()].into(),
@@ -1500,5 +1520,168 @@ fn os_board_json_by_id_unknown_id_returns_no_rows() {
     assert!(
         matches!(res, Err(rusqlite::Error::QueryReturnedNoRows)),
         "Unknown board id should return QueryReturnedNoRows, got {res:?}"
+    );
+}
+
+/// A board's bootfs tarball, used by images flashed with
+/// [`bb_config::config::Flasher::SdCardNoBootloader`].
+fn test_bootfs() -> bb_config::config::Bootfs {
+    bb_config::config::Bootfs {
+        url: "https://example.com/bootfs.tar.xz".try_into().unwrap(),
+        extract_size: 4096,
+        image_download_sha256: [7; 32],
+    }
+}
+
+fn board_with_bootfs(
+    name: &str,
+    tag: &str,
+    bootfs: Option<bb_config::config::Bootfs>,
+) -> bb_config::config::Device {
+    bb_config::config::Device {
+        name: name.to_string(),
+        description: "Test Board description".to_string(),
+        icon: None,
+        flasher: bb_config::config::Flasher::SdCard,
+        instructions: None,
+        oshw: None,
+        bootfs,
+        specification: vec![],
+        documentation: None,
+        tags: Box::new([tag.into()]),
+    }
+}
+
+/// A sublist of images that carry no bootloader, plus one image inside it.
+fn no_bootloader_sublist(tag: &str) -> bb_config::config::OsSubList {
+    bb_config::config::OsSubList {
+        name: "Fedora Images".to_string(),
+        description: "Images without a bootloader".to_string(),
+        icon: "https://example.com/sublist.png".try_into().unwrap(),
+        flasher: bb_config::config::Flasher::SdCardNoBootloader,
+        subitems: vec![bb_config::config::OsListItem::Image(
+            bb_config::config::OsImage {
+                name: "Fedora Minimal".to_string(),
+                description: "Test OS description".to_string(),
+                icon: "https://example.com/icon.png".try_into().unwrap(),
+                url: "https://example.com/os.raw.xz".try_into().unwrap(),
+                image_download_size: Some(1024),
+                image_download_sha256: [1; 32],
+                extract_size: 2048,
+                release_date: chrono::NaiveDate::from_ymd_opt(2024, 1, 1).unwrap(),
+                devices: Box::new([tag.into()]),
+                init_format: bb_config::config::InitFormat::None,
+                bmap: None,
+                info_text: None,
+                support: None,
+            },
+        )],
+    }
+}
+
+/// This test verifies that a board's bootfs tarball survives the round trip
+/// through the `boards` table.
+///
+/// What this test checks:
+/// 1. A device with a bootfs is inserted.
+/// 2. board_by_id() returns all three of url, extract size and sha256.
+/// 3. os_board_json_by_id() reconstructs the same [`bb_config::config::Device`].
+///
+/// Why this matters:
+/// - The tarball is stored as three separate nullable columns; dropping one of
+///   them from an INSERT or SELECT would silently yield a board that cannot
+///   flash bootloader-less images, or a wrong sha that fails verification only
+///   after a full download.
+#[test]
+fn board_bootfs_round_trips() {
+    let db = Db::new().expect("Failed to create DB");
+    db.init().expect("DB init should succeed");
+
+    let board = board_with_bootfs("Test Board", "test_board", Some(test_bootfs()));
+    let id = insert_board_helper(&db, board.clone());
+
+    assert_eq!(
+        db.board_by_id(id)
+            .expect("Fetching board should succeed")
+            .bootfs,
+        Some(test_bootfs())
+    );
+    assert_eq!(
+        db.os_board_json_by_id(id)
+            .expect("Fetching board json should succeed"),
+        board
+    );
+}
+
+/// The counterpart: a board without a tarball reads back as `None` rather than
+/// a half-built [`bb_config::config::Bootfs`].
+#[test]
+fn board_without_bootfs_reads_back_as_none() {
+    let db = Db::new().expect("Failed to create DB");
+    db.init().expect("DB init should succeed");
+
+    let id = insert_board_helper(&db, board_with_bootfs("Test Board", "test_board", None));
+
+    assert!(
+        db.board_by_id(id)
+            .expect("Fetching board should succeed")
+            .bootfs
+            .is_none()
+    );
+}
+
+/// This test verifies that images which need a bootloader are only offered for
+/// boards that supply one.
+///
+/// What this test checks:
+/// 1. The same `SdCardNoBootloader` sublist is linked to two boards.
+/// 2. It is listed for the board that has a bootfs tarball.
+/// 3. It is hidden for the board that does not.
+///
+/// Why this matters:
+/// - Flashing such an image onto a board with no tarball produces a card that
+///   never boots, with nothing in the UI explaining why. Hiding the entry is
+///   what keeps the combination unreachable.
+#[test]
+fn no_bootloader_sublist_is_listed_only_for_boards_with_bootfs() {
+    let db = Db::new().expect("Failed to create DB");
+    db.init().expect("DB init should succeed");
+
+    db.add_config(
+        Config {
+            imager: bb_config::config::Imager {
+                remote_configs: Default::default(),
+                devices: vec![
+                    board_with_bootfs("With Bootfs", "shared_tag", Some(test_bootfs())),
+                    board_with_bootfs("Without Bootfs", "shared_tag", None),
+                ],
+            },
+            os_list: vec![bb_config::config::OsListItem::SubList(
+                no_bootloader_sublist("shared_tag"),
+            )],
+        },
+        None,
+    )
+    .expect("add_config should succeed");
+
+    let boards = db
+        .board_list("")
+        .expect("Fetching board list should succeed");
+    let id_of = |name: &str| boards.iter().find(|b| b.name == name).unwrap().id;
+
+    let listed = |board: &str| {
+        db.os_image_items(id_of(board), None)
+            .expect("os_image_items should succeed")
+            .iter()
+            .any(|x| x.label() == "Fedora Images")
+    };
+
+    assert!(
+        listed("With Bootfs"),
+        "board supplying a bootfs should be offered the sublist"
+    );
+    assert!(
+        !listed("Without Bootfs"),
+        "board without a bootfs should not be offered images that need one"
     );
 }

--- a/bb-imager-gui/src/helpers.rs
+++ b/bb-imager-gui/src/helpers.rs
@@ -168,12 +168,9 @@ impl BoardImage {
                 _ => &[],
             },
             BoardImage::Image {
-                init_format,
-                flasher,
+                flasher: config::Flasher::SdCard | config::Flasher::SdCardNoBootloader,
                 ..
-            } if *flasher == config::Flasher::SdCard => {
-                &[config::InitFormat::Sysconf, config::InitFormat::CloudInit]
-            }
+            } => &[config::InitFormat::Sysconf, config::InitFormat::CloudInit],
             BoardImage::Image { .. } => &[],
         }
     }
@@ -418,13 +415,20 @@ impl From<bb_flasher::LocalImage> for SelectedImage {
     }
 }
 
+/// `bootfs` is the selected board's bootfs archive, if it has one.
 pub(crate) async fn flash(
     img: BoardImage,
     customization: FlashingCustomization,
     dst: Destination,
+    bootfs: Option<RemoteImage>,
     chan: mpsc::SyncSender<DownloadFlashingStatus>,
     cancel_sync: bb_helper::cancel::CancellationToken,
 ) -> anyhow::Result<()> {
+    // Every SD flash is handed the board's archive; only images that carry no bootloader of
+    // their own may have it written over their boot partition.
+    #[cfg(feature = "sd")]
+    let bootfs = bootfs.filter(|_| img.flasher() == config::Flasher::SdCardNoBootloader);
+
     match (img, customization, dst) {
         #[cfg(feature = "sd")]
         (BoardImage::SdFormat { .. }, _, Destination::SdCard(t)) => {
@@ -439,18 +443,24 @@ pub(crate) async fn flash(
             },
             customization,
             Destination::LocalFile(f),
-        ) if flasher == config::Flasher::SdCard => tokio::task::spawn_blocking(move || {
-            bb_flasher::sd::Flasher::with_file_dest(
-                img.into_image_fn(),
-                bb_flasher::sd::NONE_BOOTFS,
-                bmap.map(|x| x.into_fn()),
-                f,
-                customization.sd_customization(),
-            )
-            .flash(Some(chan), Some(cancel_sync))
-        })
-        .await
-        .unwrap(),
+        ) if matches!(
+            flasher,
+            config::Flasher::SdCard | config::Flasher::SdCardNoBootloader
+        ) =>
+        {
+            tokio::task::spawn_blocking(move || {
+                bb_flasher::sd::Flasher::with_file_dest(
+                    img.into_image_fn(),
+                    bootfs.map(|x| x.into_archive_fn(None)),
+                    bmap.map(|x| x.into_fn()),
+                    f,
+                    customization.sd_customization(),
+                )
+                .flash(Some(chan), Some(cancel_sync))
+            })
+            .await
+            .unwrap()
+        }
         #[cfg(feature = "sd")]
         (
             BoardImage::Image {
@@ -458,18 +468,24 @@ pub(crate) async fn flash(
             },
             customization,
             Destination::SdCard(t),
-        ) if flasher == config::Flasher::SdCard => tokio::task::spawn_blocking(move || {
-            bb_flasher::sd::Flasher::new(
-                img.into_image_fn(),
-                bb_flasher::sd::NONE_BOOTFS,
-                bmap.map(|x| x.into_fn()),
-                t,
-                customization.sd_customization(),
-            )
-            .flash(Some(chan), Some(cancel_sync))
-        })
-        .await
-        .unwrap(),
+        ) if matches!(
+            flasher,
+            config::Flasher::SdCard | config::Flasher::SdCardNoBootloader
+        ) =>
+        {
+            tokio::task::spawn_blocking(move || {
+                bb_flasher::sd::Flasher::new(
+                    img.into_image_fn(),
+                    bootfs.map(|x| x.into_archive_fn(None)),
+                    bmap.map(|x| x.into_fn()),
+                    t,
+                    customization.sd_customization(),
+                )
+                .flash(Some(chan), Some(cancel_sync))
+            })
+            .await
+            .unwrap()
+        }
         #[cfg(feature = "sd")]
         (BoardImage::Image { img, flasher, .. }, _, Destination::SdCard(t))
             if flasher == config::Flasher::SdCardBootfs =>
@@ -617,12 +633,12 @@ pub(crate) fn destinations(
 
     match flasher {
         #[cfg(feature = "sd")]
-        config::Flasher::SdCard | config::Flasher::SdCardBootfs => {
-            bb_flasher::sd::Target::destinations(filter)
-                .map(Destination::SdCard)
-                .filter(filter_func)
-                .collect()
-        }
+        config::Flasher::SdCard
+        | config::Flasher::SdCardBootfs
+        | config::Flasher::SdCardNoBootloader => bb_flasher::sd::Target::destinations(filter)
+            .map(Destination::SdCard)
+            .filter(filter_func)
+            .collect(),
         #[cfg(feature = "bcf_cc1352p7")]
         config::Flasher::BeagleConnectFreedom => {
             bb_flasher::bcf::cc1352p7::Target::destinations(filter)
@@ -647,9 +663,9 @@ pub(crate) fn destinations(
 pub(crate) fn file_filter(flasher: config::Flasher) -> &'static [&'static str] {
     match flasher {
         #[cfg(feature = "sd")]
-        config::Flasher::SdCard | config::Flasher::SdCardBootfs => {
-            bb_flasher::sd::Target::FILE_TYPES
-        }
+        config::Flasher::SdCard
+        | config::Flasher::SdCardBootfs
+        | config::Flasher::SdCardNoBootloader => bb_flasher::sd::Target::FILE_TYPES,
         #[cfg(feature = "bcf_cc1352p7")]
         config::Flasher::BeagleConnectFreedom => bb_flasher::bcf::cc1352p7::Target::FILE_TYPES,
         #[cfg(feature = "bcf_msp430")]
@@ -663,7 +679,9 @@ pub(crate) fn file_filter(flasher: config::Flasher) -> &'static [&'static str] {
 pub(crate) const fn flasher_supported(flasher: config::Flasher) -> bool {
     match flasher {
         #[cfg(feature = "sd")]
-        config::Flasher::SdCard | config::Flasher::SdCardBootfs => true,
+        config::Flasher::SdCard
+        | config::Flasher::SdCardBootfs
+        | config::Flasher::SdCardNoBootloader => true,
         #[cfg(feature = "bcf_cc1352p7")]
         config::Flasher::BeagleConnectFreedom => true,
         #[cfg(feature = "bcf_msp430")]
@@ -691,7 +709,9 @@ impl FlashingCustomization {
         app_config: &crate::persistance::GuiConfiguration,
     ) -> Self {
         match flasher {
-            config::Flasher::SdCard if img.init_format() == config::InitFormat::Sysconf => {
+            config::Flasher::SdCard | config::Flasher::SdCardNoBootloader
+                if img.init_format() == config::InitFormat::Sysconf =>
+            {
                 Self::LinuxSdSysconfig(
                     app_config
                         .sd_customization
@@ -700,7 +720,9 @@ impl FlashingCustomization {
                         .unwrap_or_default(),
                 )
             }
-            config::Flasher::SdCard if img.init_format() == config::InitFormat::CloudInit => {
+            config::Flasher::SdCard | config::Flasher::SdCardNoBootloader
+                if img.init_format() == config::InitFormat::CloudInit =>
+            {
                 Self::LinuxSdCloudInit(
                     app_config
                         .sd_customization
@@ -709,7 +731,9 @@ impl FlashingCustomization {
                         .unwrap_or_default(),
                 )
             }
-            config::Flasher::SdCard | config::Flasher::SdCardBootfs => Self::NoneSd,
+            config::Flasher::SdCard
+            | config::Flasher::SdCardBootfs
+            | config::Flasher::SdCardNoBootloader => Self::NoneSd,
             config::Flasher::BeagleConnectFreedom => Self::Bcf,
             config::Flasher::Msp430Usb => Self::Msp430,
             config::Flasher::Mspm0 => Self::Zepto,
@@ -850,15 +874,15 @@ pub(crate) fn no_customization(
     img: &BoardImage,
 ) -> Option<FlashingCustomization> {
     match flasher {
-        config::Flasher::SdCard
+        config::Flasher::SdCard | config::Flasher::SdCardNoBootloader
             if img.init_format() == config::InitFormat::Sysconf
                 || img.init_format() == config::InitFormat::CloudInit =>
         {
             None
         }
-        config::Flasher::SdCard | config::Flasher::SdCardBootfs => {
-            Some(FlashingCustomization::NoneSd)
-        }
+        config::Flasher::SdCard
+        | config::Flasher::SdCardBootfs
+        | config::Flasher::SdCardNoBootloader => Some(FlashingCustomization::NoneSd),
         config::Flasher::Msp430Usb => Some(FlashingCustomization::Msp430),
         config::Flasher::BeagleConnectFreedom => Some(FlashingCustomization::Bcf),
         config::Flasher::Mspm0 => Some(FlashingCustomization::Zepto),
@@ -1130,6 +1154,10 @@ mod tests {
             cfg!(feature = "sd")
         );
         assert_eq!(
+            flasher_supported(config::Flasher::SdCardNoBootloader),
+            cfg!(feature = "sd")
+        );
+        assert_eq!(
             flasher_supported(config::Flasher::BeagleConnectFreedom),
             cfg!(feature = "bcf_cc1352p7")
         );
@@ -1195,7 +1223,7 @@ mod tests {
     ///
     /// Remote specifically: a local image always reports `InitFormat::None`, so
     /// it cannot exercise format detection.
-    fn remote_sd_image(init_format: config::InitFormat) -> BoardImage {
+    fn remote_sd_image(flasher: config::Flasher, init_format: config::InitFormat) -> BoardImage {
         let cache = tempfile::tempdir().unwrap();
         let downloader = bb_downloader::Downloader::new(cache.path()).unwrap();
 
@@ -1215,10 +1243,15 @@ mod tests {
                 info_text: None,
                 support: None,
             },
-            config::Flasher::SdCard,
+            flasher,
             downloader,
         )
     }
+
+    /// Both SD flashers are the same as far as customization goes; only the
+    /// bootfs archive differs.
+    const SD_FLASHERS: [config::Flasher; 2] =
+        [config::Flasher::SdCard, config::Flasher::SdCardNoBootloader];
 
     /// Returning `Some` for a customizable image skips the Customize page and
     /// writes an empty config, so the user silently loses hostname, user, wifi
@@ -1228,12 +1261,14 @@ mod tests {
     /// or break one without touching the other.
     #[test]
     fn customizable_init_formats_reach_the_customization_page() {
-        for format in [config::InitFormat::Sysconf, config::InitFormat::CloudInit] {
-            let img = remote_sd_image(format);
-            assert!(
-                no_customization(config::Flasher::SdCard, &img).is_none(),
-                "{format:?} images must be customizable"
-            );
+        for flasher in SD_FLASHERS {
+            for format in [config::InitFormat::Sysconf, config::InitFormat::CloudInit] {
+                let img = remote_sd_image(flasher, format);
+                assert!(
+                    no_customization(flasher, &img).is_none(),
+                    "{format:?} images must be customizable on {flasher:?}"
+                );
+            }
         }
     }
 
@@ -1241,15 +1276,17 @@ mod tests {
     /// showing one that would do nothing.
     #[test]
     fn unwritable_init_formats_skip_the_customization_page() {
-        for format in [config::InitFormat::None, config::InitFormat::Armbian] {
-            let img = remote_sd_image(format);
-            assert!(
-                matches!(
-                    no_customization(config::Flasher::SdCard, &img),
-                    Some(FlashingCustomization::NoneSd)
-                ),
-                "{format:?} images have no customization we can apply"
-            );
+        for flasher in SD_FLASHERS {
+            for format in [config::InitFormat::None, config::InitFormat::Armbian] {
+                let img = remote_sd_image(flasher, format);
+                assert!(
+                    matches!(
+                        no_customization(flasher, &img),
+                        Some(FlashingCustomization::NoneSd)
+                    ),
+                    "{format:?} images have no customization we can apply on {flasher:?}"
+                );
+            }
         }
     }
 
@@ -1262,6 +1299,10 @@ mod tests {
         ));
         assert!(matches!(
             no_customization(config::Flasher::SdCardBootfs, &img),
+            Some(FlashingCustomization::NoneSd)
+        ));
+        assert!(matches!(
+            no_customization(config::Flasher::SdCardNoBootloader, &img),
             Some(FlashingCustomization::NoneSd)
         ));
         assert!(matches!(
@@ -1287,6 +1328,10 @@ mod tests {
 
         assert!(matches!(
             FlashingCustomization::new(config::Flasher::SdCard, &img, &cfg),
+            FlashingCustomization::NoneSd
+        ));
+        assert!(matches!(
+            FlashingCustomization::new(config::Flasher::SdCardNoBootloader, &img, &cfg),
             FlashingCustomization::NoneSd
         ));
         assert!(matches!(
@@ -1485,5 +1530,88 @@ mod tests {
     fn system_keymap_is_never_empty() {
         // Falls back to "us" when the locale cannot be resolved.
         assert!(!system_keymap().is_empty());
+    }
+
+    /// `SdCardNoBootloader` is an SD flasher in every respect except the bootfs
+    /// archive, so it must offer the same destinations and file types. These
+    /// matches end in a catch-all, so a missed variant panics at runtime rather
+    /// than failing to compile.
+    #[cfg(feature = "sd")]
+    #[test]
+    fn no_bootloader_flasher_behaves_like_sd_card() {
+        assert_eq!(
+            file_filter(config::Flasher::SdCardNoBootloader),
+            file_filter(config::Flasher::SdCard)
+        );
+        // Enumeration hits the same catch-all; the call itself is the assertion.
+        let _ = destinations(config::Flasher::SdCardNoBootloader, false, "".into());
+
+        for format in [
+            config::InitFormat::Sysconf,
+            config::InitFormat::CloudInit,
+            config::InitFormat::None,
+        ] {
+            let img = remote_sd_image(config::Flasher::SdCardNoBootloader, format);
+            assert_eq!(
+                img.supported_init_formats(),
+                remote_sd_image(config::Flasher::SdCard, format).supported_init_formats(),
+                "{format:?} should offer the same init formats on both SD flashers"
+            );
+        }
+    }
+
+    /// The board's bootfs archive, as `start_flashing` builds it.
+    #[cfg(feature = "sd")]
+    fn board_bootfs() -> RemoteImage {
+        let cache = tempfile::tempdir().unwrap();
+
+        RemoteImage::new(
+            "Bootfs".into(),
+            Box::new(url::Url::parse("https://example.com/bootfs.tar.xz").unwrap()),
+            [7u8; 32],
+            4096,
+            bb_downloader::Downloader::new(cache.path()).unwrap(),
+        )
+    }
+
+    /// A local image flashed to a file, so the flash needs no SD card and no
+    /// elevated permissions.
+    #[cfg(feature = "sd")]
+    async fn flash_local_image(
+        flasher: config::Flasher,
+        bootfs: Option<RemoteImage>,
+    ) -> (anyhow::Result<()>, tempfile::NamedTempFile, Vec<u8>) {
+        use std::io::Write;
+
+        let data: Vec<u8> = (0..4096u32).map(|x| (x % 251) as u8).collect();
+        let mut src = tempfile::NamedTempFile::new().unwrap();
+        src.write_all(&data).unwrap();
+        src.flush().unwrap();
+
+        let dst = tempfile::NamedTempFile::new().unwrap();
+        let res = flash(
+            BoardImage::local(src.path().to_path_buf(), flasher),
+            FlashingCustomization::NoneSd,
+            Destination::LocalFile(dst.path().to_path_buf()),
+            bootfs,
+            mpsc::sync_channel(8).0,
+            bb_helper::cancel::CancellationToken::default(),
+        )
+        .await;
+
+        (res, dst, data)
+    }
+
+    /// The board's archive is handed to every SD flash, so only the flasher type
+    /// decides who writes it. The archive here points at a host that does not
+    /// resolve, so applying it to a plain SD image would fail the flash.
+    #[cfg(feature = "sd")]
+    #[tokio::test]
+    async fn plain_sd_image_ignores_the_boards_bootfs() {
+        let (res, dst, data) =
+            flash_local_image(config::Flasher::SdCard, Some(board_bootfs())).await;
+
+        res.expect("a plain SD image must not pick up the board's bootfs");
+        assert_eq!(std::fs::read(dst.path()).unwrap(), data);
     }
 }

--- a/bb-imager-gui/src/main.rs
+++ b/bb-imager-gui/src/main.rs
@@ -261,6 +261,15 @@ impl BBImager {
         let customization = ctx.customization.clone();
         let img = ctx.selected_image.1.clone();
         let dst = ctx.selected_dest.clone();
+        let bootfs = ctx.selected_board.bootfs.as_ref().map(|x| {
+            helpers::RemoteImage::new(
+                "Bootfs".into(),
+                Box::new(x.url.clone()),
+                x.image_download_sha256,
+                x.extract_size,
+                common.downloader.clone(),
+            )
+        });
 
         tracing::info!("Starting Flashing Process");
         tracing::info!("Selected Board: {:#?}", ctx.selected_board);
@@ -275,7 +284,7 @@ impl BBImager {
 
             let cancel_child = cancel.clone();
             let flash_task = tokio::spawn(async move {
-                helpers::flash(img, customization, dst, tx, cancel_child).await
+                helpers::flash(img, customization, dst, bootfs, tx, cancel_child).await
             });
             let mut chan_clone = chan.clone();
             let progress_task = tokio::task::spawn_blocking(move || {


### PR DESCRIPTION
- Used for Fedora images.
- It's a shame that fedora does not provide bmap files. The flashing is
  rather slow.
