### PR TITLE
bb-flasher-sd: mock_sd: Rename len to size

### DIFF
--- a/bb-flasher-sd/src/mock_sd.rs
+++ b/bb-flasher-sd/src/mock_sd.rs
@@ -73,7 +73,7 @@ impl MockSd {
         }
     }
 
-    pub fn len(&self) -> u64 {
+    pub fn size(&self) -> u64 {
         DISK_SIZE
     }
 

--- a/bb-flasher-sd/tests/flash_bootfs.rs
+++ b/bb-flasher-sd/tests/flash_bootfs.rs
@@ -55,7 +55,7 @@ fn flash_applies_bootfs_through_public_api() {
     let mut mock = MockSd::new();
     let mut img = mock.image_copy();
     img.rewind().unwrap();
-    let img_size = mock.len();
+    let img_size = mock.size();
 
     const FILE_CONTENTS: &str = "contents pulled in from a path";
     let mut temp_file = tempfile::NamedTempFile::new().unwrap();
@@ -107,7 +107,7 @@ fn flash_applies_bootfs_before_customizations() {
     let mut mock = MockSd::new();
     let mut img = mock.image_copy();
     img.rewind().unwrap();
-    let img_size = mock.len();
+    let img_size = mock.size();
 
     let archive = archive(None);
 
@@ -153,7 +153,7 @@ fn flash_applies_bootfs_before_customizations() {
 fn flash_propagates_bootfs_resolver_error() {
     let mock = MockSd::new();
     let img = mock.image_copy();
-    let img_size = mock.len();
+    let img_size = mock.size();
 
     let bootfs = || -> io::Result<MockArchive> {
         Err(io::Error::new(


### PR DESCRIPTION
Fixes clippy error.