### PR TITLE
bb-flasher-sd: bootfs_update: internal: Remove Debug traitbound

### DIFF
--- a/bb-flasher-sd/src/bootfs_update.rs
+++ b/bb-flasher-sd/src/bootfs_update.rs
@@ -48,7 +48,7 @@ where
 
 pub(crate) fn internal<'a, I, S>(imgs: I, sd: S, cancel: Option<CancellationToken>) -> Result<()>
 where
-    S: Read + Write + Seek + std::fmt::Debug,
+    S: Read + Write + Seek,
     I: Iterator<Item = (Box<str>, ContentType<'a>)>,
 {
     tracing::info!("Starting bootfs update");


### PR DESCRIPTION
- No longer required.