### PR TITLE
config.json: Remove mspm0-adc-eeprom link

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,7 +6,6 @@
 			"https://github.com/beagleboard/bb-imager-rs/releases/download/continuous-release/os_list.json",
 			"https://github.com/beagleboard/micropython-builder/releases/download/continuous-release/os_list.json",
 			"https://github.com/beagleboard/microblocks-zephyr/releases/latest/download/os_list.json",
-			"https://github.com/beagleboard/mspm0-adc-eeprom/releases/download/os-list/os_list.json",
 			"https://github.com/beagleboard/bb-zephyr-images/releases/download/continuous-release/os_list.json",
 			"https://raw.githubusercontent.com/FalconChristmas/fpp/refs/heads/master/rpi-imager/rpi-imager_falcon_player.json",
 			"https://raw.githubusercontent.com/BelaPlatform/bela-distros/refs/heads/main/os_list.json"


### PR DESCRIPTION
Flashing pb2-mspm0 is no longer possible from GUI. So remove this link.